### PR TITLE
bump sentry-raven into sentry-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,8 @@ gem "omniauth-rails_csrf_protection", '~> 1.0'
 gem 'strong_password', '~> 0.0.10'
 
 # We report errors with sentry
-gem 'sentry-raven'
+gem 'sentry-ruby'
+gem 'sentry-rails'
 
 # Security libraries
 gem 'rack-attack', '~> 6.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,8 +377,16 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
-    sentry-raven (3.1.2)
+    sentry-rails (4.6.5)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.6.0)
+    sentry-ruby (4.6.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.6.5)
+    sentry-ruby-core (4.6.5)
+      concurrent-ruby
+      faraday
     shog (0.2.1)
       colorize (>= 0.8)
       rails (>= 4)
@@ -494,7 +502,8 @@ DEPENDENCIES
   sass-rails (>= 6)
   sdoc (~> 2.2.0)
   selenium-webdriver
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   shog
   shoulda-context
   simplecov

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :prevent_caching_via_headers
   before_action :set_locale
-  before_action :set_raven_context
+  before_action :set_sentry_context
   before_action :set_paper_trail_whodunnit
 
   # whitelists attributes in devise
@@ -66,8 +66,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def set_raven_context
-    Raven.user_context(id: current_user&.id)
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  def set_sentry_context
+    Sentry.set_user(id: current_user&.id)
+    Sentry.set_extras(params: params.to_unsafe_h, url: request.url)
   end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,29 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :email, :name, :age, :employment_status, :primary_phone, :secondary_phone, :city, :state, :zip, :appointment_date, :insurance, :street_address_1, :street_address_2, :urgent_flag, :income, :special_circumstances, :procedure_cost, :procedure_date, :procedure_completed_date, :household_size, :full_text, :search]
+# If this gets changed, make sure Sentry gets updated as well.
+Rails.application.config.filter_parameters += [
+  :password,
+  :email,
+  :name,
+  :age,
+  :employment_status,
+  :primary_phone,
+  :secondary_phone,
+  :city,
+  :state,
+  :zip,
+  :appointment_date,
+  :insurance,
+  :street_address_1,
+  :street_address_2,
+  :urgent_flag,
+  :income,
+  :special_circumstances,
+  :procedure_cost,
+  :procedure_date,
+  :procedure_completed_date,
+  :household_size,
+  :full_text,
+  :search
+]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,7 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-# If this gets changed, make sure Sentry gets updated as well.
 Rails.application.config.filter_parameters += [
   :password,
   :email,

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,11 @@
 # Configure sentry
-Raven.configure do |config|
+Sentry.init do |config|
   config.dsn = ENV['SENTRY_DSN']
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.send_default_pii = true
+
+  # Roughly reimplement sanitize_fields; see https://github.com/getsentry/sentry-ruby/issues/1140#issuecomment-788089679
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  config.before_send = lambda do |event, hint|
+    filter.filter(event.to_hash)
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Following the migration guide at https://docs.sentry.io/platforms/ruby/migration/ , bump sentry-raven into sentry-ruby, the new sdk. See a couple inline notes.

This pull request makes the following changes:
* swap `sentry-raven` out for `sentry-ruby`/`sentry-rails` and bundle i
* a few place changes per the upgrade guide

no view changes

It relates to the following issue #s: 
* Fixes #2342
* Fixes #2293 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
