### PR TITLE
re-add rexml, which is needed for bootsnap to fire up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'sdoc', '~> 2.2.0', group: :doc
 gem 'nokogiri', '>= 1.11.1'
 gem 'tzinfo-data', require: false
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'rexml' # not a ruby default in 3, but a requirement of bootsnap
 
 # Asset pipeline
 gem 'webpacker', '~> 5.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,6 +480,7 @@ DEPENDENCIES
   rails-html-sanitizer (>= 1.0.4)
   rails-i18n (~> 6.0)
   render_async (~> 2.1)
+  rexml
   rubocop
   rubocop-rails
   ruby_audit


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Pretty much what it says on the label - we had a build on heroku fail because rexml is no longer a standard dependency in ruby 3.
(Have verified that this solves the deploy failure!)

This pull request makes the following changes:
* explicitly add rexml gem

no views
no issues - hotfix

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
