### PR TITLE
Set up acts_as_tenant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem 'devise', '~> 4.8'
 gem 'omniauth-google-oauth2', '~> 1.0.0'
 gem "omniauth-rails_csrf_protection", '~> 1.0'
 
+# Run multiple funds on one server
+gem 'acts_as_tenant', '~> 0.5.0'
+
 # Strong Password for user password validation for folks not on oauth
 gem 'strong_password', '~> 0.0.10'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,9 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts_as_tenant (0.5.1)
+      rails (>= 5.2)
+      request_store (>= 1.0.5)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     afm (0.2.2)
@@ -438,6 +441,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store
+  acts_as_tenant (~> 0.5.0)
   bootsnap (>= 1.4.2)
   bootstrap (~> 4.5, < 5)
   bootstrap_form (~> 4.5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
     # If you need to access the other fund in dev, hit catbox.lvh.me:3000
     # to tunnel in.
     if ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
+      # If this errors, make sure you've run rails db:seed to populate db!
       ActsAsTenant.current_tenant = Fund.find_by! name: 'CatFund'
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::Base
   prepend_before_action :authenticate_user!
   prepend_before_action :confirm_user_not_disabled!, unless: :devise_controller?
 
+  if Rails.env.development?
+    before_action :confirm_tenant_set_development
+  end
   before_action :confirm_tenant_set
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :prevent_caching_via_headers
@@ -22,6 +25,15 @@ class ApplicationController < ActionController::Base
     # but we do it here so we can control when it runs.
     if ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
       raise ActsAsTenant::Errors::NoTenantSet
+    end
+  end
+
+  # In development only, set first fund as tenant by default.
+  def confirm_tenant_set_development
+    # If you need to access the other fund in dev, hit catbox.lvh.me:3000
+    # to tunnel in.
+    if ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
+      ActsAsTenant.current_tenant = Fund.find_by! name: 'CatFund'
     end
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -46,7 +46,8 @@ class PatientsController < ApplicationController
       pdf_filename = "#{@patient.name}_pledge_form_#{now}.pdf"
       pdf = PledgeFormGenerator.new(current_user,
                                     @patient,
-                                    params[:case_manager_name].to_s)
+                                    params[:case_manager_name].to_s,
+                                    current_tenant)
                                .generate_pledge_pdf
       @patient.update pledge_generated_at: Time.zone.now,
                       pledge_generated_by: current_user

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -84,7 +84,9 @@ class PatientsController < ApplicationController
     @patient = Patient.new patient_params
 
     if @patient.save
-      flash[:notice] = t('flash.patient_save_success', patient: @patient.name, fund: FUND)
+      flash[:notice] = t('flash.patient_save_success',
+                         patient: @patient.name,
+                         fund: current_tenant.name)
       redirect_to edit_patient_path @patient
     else
       flash[:alert] = t('flash.patient_save_error', error: @patient.errors.full_messages.to_sentence)

--- a/app/helpers/calls_helper.rb
+++ b/app/helpers/calls_helper.rb
@@ -68,13 +68,13 @@ module CallsHelper
 
   def voicemail_ok_notifier
     content_tag :p, class: 'text-success' do
-      content_tag :strong, t('call.new.voicemail_instructions.voicemail_identify', fund: "#{FUND}")
+      content_tag :strong, t('call.new.voicemail_instructions.voicemail_identify', fund: ActsAsTenant.current_tenant.name)
     end
   end
 
   def voicemail_not_specified_notifier
     content_tag :p, class: 'text-warning' do
-      content_tag :strong, t('call.new.voicemail_instructions.voicemail_no_identify', fund: "#{FUND}")
+      content_tag :strong, t('call.new.voicemail_instructions.voicemail_no_identify', fund: ActsAsTenant.current_tenant.name)
     end
   end
 

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -46,7 +46,7 @@ module PatientsHelper
       nil,
       [ t('patient.helper.referred_by.clinic'),                       'Clinic' ],
       [ t('patient.helper.referred_by.crime_victim_advocacy_center'), 'Crime victim advocacy center' ],
-      [ t('patient.helper.referred_by.fund', fund: "#{FUND}"),        "#{FUND} website or social media" ],
+      [ t('patient.helper.referred_by.fund', fund: ActsAsTenant.current_tenant.name),        "#{ActsAsTenant.current_tenant.name} website or social media" ],
       [ t('patient.helper.referred_by.domestic_violence_org'),        'Domestic violence crisis/intervention org' ],
       [ t('patient.helper.referred_by.family'),                       'Family member' ],
       [ t('patient.helper.referred_by.friend'),                       'Friend' ],
@@ -121,7 +121,7 @@ module PatientsHelper
     # Map inactives; if there are any, put in a breaker
     inactive_clinics = clinics.reject(&:active)
                               .map { |clinic| [
-                                t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: FUND, clinic_name: clinic.name),
+                                t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: ActsAsTenant.current_tenant.name, clinic_name: clinic.name),
                                 clinic.id,
                                 { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
                               ]}

--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -18,7 +18,7 @@ module PracticalSupportsHelper
   end
 
   def practical_support_source_options(current_value = nil)
-    options = [nil, FUND_FULL] +
+    options = [nil, ActsAsTenant.current_tenant.full_name] +
       Config.find_or_create_by(config_key: 'external_pledge_source').options +
       [
         [ t('common.patient'), 'Patient' ],
@@ -36,7 +36,7 @@ module PracticalSupportsHelper
     url = UriService.new(maybe_url).uri
 
     return unless url.present?
-    link_to t('patient.practical_support.guidance_link', fund: FUND), url.to_s, target: '_blank'
+    link_to t('patient.practical_support.guidance_link', fund: ActsAsTenant.current_tenant.name), url.to_s, target: '_blank'
     # "For guidance on practical support, view the #{link_content}."
   end
 end

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -23,7 +23,7 @@ module TooltipsHelper
   end
 
   def budget_bar_help_text
-    t('tooltips.budget_bar', fund: FUND).strip
+    t('tooltips.budget_bar', fund: ActsAsTenant.current_tenant.name).strip
   end
 
   def completed_calls_help_text

--- a/app/lib/paper_trail_version.rb
+++ b/app/lib/paper_trail_version.rb
@@ -1,5 +1,7 @@
 # Extensions to base class of PaperTrail.
 class PaperTrailVersion < PaperTrail::Version
+  acts_as_tenant :fund
+
   # Relations
   belongs_to :user, foreign_key: :whodunnit, optional: true
 

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -1,5 +1,7 @@
 # A PII stripped patient for reporting.
 class ArchivedPatient < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
   include Exportable

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -1,5 +1,7 @@
 # Object representing a case manager dialing a patient.
 class Call < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include EventLoggable
   include PaperTrailable

--- a/app/models/call_list_entry.rb
+++ b/app/models/call_list_entry.rb
@@ -1,10 +1,12 @@
 # Object representing a patient's call list.
 class CallListEntry < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Relationships
   belongs_to :user
   belongs_to :patient
 
   # Validations
   validates :order_key, :line, presence: true
-  validates :patient, uniqueness: { scope: :user }
+  validates_uniqueness_to_tenant :patient, scope: :user
 end

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -20,7 +20,7 @@ class Clinic < ApplicationRecord
 
   # Validations
   validates :name, :street_address, :city, :state, :zip, presence: true
-  validates :name, uniqueness: true
+  validates_uniqueness_to_tenant :name
 
   # Methods
   def display_location

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -1,5 +1,7 @@
 # Object representing a clinic that a patient is going to.
 class Clinic < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
 

--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -39,7 +39,7 @@ module CallListable
   end
 
   def reorder_call_list(order, line)
-    current_entries = call_list_entries.includes(:patient).where(line: line).to_a
+    current_entries = call_list_entries.includes(:patient, :fund).where(line: line).to_a
     order.each_with_index do |pt, i|
       current = current_entries.find { |x| x.patient_id.to_s == pt }
       current.update order_key: i

--- a/app/models/concerns/pledgeable.rb
+++ b/app/models/concerns/pledgeable.rb
@@ -18,7 +18,7 @@ module Pledgeable
   end
 
   def pledge_info_presence
-    errors.add(:pledge_sent, I18n.t('patient.pledge.errors.blank_fund', fund: "#{FUND}")) if fund_pledge.blank?
+    errors.add(:pledge_sent, I18n.t('patient.pledge.errors.blank_fund', fund: ActsAsTenant.current_tenant.name)) if fund_pledge.blank?
     errors.add(:pledge_sent, I18n.t('patient.pledge.errors.blank_patient')) if name.blank?
     errors.add(:pledge_sent, I18n.t('patient.pledge.errors.blank_clinic')) if clinic.blank?
     errors.add(:pledge_sent, I18n.t('patient.pledge.errors.blank_appt')) if appointment_date.blank?

--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -19,7 +19,7 @@ module Statusable
                  help_text: I18n.t('patient.status.help.fulfilled')},
     dropoff: { key: I18n.t('patient.status.key.dropoff'),
                help_text: I18n.t('patient.status.help.dropoff')},
-    resolved: { key: I18n.t('patient.status.key.resolved', fund: FUND),
+    resolved: { key: I18n.t('patient.status.key.resolved', fund: ActsAsTenant.current_tenant&.name),
                 help_text: I18n.t('patient.status.help.resolved')}
   }.freeze
 

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -1,5 +1,7 @@
 # Class so that funds can set their own dropdown lists of things
 class Config < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,7 @@
 # Object representing relevant actions taken by a case manager.
 class Event < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Enums
   enum event_type: {
     reached_patient: 0,

--- a/app/models/external_pledge.rb
+++ b/app/models/external_pledge.rb
@@ -1,6 +1,8 @@
 # Object representing money from organizations that aren't the fund or NAF.
 # For primary fund pledges or NAF pledges, see the patient model.
 class ExternalPledge < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
 

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -1,6 +1,8 @@
 # Indicator that a pledge by the primary fund was cashed in,
 # which in turn indicates that the patient used our pledged money.
 class Fulfillment < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
 

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -1,0 +1,2 @@
+class Fund < ApplicationRecord
+end

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -1,2 +1,13 @@
 class Fund < ApplicationRecord
+  # Concerns
+  # include PaperTrailable
+
+  # Validations
+  validates :name,
+            :subdomain,
+            :domain,
+            :full_name,
+            :site_domain,
+            :phone,
+            presence: true
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,7 @@
 # A case manager's log of their interactions with a patient.
 class Note < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,5 +1,7 @@
 # Object representing core patient information and demographic data.
 class Patient < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
   include Urgency
@@ -44,6 +46,7 @@ class Patient < ApplicationRecord
   accepts_nested_attributes_for :fulfillment
 
   # Validations
+  validates_uniqueness_to_tenant :primary_phone
   validates :name,
             :primary_phone,
             :initial_call_date,

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -1,5 +1,7 @@
 # Representation of non-monetary assistance coordinated for a patient.
 class PracticalSupport < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,12 +12,17 @@ class User < ApplicationRecord
           :registerable,
           :recoverable,
           :trackable,
-          :validatable,
           :lockable,
           :timeoutable,
           :omniauthable, omniauth_providers: [:google_oauth2]
+  # :validatable, # We override this to accommodate tenancy
   # :rememberable
   # :confirmable
+
+  # Constants
+  MIN_PASSWORD_LENGTH = 8
+  TIME_BEFORE_DISABLED_BY_FUND = 9.months
+  SEARCH_LIMIT = 15
 
   # Enums
   enum role: {
@@ -36,14 +41,23 @@ class User < ApplicationRecord
   # Validations
   validates_uniqueness_to_tenant :email, allow_blank: true, if: :email_changed?
   # email presence validated through Devise
-  validates :name, :role, presence: true
+  validates :name, :role, :email, presence: true
   validates_format_of :email, with: Devise::email_regexp
   validate :secure_password, if: :updating_password?
   # i18n-tasks-use t('errors.messages.password.password_strength')
   validates :password, password_strength: {use_dictionary: true}, if: :updating_password?
 
-  TIME_BEFORE_DISABLED_BY_FUND = 9.months
-  SEARCH_LIMIT = 15
+  # To accommodate tenancy, we use our own devise validations
+  # See https://github.com/heartcombo/devise/blob/master/lib/devise/models/validatable.rb
+  validates_format_of       :email, with: Devise::email_regexp, allow_blank: true, if: :email_changed?
+  validates_presence_of     :password, if: :password_required?
+  validates_confirmation_of :password, if: :password_required?
+  validates_length_of       :password, within: MIN_PASSWORD_LENGTH..100, allow_blank: true
+
+  def password_required?
+    !persisted? || !password.nil? || !password_confirmation.nil?
+  end
+  # end boilerplate from validatable
 
   def updating_password?
     return !password.nil?
@@ -54,7 +68,7 @@ class User < ApplicationRecord
     if pc == false
       errors.add :password, 'Password must include at least one lowercase ' \
                             'letter, one uppercase letter, and one digit. ' \
-                            "Forbidden words include #{FUND} and password."
+                            "Forbidden words include #{ActsAsTenant.current_tenant.name} and password."
     end
   end
 
@@ -100,12 +114,12 @@ class User < ApplicationRecord
   private
 
   def verify_password_complexity
-    return false unless password.length >= 8 # length at least 8
+    return false unless password.length >= MIN_PASSWORD_LENGTH # length at least 8
     return false if (password =~ /[a-z]/).nil? # at least one lowercase
     return false if (password =~ /[A-Z]/).nil? # at least one uppercase
     return false if (password =~ /[0-9]/).nil? # at least one digit
     # Make sure no bad words are in there
-    fund = FUND.downcase
+    fund = ActsAsTenant.current_tenant.name.downcase
     return false unless password.downcase[/(password|#{fund})/].nil?
     true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # Object representing a case manager.
 # Fields are all devise settings; most of the methods relate to call list mgmt.
 class User < ApplicationRecord
+  acts_as_tenant :fund
+  
   # Concerns
   include PaperTrailable
   include CallListable
@@ -32,6 +34,7 @@ class User < ApplicationRecord
   has_many :call_list_entries
 
   # Validations
+  validates_uniqueness_to_tenant :email, allow_blank: true, if: :email_changed?
   # email presence validated through Devise
   validates :name, :role, presence: true
   validates_format_of :email, with: Devise::email_regexp

--- a/app/views/accountants/_table_content.html.erb
+++ b/app/views/accountants/_table_content.html.erb
@@ -5,7 +5,7 @@
       <th><%= t 'accountants.table_content.line' %></th>
       <th><%= t 'accountants.table_content.clinic' %></th>
       <th><%= t 'common.patient' %></th>
-      <th><%= t 'accountants.table_content.fund_payout', fund: FUND %></th>
+      <th><%= t 'accountants.table_content.fund_payout', fund: current_tenant.name %></th>
       <th><%= t 'accountants.table_content.weeks_at_procedure' %></th>
       <th><%= t 'accountants.table_content.pledge_sent' %></th>
       <th><%= t 'accountants.table_content.pledge_amount' %></th>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -8,7 +8,7 @@
 
 <div class="row mb-6">
 	<div id="app_footer" class="col text-center">
-	  <a href="http://<%= FUND_DOMAIN %>/"><%= FUND_FULL %></a> -- <a href="tel:<%= FUND_PHONE %>"><i class="fas fa-phone-alt fa-sm" aria-hidden="true"></i> <%= FUND_PHONE %></a><br>
+	  <a href="http://<%= current_tenant.site_domain %>/"><%= current_tenant.full_name %></a> -- <a href="tel:<%= current_tenant.phone %>"><i class="fas fa-phone-alt fa-sm" aria-hidden="true"></i> <%= current_tenant.phone %></a><br>
 
 	  <%= link_to t('navigation.footer.national_abortion_federation'), 'https://prochoice.org' %> -- <a href="tel:800-772-9100"><i class="fas fa-phone-alt fa-sm" aria-hidden="true"></i> 800-772-9100</a><br>
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-inverse fixed-top navbar-expand-lg">
   <div class="navbar-header">
-    <%= link_to "DARIA - " + (ENV['DARIA_FUND_FULL'] || Rails.env), root_path, class: 'navbar-brand' %>
+    <%= link_to "DARIA - #{current_tenant.full_name}#{Rails.env.production? ? '' : ' - Development'}", root_path, class: 'navbar-brand' %>
 
     <button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse" aria-label="Toggle navigation" aria-controls="navbar-collapse" aria-expanded="false">
       <span class="navbar-toggler-icon"></span>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-inverse fixed-top navbar-expand-lg">
   <div class="navbar-header">
-    <%= link_to "DARIA - #{current_tenant.full_name}#{Rails.env.production? ? '' : ' - Development'}", root_path, class: 'navbar-brand' %>
+    <%= link_to "DARIA - #{current_tenant.full_name}#{' - Development' if !Rails.env.production?}", root_path, class: 'navbar-brand' %>
 
     <button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse" aria-label="Toggle navigation" aria-controls="navbar-collapse" aria-expanded="false">
       <span class="navbar-toggler-icon"></span>

--- a/app/views/lines/new.html.erb
+++ b/app/views/lines/new.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col lines-form">
-    <h1 class="border-bottom title"><%= t 'lines.new.welcome_to_daria', fund: FUND %></h1>
+    <h1 class="border-bottom title"><%= t 'lines.new.welcome_to_daria', fund: current_tenant.name %></h1>
 
     <%= bootstrap_form_with url: lines_path, local: true, class: 'line-select-form' do |f| %>
       <%= f.form_group :line, label: { text: t('lines.new.what_line') } do %>

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -28,7 +28,7 @@
       <div class="col info-form-right">
         <%= f.form_group :abortion_info_checkboxes do %>
           <%= f.check_box :resolved_without_fund, 
-                          label: t('patient.abortion_information.clinic_section.resolved_without_fund', fund: "#{FUND}"),
+                          label: t('patient.abortion_information.clinic_section.resolved_without_fund', fund: current_tenant.name),
                           label_class: 'tooltip-header-checkbox',
                           data: { 'tooltip-text': resolved_without_fund_help_text } %>
           <%= f.check_box :referred_to_clinic,
@@ -77,7 +77,7 @@
                              autocomplete: 'off',
                              prepend: '$' %>
           <%= f.number_field :fund_pledge,
-                             label: t('patient.abortion_information.cost_section.fund_pledge', fund: "#{FUND}"),
+                             label: t('patient.abortion_information.cost_section.fund_pledge', fund: current_tenant.name),
                              autocomplete: 'off',
                              prepend: '$',
                              label_class: 'tooltip-header-input',

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -4,7 +4,7 @@
   <h5 class="mt-4"><%= t('patient.pledge_fulfillment.confirmation.confirm_info') %></h5>
   <ul class="fulfillment-list">
     <li><%= t('patient.pledge_fulfillment.confirmation.clinic') %> <%= @patient.clinic.try(:name) %></li>
-    <li><%= t('patient.pledge_fulfillment.confirmation.fund_pledge_amount', fund: "#{FUND}") %> $<%= @patient.fund_pledge %></li>
+    <li><%= t('patient.pledge_fulfillment.confirmation.fund_pledge_amount', fund: current_tenant.name) %> $<%= @patient.fund_pledge %></li>
     <li><%= t('patient.pledge_fulfillment.confirmation.pledge_generated_by') %> <%= @patient.pledge_generated_by.try(:name) || 'N/A' %></li>
     <li><%= t('patient.pledge_fulfillment.confirmation.pledge_generated_at') %> <%= @patient.pledge_generated_at.try(:display_date) || 'N/A' %></li>
     <li><%= t('patient.pledge_fulfillment.confirmation.pledge_sent_by') %> <%= @patient.pledge_sent_by.try(:name) ||  'N/A' %></li>
@@ -28,7 +28,7 @@
       <div class="info-form-left col-6">
         <%= f.fields_for :fulfillment do |pt| %>
           <%= pt.number_field :fund_payout,
-                              label: t('patient.pledge_fulfillment.form.fund_payout', fund: "#{FUND}"),
+                              label: t('patient.pledge_fulfillment.form.fund_payout', fund: current_tenant.name),
                               autocomplete: 'off',
                               prepend: '$'%>
           <%= pt.select :gestation_at_procedure,

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -90,7 +90,7 @@
         <%= f.select :referred_by,
                      options_for_select(referred_by_options(patient.referred_by),
                                         patient.referred_by),
-                     label: t('patient.information.referred_by', fund: "#{FUND}"),
+                     label: t('patient.information.referred_by', fund: current_tenant.name),
                      autocomplete: 'off' %>
 
         <fieldset>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -33,9 +33,9 @@
 
     <div class="hide" data-step="3" data-title="<%= t('patient.pledge.step_three.title') %>">
       <% unless ENV['DARIA_PLEDGE_GENERATOR_DISABLED'] %>
-        <p class="row"><%= t('patient.pledge.step_three.generated', fund: "#{FUND}") %></p>
+        <p class="row"><%= t('patient.pledge.step_three.generated', fund: current_tenant.name) %></p>
         <p class="row">
-          <%= t('patient.pledge.step_three.downloads') %> <%= link_to FUND_FAX_SERVICE, "http://#{FUND_FAX_SERVICE}", target: '_blank', rel: 'noopener nofollow' %>
+          <%= t('patient.pledge.step_three.downloads') %> <%= fax_service %>
         </p>
       <% end %>
 

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -65,7 +65,7 @@
     <div class="col">
       <%= f.number_field :fund_pledge,
                          label: t('patient.abortion_information.cost_section.fund_pledge',
-                         fund: "#{FUND}"),
+                         fund: current_tenant.name),
                          autocomplete: 'off' %>
     </div>
     <div class="col">
@@ -139,7 +139,7 @@
 
   <%= f.check_box :referred_to_clinic, label: t('patient.abortion_information.clinic_section.referred_to_clinic') %>
   <%= f.check_box :completed_ultrasound, label: t('patient.abortion_information.clinic_section.ultrasound_completed') %>
-  <%= f.check_box :resolved_without_fund, label: t('patient.status.key.resolved', fund: "#{FUND}") %>
+  <%= f.check_box :resolved_without_fund, label: t('patient.status.key.resolved', fund: current_tenant.name) %>
 
   <fieldset class="mt-5">
     <legend class="font-weight-bold" id="special_circumstances_label">

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h1><strong><%= FUND %> Data Center</strong></h1>
+<h1><strong><%= current_tenant.name %> Data Center</strong></h1>
 <div class="row">
   <h4 class="col-sm-8"><strong>Budget bar, design TK</strong></h4>
 </div>

--- a/app/views/user_mailer/account_created.html.erb
+++ b/app/views/user_mailer/account_created.html.erb
@@ -3,4 +3,4 @@
 <p>We recommend logging in with Google. If you don't log in with Google, you will need to reset your password.</p>
 <p>If you experience any difficulties, please reach out to your case management director or volunteer contact.</p>
 <p>Thanks for your service!</p>
-<p>- Team <%= FUND %></p>
+<p>- Team <%= current_tenant.name %></p>

--- a/app/views/user_mailer/account_created.text.erb
+++ b/app/views/user_mailer/account_created.text.erb
@@ -8,4 +8,4 @@ If you experience any difficulties, please reach out to your case management dir
 
 Thanks for your service!
 
-- Team <%= FUND %>
+- Team <%= current_tenant.name %>

--- a/app/views/user_mailer/password_changed.html.erb
+++ b/app/views/user_mailer/password_changed.html.erb
@@ -2,4 +2,4 @@
 <p>We wanted to let you know that your DARIA password was changed. If you changed it, you can ignore this email.</p>
 <p>If you did not make this change, please let the CM Directors know immediately!</p>
 <p>Thanks for your hustlin'!</p>
-<p>- Team <%= FUND %></p>
+<p>- Team <%= current_tenant.name %></p>

--- a/app/views/user_mailer/password_changed.text.erb
+++ b/app/views/user_mailer/password_changed.text.erb
@@ -6,4 +6,4 @@ If you did not change it, please let the CM Directors know immediately!
 
 Thanks for your hustlin'!
 
-- Team <%= FUND %>
+- Team <%= current_tenant.name %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,4 +80,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # To allow usage of lvh.me, a tunnelling service, in development for multitenancy.
+  config.hosts = nil
 end

--- a/config/initializers/_env_var_constants.rb
+++ b/config/initializers/_env_var_constants.rb
@@ -8,10 +8,5 @@ LINES = if ENV['DARIA_LINES'].present?
           %w(DC MD VA).map(&:to_sym).freeze
         end
 
-# Definition of fund
-FUND_FULL = ENV['DARIA_FUND_FULL'] || 'DC Abortion Fund'
-FUND_DOMAIN = ENV['FUND_DOMAIN'] || 'dcabortionfund.org'
+# Where the emails come from
 FUND_MAILER_DOMAIN = ENV['FUND_MAILER_DOMAIN'] || 'dcabortionfund.org'
-FUND_PHONE = ENV['DARIA_FUND_PHONE'] || '202-452-7464'
-FUND = ENV['DARIA_FUND'] || 'DCAF'
-FUND_FAX_SERVICE = ENV['DARIA_FAX_SERVICE'] || 'www.efax.com'

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,0 +1,3 @@
+# Configure acts_as_tenant, if necessary.
+ActsAsTenant.configure do |config|
+end

--- a/db/migrate/20210927013527_create_funds.rb
+++ b/db/migrate/20210927013527_create_funds.rb
@@ -1,0 +1,14 @@
+class CreateFunds < ActiveRecord::Migration[6.1]
+  def change
+    create_table :funds do |t|
+      t.string :name
+      t.string :subdomain
+      t.string :domain
+      t.string :full_name
+      t.string :site_domain
+      t.string :phone
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210927014027_add_fund_to_models.rb
+++ b/db/migrate/20210927014027_add_fund_to_models.rb
@@ -1,0 +1,20 @@
+class AddFundToModels < ActiveRecord::Migration[6.1]
+  def change
+    %w(
+      archived_patients
+      calls
+      call_list_entries
+      clinics
+      configs
+      events
+      external_pledges
+      fulfillments
+      notes
+      patients
+      practical_supports
+      users
+    ).each do |model|
+      add_reference model, :fund, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20210927014027_add_fund_to_models.rb
+++ b/db/migrate/20210927014027_add_fund_to_models.rb
@@ -13,6 +13,7 @@ class AddFundToModels < ActiveRecord::Migration[6.1]
       patients
       practical_supports
       users
+      versions
     ).each do |model|
       add_reference model, :fund, foreign_key: true
     end

--- a/db/migrate/20210927014219_allow_multitenant_validation.rb
+++ b/db/migrate/20210927014219_allow_multitenant_validation.rb
@@ -1,0 +1,16 @@
+class AllowMultitenantValidation < ActiveRecord::Migration[6.1]
+  def change
+    # This rescopes uniqueness on a few models to be within a particular fund_id.
+    # For ex, a user can have an account with more than one fund.
+    remove_index :users, :email, unique: true
+    add_index :users, [:email, :fund_id], unique: true
+
+    # And a patient might show up in multiple funds.
+    remove_index :patients, :primary_phone, unique: true
+    add_index :patients, [:primary_phone, :fund_id], unique: true
+
+    # And every fund has their own set of configs.
+    remove_index :configs, :config_key, unique: true
+    add_index :configs, [:config_key, :fund_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -321,14 +321,15 @@ ActiveRecord::Schema.define(version: 2021_09_27_014219) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type"
-    t.string "{:null=>false}"
+    t.string "item_type", null: false
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.json "object"
     t.json "object_changes"
     t.datetime "created_at"
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_versions_on_fund_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
@@ -353,4 +354,5 @@ ActiveRecord::Schema.define(version: 2021_09_27_014219) do
   add_foreign_key "patients", "users", column: "pledge_sent_by_id"
   add_foreign_key "practical_supports", "funds"
   add_foreign_key "users", "funds"
+  add_foreign_key "versions", "funds"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_25_025609) do
+ActiveRecord::Schema.define(version: 2021_09_27_014219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -54,7 +54,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "pledge_sent_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["clinic_id"], name: "index_archived_patients_on_clinic_id"
+    t.index ["fund_id"], name: "index_archived_patients_on_fund_id"
     t.index ["line"], name: "index_archived_patients_on_line"
     t.index ["pledge_generated_by_id"], name: "index_archived_patients_on_pledge_generated_by_id"
     t.index ["pledge_sent_by_id"], name: "index_archived_patients_on_pledge_sent_by_id"
@@ -67,6 +69,8 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.integer "order_key", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_call_list_entries_on_fund_id"
     t.index ["line"], name: "index_call_list_entries_on_line"
     t.index ["patient_id"], name: "index_call_list_entries_on_patient_id"
     t.index ["user_id"], name: "index_call_list_entries_on_user_id"
@@ -78,7 +82,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_call_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["can_call_type", "can_call_id"], name: "index_calls_on_can_call_type_and_can_call_id"
+    t.index ["fund_id"], name: "index_calls_on_fund_id"
   end
 
   create_table "clinics", force: :cascade do |t|
@@ -122,6 +128,8 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.integer "costs_30wks"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_clinics_on_fund_id"
   end
 
   create_table "configs", force: :cascade do |t|
@@ -129,7 +137,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.jsonb "config_value", default: {"options"=>[]}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["config_key"], name: "index_configs_on_config_key", unique: true
+    t.bigint "fund_id"
+    t.index ["config_key", "fund_id"], name: "index_configs_on_config_key_and_fund_id", unique: true
+    t.index ["fund_id"], name: "index_configs_on_fund_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -141,7 +151,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.integer "pledge_amount"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["created_at"], name: "index_events_on_created_at"
+    t.index ["fund_id"], name: "index_events_on_fund_id"
     t.index ["line"], name: "index_events_on_line"
   end
 
@@ -153,7 +165,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_pledge_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["can_pledge_type", "can_pledge_id"], name: "index_external_pledges_on_can_pledge_type_and_can_pledge_id"
+    t.index ["fund_id"], name: "index_external_pledges_on_fund_id"
   end
 
   create_table "fulfillments", force: :cascade do |t|
@@ -168,9 +182,22 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_fulfill_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["audited"], name: "index_fulfillments_on_audited"
     t.index ["can_fulfill_type", "can_fulfill_id"], name: "index_fulfillments_on_can_fulfill_type_and_can_fulfill_id"
     t.index ["fulfilled"], name: "index_fulfillments_on_fulfilled"
+    t.index ["fund_id"], name: "index_fulfillments_on_fund_id"
+  end
+
+  create_table "funds", force: :cascade do |t|
+    t.string "name"
+    t.string "subdomain"
+    t.string "domain"
+    t.string "full_name"
+    t.string "site_domain"
+    t.string "phone"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "notes", force: :cascade do |t|
@@ -178,6 +205,8 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "patient_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_notes_on_fund_id"
     t.index ["patient_id"], name: "index_notes_on_patient_id"
   end
 
@@ -228,7 +257,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "last_edited_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["clinic_id"], name: "index_patients_on_clinic_id"
+    t.index ["fund_id"], name: "index_patients_on_fund_id"
     t.index ["identifier"], name: "index_patients_on_identifier"
     t.index ["last_edited_by_id"], name: "index_patients_on_last_edited_by_id"
     t.index ["line"], name: "index_patients_on_line"
@@ -238,7 +269,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.index ["pledge_generated_by_id"], name: "index_patients_on_pledge_generated_by_id"
     t.index ["pledge_sent"], name: "index_patients_on_pledge_sent"
     t.index ["pledge_sent_by_id"], name: "index_patients_on_pledge_sent_by_id"
-    t.index ["primary_phone"], name: "index_patients_on_primary_phone", unique: true
+    t.index ["primary_phone", "fund_id"], name: "index_patients_on_primary_phone_and_fund_id", unique: true
     t.index ["urgent_flag"], name: "index_patients_on_urgent_flag"
   end
 
@@ -250,7 +281,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_support_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["can_support_type", "can_support_id"], name: "index_practical_supports_on_can_support_type_and_can_support_id"
+    t.index ["fund_id"], name: "index_practical_supports_on_fund_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -281,12 +314,15 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.inet "last_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.bigint "fund_id"
+    t.index ["email", "fund_id"], name: "index_users_on_email_and_fund_id", unique: true
+    t.index ["fund_id"], name: "index_users_on_fund_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
@@ -297,12 +333,24 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
   end
 
   add_foreign_key "archived_patients", "clinics"
+  add_foreign_key "archived_patients", "funds"
   add_foreign_key "archived_patients", "users", column: "pledge_generated_by_id"
   add_foreign_key "archived_patients", "users", column: "pledge_sent_by_id"
+  add_foreign_key "call_list_entries", "funds"
   add_foreign_key "call_list_entries", "patients"
   add_foreign_key "call_list_entries", "users"
+  add_foreign_key "calls", "funds"
+  add_foreign_key "clinics", "funds"
+  add_foreign_key "configs", "funds"
+  add_foreign_key "events", "funds"
+  add_foreign_key "external_pledges", "funds"
+  add_foreign_key "fulfillments", "funds"
+  add_foreign_key "notes", "funds"
   add_foreign_key "patients", "clinics"
+  add_foreign_key "patients", "funds"
   add_foreign_key "patients", "users", column: "last_edited_by_id"
   add_foreign_key "patients", "users", column: "pledge_generated_by_id"
   add_foreign_key "patients", "users", column: "pledge_sent_by_id"
+  add_foreign_key "practical_supports", "funds"
+  add_foreign_key "users", "funds"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,17 +2,20 @@
 raise 'No running seeds in prod' unless [nil, 'Sandbox'].include? ENV['DARIA_FUND']
 
 # Clear out existing DB
-Config.destroy_all
-Event.destroy_all
-Call.destroy_all
-CallListEntry.destroy_all
-ExternalPledge.destroy_all
-Fulfillment.destroy_all
-Note.destroy_all
-Patient.destroy_all
-ArchivedPatient.destroy_all
-User.destroy_all
-Clinic.destroy_all
+ActsAsTenant.without_tenant do
+  Config.destroy_all
+  Event.destroy_all
+  Call.destroy_all
+  CallListEntry.destroy_all
+  ExternalPledge.destroy_all
+  Fulfillment.destroy_all
+  Note.destroy_all
+  Patient.destroy_all
+  ArchivedPatient.destroy_all
+  User.destroy_all
+  Clinic.destroy_all
+  Fund.destroy_all
+end
 
 # Do versioning
 PaperTrail.enabled = true
@@ -21,397 +24,420 @@ PaperTrail.enabled = true
 lines = %w[DC VA MD]
 note_text = 'This is a note ' * 10
 additional_note_text = 'Additional note ' * 10
+password = 'AbortionsAreAHumanRight1'
 
-# Create test users
-user = User.create! name: 'testuser (admin)', email: 'test@example.com',
-                    password: 'AbortionsAreAHumanRight1', password_confirmation: 'AbortionsAreAHumanRight1',
-                    role: :admin
-user2 = User.create! name: 'testuser2', email: 'test2@example.com',
-                     password: 'AbortionsAreAHumanRight1', password_confirmation: 'AbortionsAreAHumanRight1',
-                     role: :cm
-User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
-             password: 'AbortionsAreAHumanRight1', password_confirmation: 'AbortionsAreAHumanRight1',
-             role: :cm
+# Create a few test funds
+fund1 = Fund.create! name: 'DCAF',
+                     domain: 'catfund.org',
+                     subdomain: 'sandbox',
+                     full_name: 'DC Abortion Fund',
+                     site_domain: 'dcabortionfund.org',
+                     phone: '202-452-7464'
 
-# Default to user2 as the actor
-PaperTrail.request.whodunnit = user2.id
+fund2 = Fund.create! name: 'BCAF',
+                     domain: 'catfund.org',
+                     subdomain: 'catbox',
+                     full_name: 'Big Cat Abortion Fund',
+                     site_domain: 'petfinder.com/cats',
+                     phone: '603-413-4124'
 
-# Create a few clinics
-Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '1600 Pennsylvania Ave',
-               city: 'Washington', state: 'DC', zip: '20500'
-Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '1400 Defense',
-               city: 'Arlington', state: 'VA', zip: '20301'
-Clinic.create! name: 'Sample Clinic with NAF', street_address: '815 V Street NW',
-               city: 'Washington', state: 'DC', zip: '20001', accepts_naf: true
-Clinic.create! name: 'Sample Clinic without NAF', street_address: '1811 14th Street NW',
-               city: 'Washington', state: 'DC', zip: '20009', accepts_naf: false, accepts_medicaid: true
+[fund1, fund2].each do |fund|
+  ActsAsTenant.with_tenant(fund) do
+    # Create test users
+    user = User.create! name: 'testuser (admin)', email: 'test@example.com',
+                        password: password, password_confirmation: password,
+                        role: :admin
+    user2 = User.create! name: 'testuser2', email: 'test2@example.com',
+                         password: password, password_confirmation: password,
+                         role: :cm
+    User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
+                 password: password, password_confirmation: password,
+                 role: :cm
 
-# Create user-settable configuration
-Config.create config_key: :insurance,
-              config_value: { options: ['DC Medicaid', 'MD Medicaid', 'VA Medicaid', 'Other Insurance'] }
-Config.create config_key: :external_pledge_source,
-              config_value: { options: ['Baltimore Abortion Fund', 'Metallica Abortion Fund'] }
-Config.create config_key: :pledge_limit_help_text,
-              config_value: { options: ['Pledge Limit Guidelines:', '1st trimester (7-12 weeks): $100', '2nd trimester (12-24 weeks): $300', 'Later care (25+ weeks): $600'] }
-Config.create config_key: :language,
-              config_value: { options: %w[Spanish French Korean] }
-Config.create config_key: :resources_url,
-              config_value: { options: ['https://www.petfinder.com/cats/'] }
-Config.create config_key: :practical_support_guidance_url,
-              config_value: { options: ['https://www.petfinder.com/dogs/'] }
-Config.create config_key: :referred_by,
-              config_value: { options: ['Metal band'] }
-Config.create config_key: :fax_service,
-              config_value: { options: ['www.yolofax.com'] }
-Config.create config_key: :start_of_week,
-              config_value: { options: ['Monday'] }
+    # Default to user2 as the actor
+    PaperTrail.request.whodunnit = user2.id
 
-# Create ten active patients with generic info.
-10.times do |i|
-  patient = Patient.create! name: "Patient #{i}",
-                            primary_phone: "123-123-123#{i}",
-                            initial_call_date: 3.days.ago,
-                            urgent_flag: i.even?,
-                            last_menstrual_period_weeks: (i + 1 * 2),
-                            last_menstrual_period_days: 3,
-                            line: 'DC'
+    # Create a few clinics
+    Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '1600 Pennsylvania Ave',
+                   city: 'Washington', state: 'DC', zip: '20500'
+    Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '1400 Defense',
+                   city: 'Arlington', state: 'VA', zip: '20301'
+    Clinic.create! name: 'Sample Clinic with NAF', street_address: '815 V Street NW',
+                   city: 'Washington', state: 'DC', zip: '20001', accepts_naf: true
+    Clinic.create! name: 'Sample Clinic without NAF', street_address: '1811 14th Street NW',
+                   city: 'Washington', state: 'DC', zip: '20009', accepts_naf: false, accepts_medicaid: true
 
-  # Create associated objects
-  case i
-  when 0
-    10.times do
-      patient.calls.create! status: :reached_patient,
-                            created_at: 3.days.ago
+    # Create user-settable configuration
+    Config.create config_key: :insurance,
+                  config_value: { options: ['DC Medicaid', 'MD Medicaid', 'VA Medicaid', 'Other Insurance'] }
+    Config.create config_key: :external_pledge_source,
+                  config_value: { options: ['Baltimore Abortion Fund', 'Metallica Abortion Fund'] }
+    Config.create config_key: :pledge_limit_help_text,
+                  config_value: { options: ['Pledge Limit Guidelines:', '1st trimester (7-12 weeks): $100', '2nd trimester (12-24 weeks): $300', 'Later care (25+ weeks): $600'] }
+    Config.create config_key: :language,
+                  config_value: { options: %w[Spanish French Korean] }
+    Config.create config_key: :resources_url,
+                  config_value: { options: ['https://www.petfinder.com/cats/'] }
+    Config.create config_key: :practical_support_guidance_url,
+                  config_value: { options: ['https://www.petfinder.com/dogs/'] }
+    Config.create config_key: :referred_by,
+                  config_value: { options: ['Metal band'] }
+    Config.create config_key: :fax_service,
+                  config_value: { options: ['www.yolofax.com'] }
+    Config.create config_key: :start_of_week,
+                  config_value: { options: ['Monday'] }
+
+    # Create ten active patients with generic info.
+    10.times do |i|
+      patient = Patient.create! name: "Patient #{i}",
+                                primary_phone: "123-123-123#{i}",
+                                initial_call_date: 3.days.ago,
+                                urgent_flag: i.even?,
+                                last_menstrual_period_weeks: (i + 1 * 2),
+                                last_menstrual_period_days: 3,
+                                line: lines.first
+
+      # Create associated objects
+      case i
+      when 0
+        10.times do
+          patient.calls.create! status: :reached_patient,
+                                created_at: 3.days.ago
+        end
+      when 1
+        PaperTrail.request(whodunnit: user.id) do
+          patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
+                          other_phone: '234-456-6789', other_contact_relationship: 'Sister'
+          patient.calls.create! status: :reached_patient,
+                                created_at: 14.hours.ago
+        end
+      when 2
+        # appointment one week from today && clinic selected
+        patient.update! name: 'Clinic and Appt - 2',
+                        zipcode: "20009",
+                        pronouns: 'she/they',
+                        clinic: Clinic.first,
+                        appointment_date: 2.days.from_now
+      when 3
+        # pledge submitted
+        patient.update! clinic: Clinic.first,
+                        appointment_date: 3.days.from_now,
+                        naf_pledge: 200,
+                        procedure_cost: 400,
+                        fund_pledge: 100,
+                        pledge_sent: true,
+                        patient_contribution: 100,
+                        zipcode: "06222",
+                        pronouns: 'ze/zir',
+                        name: 'Pledge submitted - 3'
+      when 4
+        PaperTrail.request(whodunnit: user.id) do
+          # With special circumstances
+          patient.update! name: 'Special Circumstances - 4',
+                          special_circumstances: ['Prison', 'Fetal anomaly']
+          # And a recent call on file
+          patient.calls.create! status: :left_voicemail
+        end
+      when 5
+        # Resolved without DCAF
+        patient.update! name: 'Resolved without DCAF - 5',
+                        resolved_without_fund: true
+      end
+
+      if i != 9
+        5.times do
+          patient.calls.create! status: :left_voicemail,
+                                created_at: 3.days.ago
+        end
+      end
+
+      # Add notes for most patients
+      unless [0, 1].include? i
+        patient.notes.create! full_text: note_text
+      end
+
+      if i.even?
+        patient.notes.create! full_text: additional_note_text
+      end
+
+      # Add select patients to call list for user
+      user.add_patient patient if [0, 1, 2, 3, 4, 5].include? i
+
+      patient.save
     end
-  when 1
-    PaperTrail.request(whodunnit: user.id) do
-      patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
-                      other_phone: '234-456-6789', other_contact_relationship: 'Sister'
-      patient.calls.create! status: :reached_patient,
-                            created_at: 14.hours.ago
+
+    # Add patients for reporting purposes - CSV exports, fulfillments, etc.
+    PaperTrail.request.whodunnit = user.id
+    10.times do |i|
+      patient = Patient.create!(
+        name: "Reporting Patient #{i}",
+        primary_phone: "321-0#{i}0-001#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: i.even?,
+        line: i.even? ? lines.first : lines.second,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now,
+        last_menstrual_period_weeks: 7,
+        last_menstrual_period_days: 7,
+        naf_pledge: 300,
+        fund_pledge: 50,
+        procedure_cost: 600,
+        pledge_sent: true,
+        patient_contribution: 100
+      )
+
+      next unless i.even?
+
+      patient.fulfillment.update fulfilled: true,
+                                 fund_payout: 4000,
+                                 procedure_date: 10.days.from_now
     end
-  when 2
-    # appointment one week from today && clinic selected
-    patient.update! name: 'Clinic and Appt - 2',
-                    zipcode: "20009",
-                    pronouns: 'she/they',
-                    clinic: Clinic.first,
-                    appointment_date: 2.days.from_now
-  when 3
-    # pledge submitted
-    patient.update! clinic: Clinic.first,
-                    appointment_date: 3.days.from_now,
-                    naf_pledge: 200,
-                    procedure_cost: 400,
-                    fund_pledge: 100,
-                    pledge_sent: true,
-                    patient_contribution: 100,
-                    zipcode: "06222",
-                    pronouns: 'ze/zir',
-                    name: 'Pledge submitted - 3'
-  when 4
-    PaperTrail.request(whodunnit: user.id) do
-      # With special circumstances
-      patient.update! name: 'Special Circumstances - 4',
-                      special_circumstances: ['Prison', 'Fetal anomaly']
-      # And a recent call on file
-      patient.calls.create! status: :left_voicemail
+
+    (1..5).each do |patient_number|
+      patient = Patient.create!(
+        name: "Reporting Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-002#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: patient_number.even?,
+        line: lines[patient_number % 3] || lines.first,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now
+      )
+
+      # reached within the past 30 days
+      5.times do
+        patient.calls.create! status: :reached_patient,
+                              created_at: (Time.now - rand(10).days)
+        patient.calls.create! status: :reached_patient,
+                              created_at: (Time.now - rand(10).days - 10.days)
+      end
     end
-  when 5
-    # Resolved without DCAF
-    patient.update! name: 'Resolved without DCAF - 5',
-                    resolved_without_fund: true
-  end
 
-  if i != 9
-    5.times do
-      patient.calls.create! status: :left_voicemail,
-                            created_at: 3.days.ago
+    (1..5).each do |patient_number|
+      patient = Patient.create!(
+        name: "Old Reporting Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-003#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: patient_number.even?,
+        line: lines[patient_number % 3] || lines.first,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now
+      )
+
+      5.times do
+        patient.calls.create! status: :reached_patient,
+                              created_at: (Time.now - rand(10).days - 6.months)
+      end
+    end
+
+    (1..5).each do |patient_number|
+      Patient.create!(
+        name: "Pledge Reporting Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-004#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: patient_number.even?,
+        line: lines[patient_number % 3] || lines.first,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now,
+        pledge_sent: true,
+        fund_pledge: 50
+      )
+    end
+
+    # Add patients for archiving purposes with ALL THE INFO
+    (1..2).each do |patient_number|
+      # initial create data from voicemail
+      patient = Patient.create!(
+        name: "Archive Dataful Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-005#{rand(10)}",
+        voicemail_preference: 'yes',
+        line: lines.first,
+        language: 'Spanish',
+        initial_call_date: 140.days.ago,
+        last_menstrual_period_weeks: 6,
+        last_menstrual_period_days: 5,
+        created_at: 140.days.ago
+      )
+
+      # Call, but no answer. leave a VM.
+      patient.calls.create status: :left_voicemail, created_at: 139.days.ago
+
+      # Call, which updates patient info, maybe flags urgent, make a note.
+      patient.calls.create status: :reached_patient, created_at: 138.days.ago
+
+      patient.update!(
+        # header info - hand filled in
+        appointment_date: 130.days.ago,
+
+        # patient info - hand filled in
+        age: 24,
+        race_ethnicity: 'Hispanic/Latino',
+        city: 'Washington',
+        state: 'DC',
+        county: 'Washington',
+        other_contact: 'Susie Q.',
+        other_phone: "555-0#{patient_number}0-0053",
+        other_contact_relationship: 'Mother',
+        employment_status: 'Student',
+        income: '$10,000-14,999',
+        household_size_adults: 3,
+        household_size_children: 2,
+        insurance: 'Other Insurance',
+        referred_by: 'Clinic',
+        special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
+
+        # abortion info - hand filled in
+        clinic: Clinic.all.sample,
+        referred_to_clinic: patient_number.odd?,
+        resolved_without_fund: patient_number.even?,
+
+        updated_at: 138.days.ago # not sure if this even works?
+      )
+
+      # toggle urgent, maybe
+      patient.update!(
+        urgent_flag: patient_number.odd?,
+        updated_at: 137.days.ago
+      )
+
+      # generate notes
+      patient.notes.create!(
+        full_text: 'One note, with iffy PII! This one was from the first call!',
+        created_at: 137.days.ago
+      )
+
+      # only continue for the unresolved patient(s)
+      next if patient.resolved_without_fund?
+
+      # another call. get abortion information, create pledges, a note.
+      patient.calls.create! status: :reached_patient, created_at: 136.days.ago
+
+      # abortion info - pledges - hand filled in
+      patient.update!(
+        procedure_cost: 555,
+        patient_contribution: 120,
+        naf_pledge: 120,
+        fund_pledge: 115,
+        pledge_sent: true,
+        pledge_generated_at: 133.days.ago,
+        updated_at: 133.days.ago
+      )
+      # generate external pledges
+      patient.external_pledges.create!(
+        source: 'Metallica Abortion Fund',
+        amount: 100,
+        created_at: 133.days.ago
+      )
+      patient.external_pledges.create!(
+        source: 'Baltimore Abortion Fund',
+        amount: 100,
+        created_at: 133.days.ago
+      )
+
+      # notes tab
+      PaperTrail.request(whodunnit: user2.id) do
+        patient.notes.create!(
+          full_text: 'Two note, maybe with iffy PII! From the second call.',
+          created_at: 133.days.ago
+        )
+      end
+
+      # fulfillment
+      patient.fulfillment.update!(
+        fulfilled: true,
+        procedure_date: 130.days.ago,
+        gestation_at_procedure: '11',
+        fund_payout: 555,
+        check_number: 4563,
+        date_of_check: 125.days.ago,
+        updated_at: 125.days.ago
+      )
+    end
+
+    (1..2).each do |patient_number|
+      # Create dropoff patients
+      patient = Patient.create!(
+        name: "Archive Dropoff Patient #{patient_number}",
+        primary_phone: "867-9#{patient_number}0-004#{rand(10)}",
+        voicemail_preference: 'yes',
+        line: lines.first,
+        language: 'Spanish',
+        initial_call_date: 640.days.ago,
+        last_menstrual_period_weeks: 6,
+        last_menstrual_period_days: 5,
+        created_at: 640.days.ago
+      )
+
+      # Call, but no answer. leave a VM.
+      patient.calls.create status: :left_voicemail, created_at: 639.days.ago
+
+      # Call, which updates patient info, maybe flags urgent, make a note.
+      patient.calls.create status: :reached_patient, created_at: 138.days.ago
+
+      # Patient 1 drops off immediately
+      next if patient_number.odd?
+
+      # We reach Patient 2
+      patient.update!(
+        # header info - hand filled in
+        appointment_date: 630.days.ago,
+
+        # patient info - hand filled in
+        age: 24,
+        race_ethnicity: 'Hispanic/Latino',
+        city: 'Washington',
+        state: 'DC',
+        county: 'Washington',
+        zipcode: "20009",
+        pronouns: 'they/them',
+        other_contact: 'Susie Q.',
+        other_phone: "555-6#{patient_number}0-0053",
+        other_contact_relationship: 'Mother',
+
+        employment_status: 'Student',
+        income: '$10,000-14,999',
+        household_size_adults: 3,
+        household_size_children: 2,
+        insurance: 'Other Insurance',
+        referred_by: 'Clinic',
+        special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
+
+        # abortion info - hand filled in
+        clinic: Clinic.all.sample,
+        referred_to_clinic: patient_number.odd?,
+        resolved_without_fund: patient_number.even?
+      )
+
+      # toggle urgent, maybe
+      patient.update!(
+        urgent_flag: patient_number.odd?,
+        updated_at: 637.days.ago
+      )
+
+      # generate notes
+      patient.notes.create!(
+        full_text: 'One note, with iffy PII! This one was from the first call!',
+        created_at: 637.days.ago
+      )
     end
   end
-
-  # Add notes for most patients
-  unless [0, 1].include? i
-    patient.notes.create! full_text: note_text
-  end
-
-  if i.even?
-    patient.notes.create! full_text: additional_note_text
-  end
-
-  # Add select patients to call list for user
-  user.add_patient patient if [0, 1, 2, 3, 4, 5].include? i
-
-  patient.save
-end
-
-# Add patients for reporting purposes - CSV exports, fulfillments, etc.
-PaperTrail.request.whodunnit = user.id
-10.times do |i|
-  patient = Patient.create!(
-    name: "Reporting Patient #{i}",
-    primary_phone: "321-0#{i}0-001#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: i.even?,
-    line: i.even? ? 'DC' : 'MD',
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now,
-    last_menstrual_period_weeks: 7,
-    last_menstrual_period_days: 7,
-    naf_pledge: 300,
-    fund_pledge: 50,
-    procedure_cost: 600,
-    pledge_sent: true,
-    patient_contribution: 100
-  )
-
-  next unless i.even?
-
-  patient.fulfillment.update fulfilled: true,
-                             fund_payout: 4000,
-                             procedure_date: 10.days.from_now
-end
-
-(1..5).each do |patient_number|
-  patient = Patient.create!(
-    name: "Reporting Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-002#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: patient_number.even?,
-    line: lines[patient_number % 3],
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now
-  )
-
-  # reached within the past 30 days
-  5.times do
-    patient.calls.create! status: :reached_patient,
-                          created_at: (Time.now - rand(10).days)
-    patient.calls.create! status: :reached_patient,
-                          created_at: (Time.now - rand(10).days - 10.days)
-  end
-end
-
-(1..5).each do |patient_number|
-  patient = Patient.create!(
-    name: "Old Reporting Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-003#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: patient_number.even?,
-    line: lines[patient_number % 3],
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now
-  )
-
-  5.times do
-    patient.calls.create! status: :reached_patient,
-                          created_at: (Time.now - rand(10).days - 6.months)
-  end
-end
-
-(1..5).each do |patient_number|
-  Patient.create!(
-    name: "Pledge Reporting Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-004#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: patient_number.even?,
-    line: lines[patient_number % 3],
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now,
-    pledge_sent: true,
-    fund_pledge: 50
-  )
-end
-
-# Add patients for archiving purposes with ALL THE INFO
-(1..2).each do |patient_number|
-  # initial create data from voicemail
-  patient = Patient.create!(
-    name: "Archive Dataful Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-005#{rand(10)}",
-    voicemail_preference: 'yes',
-    line: 'DC',
-    language: 'Spanish',
-    initial_call_date: 140.days.ago,
-    last_menstrual_period_weeks: 6,
-    last_menstrual_period_days: 5,
-    created_at: 140.days.ago
-  )
-
-  # Call, but no answer. leave a VM.
-  patient.calls.create status: :left_voicemail, created_at: 139.days.ago
-
-  # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: :reached_patient, created_at: 138.days.ago
-
-  patient.update!(
-    # header info - hand filled in
-    appointment_date: 130.days.ago,
-
-    # patient info - hand filled in
-    age: 24,
-    race_ethnicity: 'Hispanic/Latino',
-    city: 'Washington',
-    state: 'DC',
-    county: 'Washington',
-    other_contact: 'Susie Q.',
-    other_phone: "555-0#{patient_number}0-0053",
-    other_contact_relationship: 'Mother',
-    employment_status: 'Student',
-    income: '$10,000-14,999',
-    household_size_adults: 3,
-    household_size_children: 2,
-    insurance: 'Other Insurance',
-    referred_by: 'Clinic',
-    special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
-
-    # abortion info - hand filled in
-    clinic: Clinic.all.sample,
-    referred_to_clinic: patient_number.odd?,
-    resolved_without_fund: patient_number.even?,
-
-    updated_at: 138.days.ago # not sure if this even works?
-  )
-
-  # toggle urgent, maybe
-  patient.update!(
-    urgent_flag: patient_number.odd?,
-    updated_at: 137.days.ago
-  )
-
-  # generate notes
-  patient.notes.create!(
-    full_text: 'One note, with iffy PII! This one was from the first call!',
-    created_at: 137.days.ago
-  )
-
-  # only continue for the unresolved patient(s)
-  next if patient.resolved_without_fund?
-
-  # another call. get abortion information, create pledges, a note.
-  patient.calls.create! status: :reached_patient, created_at: 136.days.ago
-
-  # abortion info - pledges - hand filled in
-  patient.update!(
-    procedure_cost: 555,
-    patient_contribution: 120,
-    naf_pledge: 120,
-    fund_pledge: 115,
-    pledge_sent: true,
-    pledge_generated_at: 133.days.ago,
-    updated_at: 133.days.ago
-  )
-  # generate external pledges
-  patient.external_pledges.create!(
-    source: 'Metallica Abortion Fund',
-    amount: 100,
-    created_at: 133.days.ago
-  )
-  patient.external_pledges.create!(
-    source: 'Baltimore Abortion Fund',
-    amount: 100,
-    created_at: 133.days.ago
-  )
-
-  # notes tab
-  PaperTrail.request(whodunnit: user2.id) do
-    patient.notes.create!(
-      full_text: 'Two note, maybe with iffy PII! From the second call.',
-      created_at: 133.days.ago
-    )
-  end
-
-  # fulfillment
-  patient.fulfillment.update!(
-    fulfilled: true,
-    procedure_date: 130.days.ago,
-    gestation_at_procedure: '11',
-    fund_payout: 555,
-    check_number: 4563,
-    date_of_check: 125.days.ago,
-    updated_at: 125.days.ago
-  )
-end
-
-(1..2).each do |patient_number|
-  # Create dropoff patients
-  patient = Patient.create!(
-    name: "Archive Dropoff Patient #{patient_number}",
-    primary_phone: "867-9#{patient_number}0-004#{rand(10)}",
-    voicemail_preference: 'yes',
-    line: 'DC',
-    language: 'Spanish',
-    initial_call_date: 640.days.ago,
-    last_menstrual_period_weeks: 6,
-    last_menstrual_period_days: 5,
-    created_at: 640.days.ago
-  )
-
-  # Call, but no answer. leave a VM.
-  patient.calls.create status: :left_voicemail, created_at: 639.days.ago
-
-  # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: :reached_patient, created_at: 138.days.ago
-
-  # Patient 1 drops off immediately
-  next if patient_number.odd?
-
-  # We reach Patient 2
-  patient.update!(
-    # header info - hand filled in
-    appointment_date: 630.days.ago,
-
-    # patient info - hand filled in
-    age: 24,
-    race_ethnicity: 'Hispanic/Latino',
-    city: 'Washington',
-    state: 'DC',
-    county: 'Washington',
-    zipcode: "20009",
-    pronouns: 'they/them',
-    other_contact: 'Susie Q.',
-    other_phone: "555-6#{patient_number}0-0053",
-    other_contact_relationship: 'Mother',
-
-    employment_status: 'Student',
-    income: '$10,000-14,999',
-    household_size_adults: 3,
-    household_size_children: 2,
-    insurance: 'Other Insurance',
-    referred_by: 'Clinic',
-    special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
-
-    # abortion info - hand filled in
-    clinic: Clinic.all.sample,
-    referred_to_clinic: patient_number.odd?,
-    resolved_without_fund: patient_number.even?
-  )
-
-  # toggle urgent, maybe
-  patient.update!(
-    urgent_flag: patient_number.odd?,
-    updated_at: 637.days.ago
-  )
-
-  # generate notes
-  patient.notes.create!(
-    full_text: 'One note, with iffy PII! This one was from the first call!',
-    created_at: 637.days.ago
-  )
 end
 
 # Log results
-puts "Seed completed! \n" \
-     "Inserted #{Config.count} Config objects. \n" \
-     "Inserted #{Event.count} Event objects. \n" \
-     "Inserted #{Call.count} Call objects. \n" \
-     "Inserted #{CallListEntry.count} CallListEntry objects. \n" \
-     "Inserted #{ExternalPledge.count} ExternalPledge objects. \n" \
-     "Inserted #{Fulfillment.count} Fulfillment objects. \n" \
-     "Inserted #{Note.count} Note objects. \n" \
-     "Inserted #{Patient.count} Patient objects. \n" \
-     "Inserted #{ArchivedPatient.count} ArchivedPatient objects. \n" \
-     "Inserted #{User.count} User objects. \n" \
-     "Inserted #{Clinic.count} Clinic objects. \n" \
-     'User credentials are as follows: ' \
-     "EMAIL: #{user.email} PASSWORD: AbortionsAreAHumanRight1"
+ActsAsTenant.without_tenant do
+  puts "Seed completed! \n" \
+       "Inserted #{Config.count} Config objects. \n" \
+       "Inserted #{Event.count} Event objects. \n" \
+       "Inserted #{Call.count} Call objects. \n" \
+       "Inserted #{CallListEntry.count} CallListEntry objects. \n" \
+       "Inserted #{ExternalPledge.count} ExternalPledge objects. \n" \
+       "Inserted #{Fulfillment.count} Fulfillment objects. \n" \
+       "Inserted #{Note.count} Note objects. \n" \
+       "Inserted #{Patient.count} Patient objects. \n" \
+       "Inserted #{ArchivedPatient.count} ArchivedPatient objects. \n" \
+       "Inserted #{User.count} User objects. \n" \
+       "Inserted #{Clinic.count} Clinic objects. \n" \
+       "Inserted #{Fund.count} Fund objects. \n" \
+       'User credentials are as follows: ' \
+       "EMAIL: #{User.where(role: :admin).first.email} PASSWORD: #{password}"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,14 +27,14 @@ additional_note_text = 'Additional note ' * 10
 password = 'AbortionsAreAHumanRight1'
 
 # Create a few test funds
-fund1 = Fund.create! name: 'DCAF',
+fund1 = Fund.create! name: 'CatFund',
                      domain: 'catfund.org',
                      subdomain: 'sandbox',
-                     full_name: 'DC Abortion Fund',
+                     full_name: 'Cat Abortion Fund',
                      site_domain: 'dcabortionfund.org',
                      phone: '202-452-7464'
 
-fund2 = Fund.create! name: 'BCAF',
+fund2 = Fund.create! name: 'BigCatFund',
                      domain: 'catfund.org',
                      subdomain: 'catbox',
                      full_name: 'Big Cat Abortion Fund',

--- a/test/factories/fund.rb
+++ b/test/factories/fund.rb
@@ -3,8 +3,16 @@ FactoryBot.define do
     sequence :name do |n|
       "Fund #{n}"
     end
+    sequence :subdomain do |n|
+      "fund#{n}"
+    end
+    domain { 'google' }
     sequence :full_name do |n|
       "Fund #{n} of Cat Town"
     end
+    sequence :site_domain do |n|
+      "www.fund#{n}.pizza"
+    end
+    phone { '(939)-555-0113' }
   end
 end

--- a/test/factories/fund.rb
+++ b/test/factories/fund.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :fund do
+    sequence :name do |n|
+      "Fund #{n}"
+    end
+    sequence :full_name do |n|
+      "Fund #{n} of Cat Town"
+    end
+  end
+end

--- a/test/helpers/calls_helper_test.rb
+++ b/test/helpers/calls_helper_test.rb
@@ -17,7 +17,7 @@ class CallsHelperTest < ActionView::TestCase
 
     it 'returns voicemail ok notifier text if vm pref is set to no' do
       @patient.voicemail_preference = 'yes'
-      assert_match(/Okay to identify as DCAF/,
+      assert_match(/Okay to identify as #{ActsAsTenant.current_tenant.name}/,
                    display_voicemail_link_with_warning(@patient))
       assert_match(/I left a voicemail for the patient/,
                    display_voicemail_link_with_warning(@patient))
@@ -25,7 +25,7 @@ class CallsHelperTest < ActionView::TestCase
 
     it 'returns voicemail not specified text if vm pref is set not spec' do
       @patient.voicemail_preference = 'not_specified'
-      assert_match(/Do not identify as DCAF/,
+      assert_match(/Do not identify as #{ActsAsTenant.current_tenant.name}/,
                    display_voicemail_link_with_warning(@patient))
       assert_match(/I left a voicemail for the patient/,
                    display_voicemail_link_with_warning(@patient))

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -76,7 +76,7 @@ class PatientsHelperTest < ActionView::TestCase
         nil,
         ["#{@active.name} (#{@active.city}, #{@active.state})", @active.id, { data: { naf: false, medicaid: false }}],
         ['--- INACTIVE CLINICS ---', nil, { disabled: true }],
-        ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
+        ["(Not currently working with #{ActsAsTenant.current_tenant.name}) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
       ]
 
       assert_same_elements clinic_options, expected_clinic_array
@@ -219,40 +219,40 @@ class PatientsHelperTest < ActionView::TestCase
   end
 
   describe 'referred_by_options' do
-    before { create_referred_by_config }
+    before do
+      create_referred_by_config
 
-    # base options come from patients_helper
-    # Metal band is added by create_referred_by_config
-    expected_referrals_base = [
-      nil,
-      ["Clinic", "Clinic"],
-      ["Crime victim advocacy center", "Crime victim advocacy center"],
-      ["DCAF website or social media", "DCAF website or social media"],
-      ["Domestic violence crisis/intervention org", "Domestic violence crisis/intervention org"],
-      ["Family member", "Family member"],
-      ["Friend", "Friend"],
-      ["Google/Web search", "Google/Web search"],
-      ["Homeless shelter", "Homeless shelter"],
-      ["Legal clinic", "Legal clinic"],
-      ["NAF", "NAF"],
-      ["NNAF", "NNAF"],
-      ["Other abortion fund", "Other abortion fund"],
-      ["Previous patient", "Previous patient"],
-      ["School", "School"],
-      ["Sexual assault crisis org", "Sexual assault crisis org"],
-      ["Youth outreach", "Youth outreach"],
-      "Metal band"
-    ]
+      # base options come from patients_helper
+      # Metal band is added by create_referred_by_config
+      @expected_referrals_base = [
+        nil,
+        ["Clinic", "Clinic"],
+        ["Crime victim advocacy center", "Crime victim advocacy center"],
+        ["#{ActsAsTenant.current_tenant.name} website or social media", "#{ActsAsTenant.current_tenant.name} website or social media"],
+        ["Domestic violence crisis/intervention org", "Domestic violence crisis/intervention org"],
+        ["Family member", "Family member"],
+        ["Friend", "Friend"],
+        ["Google/Web search", "Google/Web search"],
+        ["Homeless shelter", "Homeless shelter"],
+        ["Legal clinic", "Legal clinic"],
+        ["NAF", "NAF"],
+        ["NNAF", "NNAF"],
+        ["Other abortion fund", "Other abortion fund"],
+        ["Previous patient", "Previous patient"],
+        ["School", "School"],
+        ["Sexual assault crisis org", "Sexual assault crisis org"],
+        ["Youth outreach", "Youth outreach"],
+        "Metal band"
+      ]
+    end
 
     it 'should return default referral options' do
-      assert_same_elements expected_referrals_base, referred_by_options()
+      assert_same_elements @expected_referrals_base, referred_by_options
     end
 
     it 'should append extra options' do
-      expected_referrals = expected_referrals_base + ['Social Worker']
-
-      assert_same_elements expected_referrals, referred_by_options('Social Worker')
+      assert_same_elements @expected_referrals_base + ['Social Worker'],
+                           referred_by_options('Social Worker')
     end
   end
-
 end

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -62,7 +62,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       it 'should include the option set' do
         expected = [
           nil,
-          'DC Abortion Fund',
+          ActsAsTenant.current_tenant.full_name,
           'Baltimore Abortion Fund',
           'Tiller Fund (NNAF)',
           'NYAAF (New York)',
@@ -83,7 +83,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
 
         expected = [
           nil,
-          'DC Abortion Fund',
+          ActsAsTenant.current_tenant.full_name,
           ['Patient', 'Patient'],
           ['Clinic', 'Clinic'],
           ['Other (see notes)', 'Other (see notes)'],
@@ -98,7 +98,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       it 'should push orphaned value onto the end' do
         expected = [
           nil,
-          'DC Abortion Fund',
+          ActsAsTenant.current_tenant.full_name,
           ['Patient', 'Patient'],
           ['Clinic', 'Clinic'],
           ['Other (see notes)', 'Other (see notes)'],
@@ -122,7 +122,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       end
 
     it 'should return a link if config set' do
-      expected_link = '<a target="_blank" href="https://www.yahoo.com">DCAF practical support guidance</a>'
+      expected_link = '<a target="_blank" href="https://www.yahoo.com">' + "#{ActsAsTenant.current_tenant.name} practical support guidance</a>"
       assert_equal expected_link, practical_support_guidance_link
     end
   end

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FundTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -1,7 +1,49 @@
 require "test_helper"
 
 class FundTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  before do
+    @fund = Fund.first # created during setup
+  end
+
+  describe 'basic validations' do
+    it 'should build' do
+      assert create(:fund).valid?
+    end
+
+    [:name, :subdomain, :domain, :full_name, :site_domain, :phone].each do |attrib|
+      it "should require #{attrib}" do
+        @fund[attrib] = nil
+        refute @fund.valid?
+      end
+    end
+  end
+
+  describe 'scoping by fund' do
+    before { @fund2 = create :fund }
+
+    it 'should separate objects by fund' do
+      [@fund, @fund2].each do |fund|
+        ActsAsTenant.with_tenant(fund) do
+          create :patient
+        end
+      end
+
+      # The funds should see only one of them
+      ActsAsTenant.with_tenant(@fund) do
+        assert_equal 1, Patient.count
+        @pt1 = Patient.first
+      end
+      ActsAsTenant.with_tenant(@fund2) do
+        assert_equal 1, Patient.count
+        @pt2 = Patient.first
+      end
+      refute_equal @pt1.id, @pt2.id
+      refute_equal @pt1.fund_id, @pt2.fund_id
+
+      # But there should be two patients in db
+      ActsAsTenant.current_tenant = nil
+      ActsAsTenant.test_tenant = nil
+      assert_equal 2, Patient.count 
+    end
+  end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -511,11 +511,11 @@ class PatientTest < ActiveSupport::TestCase
       assert @patient.valid?
     end
 
-    it "should not validate pledge_sent if the #{FUND} pledge field is blank" do
+    it "should not validate pledge_sent if the pledge field is blank" do
       @patient.fund_pledge = nil
       @patient.pledge_sent = true
       refute @patient.valid?
-      assert_equal ["DCAF pledge field cannot be blank"], @patient.errors.messages[:pledge_sent]
+      assert_equal ["#{ActsAsTenant.current_tenant.name} pledge field cannot be blank"], @patient.errors.messages[:pledge_sent]
     end
 
     it 'should not validate pledge_sent if the clinic name is blank' do
@@ -538,7 +538,7 @@ class PatientTest < ActiveSupport::TestCase
       @patient.appointment_date = nil
       @patient.pledge_sent = true
       refute @patient.valid?
-      assert_equal ["DCAF pledge field cannot be blank", 'Clinic name cannot be blank', 'Appointment date cannot be blank'],
+      assert_equal ["#{ActsAsTenant.current_tenant.name} pledge field cannot be blank", 'Clinic name cannot be blank', 'Appointment date cannot be blank'],
       @patient.errors.messages[:pledge_sent]
     end
 
@@ -546,7 +546,7 @@ class PatientTest < ActiveSupport::TestCase
       refute @patient.pledge_info_present?
       @patient.fund_pledge = nil
       assert @patient.pledge_info_present?
-      assert_equal ["DCAF pledge field cannot be blank"], @patient.pledge_info_errors
+      assert_equal ["#{ActsAsTenant.current_tenant.name} pledge field cannot be blank"], @patient.pledge_info_errors
     end
 
     it 'should update sent by and sent at when sending the pledge' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -14,8 +14,7 @@ class UserTest < ActiveSupport::TestCase
       it "should require content in #{attribute}" do
         @user[attribute.to_sym] = nil
         assert_not @user.valid?
-        assert_equal "can't be blank",
-                     @user.errors.messages[attribute.to_sym].first
+        assert @user.errors.messages[attribute.to_sym].include? "can't be blank"
       end
     end
 
@@ -25,7 +24,7 @@ class UserTest < ActiveSupport::TestCase
       assert_not @user.valid?
       assert_equal 'Password must include at least one lowercase letter, ' \
                    'one uppercase letter, and one digit. Forbidden words ' \
-                   'include DCAF and password.',
+                   "include #{ActsAsTenant.current_tenant.name} and password.",
                    @user.errors.messages[:password].first
     end
 
@@ -39,12 +38,12 @@ class UserTest < ActiveSupport::TestCase
     end
 
     it 'should not allow the name of the fund' do
-      @user.password = 'AbortionsAreAHumanRight1DCAF'
-      @user.password_confirmation = 'AbortionsAreAHumanRight1DCAF'
+      @user.password = "AbortionsAreAHumanRight1#{ActsAsTenant.current_tenant.name}"
+      @user.password_confirmation = "AbortionsAreAHumanRight1#{ActsAsTenant.current_tenant.name}"
       assert_not @user.valid?
       assert_equal 'Password must include at least one lowercase letter, ' \
                    'one uppercase letter, and one digit. Forbidden words ' \
-                   'include DCAF and password.',
+                   "include #{ActsAsTenant.current_tenant.name} and password.",
                    @user.errors.messages[:password].first
     end
 

--- a/test/services/pledge_form_generator_test.rb
+++ b/test/services/pledge_form_generator_test.rb
@@ -11,11 +11,12 @@ class PledgeFormGeneratorTest < ActiveSupport::TestCase
                                 fund_pledge: 300, naf_pledge: 200
                                 
     @case_manager_name = 'Angela Davis'
+    ActsAsTenant.current_tenant = create :fund, name: 'DCAF'
   end
 
   describe 'user data' do
     before do
-      @pledge_form_generator = PledgeFormGenerator.new(@user, @patient, @case_manager_name)
+      @pledge_form_generator = PledgeFormGenerator.new(@user, @patient, @case_manager_name, ActsAsTenant.current_tenant)
       @pdf_text = PDF::Inspector::Text.analyze(@pledge_form_generator.generate_pledge_pdf.render).strings
     end
 

--- a/test/system/accountant_workflow_test.rb
+++ b/test/system/accountant_workflow_test.rb
@@ -161,7 +161,7 @@ class AccountantWorkflowTest < ApplicationSystemTestCase
         assert has_content? "Clinic: #{@clinic.name}"
 
         # And should let you update it
-        fill_in 'DCAF payout', with: '999'
+        fill_in "#{ActsAsTenant.current_tenant.name} payout", with: '999'
         fill_in 'Check #', with: 'BB8'
         find('h2').click # Click the header to get the field to save
         wait_for_ajax

--- a/test/system/clinic_management_test.rb
+++ b/test/system/clinic_management_test.rb
@@ -82,7 +82,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
 
       visit edit_patient_path @patient
       click_link 'Abortion Information'
-      select "(Not currently working with DCAF) - #{@clinic.name}", from: 'patient_clinic_id'
+      select "(Not currently working with #{ActsAsTenant.current_tenant.name}) - #{@clinic.name}", from: 'patient_clinic_id'
       assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
     end
   end
@@ -90,7 +90,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
   private
 
   def fill_in_all_clinic_fields
-    new_clinic_name = 'Games Done Quick Throw a Benefit for DCAF'
+    new_clinic_name = "Games Done Quick Throw a Benefit for #{ActsAsTenant.current_tenant.name}"
     fill_in 'Name', with: new_clinic_name
     fill_in 'Street address', with: '123 Fake Street'
     fill_in 'City', with: 'Yolo'
@@ -108,7 +108,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
   end
 
   def assert_fields_have_proper_content
-    assert has_field? 'Name', with: 'Games Done Quick Throw a Benefit for DCAF'
+    assert has_field? 'Name', with: "Games Done Quick Throw a Benefit for #{ActsAsTenant.current_tenant.name}"
     assert has_field? 'Street address', with: '123 Fake Street'
     assert has_field? 'City', with: 'Yolo'
     assert_equal 'TX', find('#clinic_state').value

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -29,7 +29,7 @@ class DataEntryTest < ApplicationSystemTestCase
       select 'DC', from: 'patient_state'
       fill_in 'County', with: 'Wash'
       fill_in 'Zipcode', with: '20009'
-      fill_in 'DCAF pledge', with: '100'
+      fill_in "#{ActsAsTenant.current_tenant.name} pledge", with: '100'
       fill_in 'Age', with: '30'
       select 'Other', from: 'patient_race_ethnicity'
       select @clinic.name, from: 'patient_clinic_id'
@@ -101,7 +101,7 @@ class DataEntryTest < ApplicationSystemTestCase
         assert has_field? 'Abortion cost', with: '200'
         assert has_field? 'Patient contribution', with: '150'
         assert has_field? 'National Abortion Federation pledge', with: '50'
-        assert has_field? 'DCAF pledge', with: '100'
+        assert has_field? "#{ActsAsTenant.current_tenant.name} pledge", with: '100'
         assert has_checked_field? 'Referred to clinic'
         assert has_checked_field? 'Ultrasound completed?'
       end
@@ -133,7 +133,7 @@ class DataEntryTest < ApplicationSystemTestCase
       fill_in 'City', with: 'Washington'
       select 'DC', from: 'patient_state'
       fill_in 'County', with: 'Wash'
-      fill_in 'DCAF pledge', with: '99'
+      fill_in "#{ActsAsTenant.current_tenant.name} pledge", with: '99'
       fill_in 'Fund pledged at', with: 80.days.ago.strftime('%m/%d/%Y')
       fill_in 'Age', with: '30'
       select 'Other', from: 'patient_race_ethnicity'

--- a/test/system/event_log_interaction_test.rb
+++ b/test/system/event_log_interaction_test.rb
@@ -62,11 +62,11 @@ class EventLogInteractionTest < ApplicationSystemTestCase
       find('#pledge-next').click
       wait_for_no_element 'Review this preview of your pledge'
 
-      assert has_text? 'Awesome, you generated a DCAF'
+      assert has_text? "Awesome, you generated a #{ActsAsTenant.current_tenant.name}"
       check 'I sent the pledge'
       wait_for_ajax
       find('#pledge-next').click
-      wait_for_no_element 'Awesome, you generated a DCAF'
+      wait_for_no_element "Awesome, you generated a #{ActsAsTenant.current_tenant.name}"
 
       visit authenticated_root_path
       within :css, '#activity_log_content' do

--- a/test/system/pledge_fulfillment_test.rb
+++ b/test/system/pledge_fulfillment_test.rb
@@ -47,7 +47,7 @@ class PledgeFulfillmentTest < ApplicationSystemTestCase
       assert has_link? 'Pledge Fulfillment'
       click_link 'Pledge Fulfillment'
       assert has_text? "Clinic: #{@clinic.name}"
-      assert has_text? 'DCAF Pledge Amount: $500'
+      assert has_text? "#{ActsAsTenant.current_tenant.name} Pledge Amount: $500"
       assert has_text? 'Procedure date'
       assert has_text? 'Check #'
     end

--- a/test/system/practical_support_behaviors_test.rb
+++ b/test/system/practical_support_behaviors_test.rb
@@ -55,7 +55,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
     it 'should save if valid and changed' do
       within :css, '#practical-support-entries' do
         select 'Companion', from: 'practical_support_support_type'
-        select 'DC Abortion Fund', from: 'practical_support_source'
+        select ActsAsTenant.current_tenant.full_name, from: 'practical_support_source'
         check 'Confirmed'
       end
 
@@ -64,7 +64,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
       reload_page_and_click_link 'Practical Support'
       within :css, '#practical-support-entries' do
         assert_equal 'Companion', find('#practical_support_support_type').value
-        assert_equal 'DC Abortion Fund', find('#practical_support_source').value
+        assert_equal ActsAsTenant.current_tenant.full_name, find('#practical_support_source').value
         assert has_checked_field? 'Confirmed'
       end
     end

--- a/test/system/routing_test.rb
+++ b/test/system/routing_test.rb
@@ -16,10 +16,9 @@ class RoutingTest < ApplicationSystemTestCase
 
   it 'should not display navigation partial on sign in' do
     @user = create :user
-    refute has_text? 'DARIA - ' + Rails.env
-    visit root_path
+    refute has_text? "DARIA - #{ActsAsTenant.current_tenant.full_name} - Development"
     log_in_as @user
     visit authenticated_root_path
-    assert has_text? 'DARIA - ' + Rails.env
+    assert has_text? "DARIA - #{ActsAsTenant.current_tenant.full_name} - Development"
   end
 end

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -38,11 +38,11 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       find('#pledge-next').click
       wait_for_no_element 'Review this preview of your pledge'
 
-      assert has_text? 'Awesome, you generated a DCAF'
+      assert has_text? "Awesome, you generated a #{ActsAsTenant.current_tenant.name}"
       check 'I sent the pledge'
       wait_for_ajax
       find('#pledge-next').click
-      wait_for_no_element 'Awesome, you generated a DCAF'
+      wait_for_no_element "Awesome, you generated a #{ActsAsTenant.current_tenant.name}"
 
       wait_for_ajax
       wait_for_element 'Patient information'

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -136,14 +136,14 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     before do
       click_link 'Abortion Information'
       select @clinic.name, from: 'patient_clinic_id'
-      check 'Resolved without assistance from DCAF'
+      check "Resolved without assistance from #{ActsAsTenant.current_tenant.name}"
       check 'Referred to clinic'
       check 'Ultrasound completed?'
 
       fill_in 'Abortion cost', with: '300'
       fill_in 'Patient contribution', with: '200'
       fill_in 'National Abortion Federation pledge', with: '50'
-      fill_in 'DCAF pledge', with: '25'
+      fill_in "#{ActsAsTenant.current_tenant.name} pledge", with: '25'
       fill_in 'Baltimore Abortion Fund pledge', with: '25', match: :prefer_exact
       fill_in 'Abortion cost', with: '300'
       click_away_from_field
@@ -162,21 +162,21 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       find('#outstanding-balance').has_text?('$19950')
       fill_in 'Baltimore Abortion Fund pledge', with: '0', match: :prefer_exact
       find('#outstanding-balance').has_text?('$19975')
-      fill_in 'DCAF pledge', with: '0'
+      fill_in "#{ActsAsTenant.current_tenant.name} pledge", with: '0'
       find('#outstanding-balance').has_text?('$20000')
     end
 
     it 'should alter the abortion information' do
       within :css, '#abortion_information' do
         assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
-        assert has_checked_field?('Resolved without assistance from DCAF')
+        assert has_checked_field?("Resolved without assistance from #{ActsAsTenant.current_tenant.name}")
         assert has_checked_field?('Referred to clinic')
         assert has_checked_field?('Ultrasound completed?')
 
         assert has_field? 'Abortion cost', with: '300'
         assert has_field? 'Patient contribution', with: '200'
         assert has_field? 'National Abortion Federation pledge', with: '50'
-        assert has_field? 'DCAF pledge', with: '25'
+        assert has_field? "#{ActsAsTenant.current_tenant.name} pledge", with: '25'
         assert has_field? 'Baltimore Abortion Fund pledge', with: '25'
       end
     end
@@ -304,7 +304,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       wait_for_ajax
 
       select '12 weeks', from: 'Weeks along at procedure'
-      fill_in 'DCAF payout', with: '100'
+      fill_in "#{ActsAsTenant.current_tenant.name} payout", with: '100'
       wait_for_ajax
 
       fill_in 'Check #', with: '444-22'
@@ -327,7 +327,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
                           with: 2.days.from_now.strftime('%Y-%m-%d')
         assert_equal '12',
                      find('#patient_fulfillment_attributes_gestation_at_procedure').value
-        assert has_field? 'DCAF payout', with: 100
+        assert has_field? "#{ActsAsTenant.current_tenant.name} payout", with: 100
         assert has_field? 'Check #', with: '444-22'
         assert has_checked_field? 'Fulfillment audited?'
 

--- a/test/system/voicemail_preference_in_call_modal_test.rb
+++ b/test/system/voicemail_preference_in_call_modal_test.rb
@@ -31,7 +31,7 @@ class VoicemailPreferenceInCallModalTest < ApplicationSystemTestCase
       end
 
       it 'should have warning text and a link' do
-        assert has_text? 'Voicemail OK; Do not identify as DCAF'
+        assert has_text? "Voicemail OK; Do not identify as #{ActsAsTenant.current_tenant.name}"
         assert has_link? 'I left a voicemail for the patient'
       end
     end
@@ -44,7 +44,7 @@ class VoicemailPreferenceInCallModalTest < ApplicationSystemTestCase
       end
 
       it 'should have goahead text and a link' do
-        assert has_text? 'Voicemail OK; Okay to identify as DCAF'
+        assert has_text? "Voicemail OK; Okay to identify as #{ActsAsTenant.current_tenant.name}"
         assert has_link? 'I left a voicemail for the patient'
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,13 +23,26 @@ class ActiveSupport::TestCase
 
   before do
     Bullet.start_request
+    setup_tenant
   end
   after do
     Bullet.perform_out_of_channel_notifications if Bullet.notification?
     Bullet.end_request
+    teardown_tenant
   end
 
   parallelize(workers: :number_of_processors)
+
+  def setup_tenant
+    tenant = create :fund
+    ActsAsTenant.current_tenant = tenant
+    ActsAsTenant.test_tenant = tenant
+  end
+
+  def teardown_tenant
+    ActsAsTenant.current_tenant = nil
+    ActsAsTenant.test_tenant = nil
+  end
 
   def create_insurance_config
     insurance_options = ['DC Medicaid', 'Other state Medicaid']


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This sets up the acts_as_tenant gem, to enable us to do multitenancy.

The general approach here is to move a lot of the stuff that's in env vars now to a `Fund` object, and read from that rather than env vars. The rest of it is, frankly, mostly grepping around for `FUND` and removing that in favor of some form of `current_tenant.name`. (Exceptions to this are lines - more on lines later - and fund-mailer-domain, which has been daria-services for a little while now.) The diff is large, but most of it turned out to be find and replace.

Deployment-wise, what this will mean in the immediate term is that every fund's instance will get turned into multitenant apps with only one tenant. We'll need to declare a brief downtime to reconfigure, but the two step plan is basically:

* Create a Fund object with the proper subdomain set
* Run some sql to set every row in every table's fund_id to 1

This approach means we can punt on lines for now, but most likely we'll need to retool to make Line a proper object. (Having line be set on the `Fund` level doesn't work super well because of the enums and validation on other objects right now.) But we can roll this out as is without a problem.

To test:
* try the migration strategy: 

```ruby
git checkout main && rails db:drop db:create db:migrate db:seed && git checkout tenants-2 && rails db:migrate
echo "Fund.create name: 'CatFund', domain: 'supercat', subdomain: 'fluffy', full_name: 'Catte Fund" | rails c
sql="
begin;
update archived_patients set fund_id = 1;
update call_list_entries set fund_id = 1;
update calls set fund_id = 1;
update clinics set fund_id = 1;
update configs set fund_id = 1;
update events set fund_id = 1;
update external_pledges set fund_id = 1;
update fulfillments set fund_id = 1;
update notes set fund_id = 1;
update patients set fund_id = 1;
update practical_supports set fund_id = 1;
update users set fund_id = 1;
update versions set fund_id = 1;
commit;
"
echo $sql | rails db
```

* spin up the app as normal - `git checkout tenants-2 && rails db:drop db:create db:migrate db:seed` then `rails s` and try logging in as normal - localhost:3000 - to confirm you can hit the first fund
* log in to the alt development tenant - http://catbox.lvh.me:3000 to confirm you can hit the second fund

This pull request makes the following changes:
* sets up acts as tenant
* adjusts a lot of stuff to be tenant

no significant view changes

It relates to the following issue #s: 
* bumps #1817 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
