### PR TITLE
minimally setup fund separation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'devise', '~> 4.8'
 gem 'omniauth-google-oauth2', '~> 1.0.0'
 gem "omniauth-rails_csrf_protection", '~> 1.0'
 
+# Run multiple funds on one server
+gem 'acts_as_tenant', '~> 0.5.0'
+
 # Strong Password for user password validation for folks not on oauth
 gem 'strong_password', '~> 0.0.10'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,9 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts_as_tenant (0.5.1)
+      rails (>= 5.2)
+      request_store (>= 1.0.5)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     afm (0.2.2)
@@ -440,6 +443,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store
+  acts_as_tenant (~> 0.5.0)
   bootsnap (>= 1.4.2)
   bootstrap (~> 4.5, < 5)
   bootstrap_form (~> 4.5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 # Sets a few devise configs and security measures
 class ApplicationController < ActionController::Base
+  set_current_tenant_by_subdomain(:fund, :subdomain)
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery prepend: true, with: :exception
@@ -7,13 +9,36 @@ class ApplicationController < ActionController::Base
   prepend_before_action :authenticate_user!
   prepend_before_action :confirm_user_not_disabled!, unless: :devise_controller?
 
+  if Rails.env.development?
+    before_action :confirm_tenant_set_development
+  end
+  before_action :confirm_tenant_set
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :prevent_caching_via_headers
   before_action :set_locale
   before_action :set_sentry_context
   before_action :set_paper_trail_whodunnit
 
-  # whitelists attributes in devise
+  # Don't let any requests through without confirming a tenant is set.
+  def confirm_tenant_set
+    # There's an ActsAsTenant config method that does this too,
+    # but we do it here so we can control when it runs.
+    if ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
+      raise ActsAsTenant::Errors::NoTenantSet
+    end
+  end
+
+  # In development only, set first fund as tenant by default.
+  def confirm_tenant_set_development
+    # If you need to access the other fund in dev, hit catbox.lvh.me:3000
+    # to tunnel in.
+    if ActsAsTenant.current_tenant.nil? && !ActsAsTenant.unscoped?
+      # If this errors, make sure you've run rails db:seed to populate db!
+      ActsAsTenant.current_tenant = Fund.find_by! name: 'CatFund'
+    end
+  end
+
+  # allowlist attributes in devise
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update) do |user|

--- a/app/lib/paper_trail_version.rb
+++ b/app/lib/paper_trail_version.rb
@@ -1,5 +1,7 @@
 # Extensions to base class of PaperTrail.
 class PaperTrailVersion < PaperTrail::Version
+  acts_as_tenant :fund
+
   # Relations
   belongs_to :user, foreign_key: :whodunnit, optional: true
 

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -1,5 +1,7 @@
 # A PII stripped patient for reporting.
 class ArchivedPatient < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
   include Exportable

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -1,5 +1,7 @@
 # Object representing a case manager dialing a patient.
 class Call < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include EventLoggable
   include PaperTrailable

--- a/app/models/call_list_entry.rb
+++ b/app/models/call_list_entry.rb
@@ -1,10 +1,12 @@
 # Object representing a patient's call list.
 class CallListEntry < ApplicationRecord
+  acts_as_tenant :fund
+
   # Relationships
   belongs_to :user
   belongs_to :patient
 
   # Validations
   validates :order_key, :line, presence: true
-  validates :patient, uniqueness: { scope: :user }
+  validates_uniqueness_to_tenant :patient, scope: :user
 end

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -1,5 +1,7 @@
 # Object representing a clinic that a patient is going to.
 class Clinic < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
 
@@ -18,7 +20,7 @@ class Clinic < ApplicationRecord
 
   # Validations
   validates :name, :street_address, :city, :state, :zip, presence: true
-  validates :name, uniqueness: true
+  validates_uniqueness_to_tenant :name
 
   # Methods
   def display_location

--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -39,7 +39,7 @@ module CallListable
   end
 
   def reorder_call_list(order, line)
-    current_entries = call_list_entries.includes(:patient).where(line: line).to_a
+    current_entries = call_list_entries.includes(:patient, :fund).where(line: line).to_a
     order.each_with_index do |pt, i|
       current = current_entries.find { |x| x.patient_id.to_s == pt }
       current.update order_key: i

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -1,5 +1,7 @@
 # Class so that funds can set their own dropdown lists of things
 class Config < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
 
@@ -64,7 +66,8 @@ class Config < ApplicationRecord
 
   before_validation :clean_config_value
 
-  validates :config_key, uniqueness: true, presence: true
+  validates :config_key, presence: true
+  validates_uniqueness_to_tenant :config_key
   validate :validate_config
 
   # Methods

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,7 @@
 # Object representing relevant actions taken by a case manager.
 class Event < ApplicationRecord
+  acts_as_tenant :fund
+
   # Enums
   enum event_type: {
     reached_patient: 0,

--- a/app/models/external_pledge.rb
+++ b/app/models/external_pledge.rb
@@ -1,6 +1,8 @@
 # Object representing money from organizations that aren't the fund or NAF.
 # For primary fund pledges or NAF pledges, see the patient model.
 class ExternalPledge < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
 

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -1,6 +1,8 @@
 # Indicator that a pledge by the primary fund was cashed in,
 # which in turn indicates that the patient used our pledged money.
 class Fulfillment < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
 

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -1,0 +1,10 @@
+class Fund < ApplicationRecord
+  # TODO make papertrailable
+
+  # Validations
+  validates :name,
+            :subdomain,
+            :domain,
+            presence: true,
+            uniqueness: true
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,7 @@
 # A case manager's log of their interactions with a patient.
 class Note < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,5 +1,7 @@
 # Object representing core patient information and demographic data.
 class Patient < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
   include Urgency
@@ -44,6 +46,8 @@ class Patient < ApplicationRecord
   accepts_nested_attributes_for :fulfillment
 
   # Validations
+  # Worry about uniqueness to tenant after porting line info.
+  # validates_uniqueness_to_tenant :primary_phone 
   validates :name,
             :primary_phone,
             :initial_call_date,

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -1,5 +1,7 @@
 # Representation of non-monetary assistance coordinated for a patient.
 class PracticalSupport < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # Object representing a case manager.
 # Fields are all devise settings; most of the methods relate to call list mgmt.
 class User < ApplicationRecord
+  acts_as_tenant :fund
+
   # Concerns
   include PaperTrailable
   include CallListable
@@ -10,12 +12,17 @@ class User < ApplicationRecord
           :registerable,
           :recoverable,
           :trackable,
-          :validatable,
           :lockable,
           :timeoutable,
           :omniauthable, omniauth_providers: [:google_oauth2]
+  # :validatable, # We override this to accommodate tenancy
   # :rememberable
   # :confirmable
+
+  # Constants
+  MIN_PASSWORD_LENGTH = 8
+  TIME_BEFORE_DISABLED_BY_FUND = 9.months
+  SEARCH_LIMIT = 15
 
   # Enums
   enum role: {
@@ -33,14 +40,24 @@ class User < ApplicationRecord
 
   # Validations
   # email presence validated through Devise
-  validates :name, :role, presence: true
+  validates_uniqueness_to_tenant :email, allow_blank: true, if: :email_changed?
+  validates :name, :role, :email, presence: true
   validates_format_of :email, with: Devise::email_regexp
   validate :secure_password, if: :updating_password?
   # i18n-tasks-use t('errors.messages.password.password_strength')
   validates :password, password_strength: {use_dictionary: true}, if: :updating_password?
 
-  TIME_BEFORE_DISABLED_BY_FUND = 9.months
-  SEARCH_LIMIT = 15
+  # To accommodate tenancy, we use our own devise validations
+  # See https://github.com/heartcombo/devise/blob/master/lib/devise/models/validatable.rb
+  validates_format_of       :email, with: Devise::email_regexp, allow_blank: true, if: :email_changed?
+  validates_presence_of     :password, if: :password_required?
+  validates_confirmation_of :password, if: :password_required?
+  validates_length_of       :password, within: MIN_PASSWORD_LENGTH..100, allow_blank: true
+
+  def password_required?
+    !persisted? || !password.nil? || !password_confirmation.nil?
+  end
+  # end boilerplate from validatable
 
   def updating_password?
     return !password.nil?
@@ -97,7 +114,7 @@ class User < ApplicationRecord
   private
 
   def verify_password_complexity
-    return false unless password.length >= 8 # length at least 8
+    return false unless password.length >= MIN_PASSWORD_LENGTH # length at least 8
     return false if (password =~ /[a-z]/).nil? # at least one lowercase
     return false if (password =~ /[A-Z]/).nil? # at least one uppercase
     return false if (password =~ /[0-9]/).nil? # at least one digit

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,4 +80,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # To allow usage of lvh.me, a tunnelling service, in development for multitenancy.
+  config.hosts = nil
 end

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,0 +1,3 @@
+# Configure acts_as_tenant, if necessary.
+ActsAsTenant.configure do |config|
+end

--- a/db/migrate/20210927013527_create_funds.rb
+++ b/db/migrate/20210927013527_create_funds.rb
@@ -1,0 +1,11 @@
+class CreateFunds < ActiveRecord::Migration[6.1]
+  def change
+    create_table :funds do |t|
+      t.string :name
+      t.string :subdomain
+      t.string :domain
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210927014027_add_fund_to_models.rb
+++ b/db/migrate/20210927014027_add_fund_to_models.rb
@@ -1,0 +1,21 @@
+class AddFundToModels < ActiveRecord::Migration[6.1]
+  def change
+    %w(
+      archived_patients
+      calls
+      call_list_entries
+      clinics
+      configs
+      events
+      external_pledges
+      fulfillments
+      notes
+      patients
+      practical_supports
+      users
+      versions
+    ).each do |model|
+      add_reference model, :fund, foreign_key: true
+    end
+  end
+end 

--- a/db/migrate/20210927014219_allow_multitenant_validation.rb
+++ b/db/migrate/20210927014219_allow_multitenant_validation.rb
@@ -1,0 +1,16 @@
+class AllowMultitenantValidation < ActiveRecord::Migration[6.1]
+  def change
+    # This rescopes uniqueness on a few models to be within a particular fund_id.
+    # For ex, a user can have an account with more than one fund.
+    remove_index :users, :email, unique: true
+    add_index :users, [:email, :fund_id], unique: true
+
+    # And a patient might show up in multiple funds.
+    remove_index :patients, :primary_phone, unique: true
+    add_index :patients, [:primary_phone, :fund_id], unique: true
+
+    # And every fund has their own set of configs.
+    remove_index :configs, :config_key, unique: true
+    add_index :configs, [:config_key, :fund_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_25_025609) do
+ActiveRecord::Schema.define(version: 2021_09_27_014219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -54,7 +54,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "pledge_sent_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["clinic_id"], name: "index_archived_patients_on_clinic_id"
+    t.index ["fund_id"], name: "index_archived_patients_on_fund_id"
     t.index ["line"], name: "index_archived_patients_on_line"
     t.index ["pledge_generated_by_id"], name: "index_archived_patients_on_pledge_generated_by_id"
     t.index ["pledge_sent_by_id"], name: "index_archived_patients_on_pledge_sent_by_id"
@@ -67,6 +69,8 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.integer "order_key", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_call_list_entries_on_fund_id"
     t.index ["line"], name: "index_call_list_entries_on_line"
     t.index ["patient_id"], name: "index_call_list_entries_on_patient_id"
     t.index ["user_id"], name: "index_call_list_entries_on_user_id"
@@ -78,7 +82,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_call_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["can_call_type", "can_call_id"], name: "index_calls_on_can_call_type_and_can_call_id"
+    t.index ["fund_id"], name: "index_calls_on_fund_id"
   end
 
   create_table "clinics", force: :cascade do |t|
@@ -122,6 +128,8 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.integer "costs_30wks"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_clinics_on_fund_id"
   end
 
   create_table "configs", force: :cascade do |t|
@@ -129,7 +137,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.jsonb "config_value", default: {"options"=>[]}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["config_key"], name: "index_configs_on_config_key", unique: true
+    t.bigint "fund_id"
+    t.index ["config_key", "fund_id"], name: "index_configs_on_config_key_and_fund_id", unique: true
+    t.index ["fund_id"], name: "index_configs_on_fund_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -141,7 +151,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.integer "pledge_amount"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["created_at"], name: "index_events_on_created_at"
+    t.index ["fund_id"], name: "index_events_on_fund_id"
     t.index ["line"], name: "index_events_on_line"
   end
 
@@ -153,7 +165,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_pledge_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["can_pledge_type", "can_pledge_id"], name: "index_external_pledges_on_can_pledge_type_and_can_pledge_id"
+    t.index ["fund_id"], name: "index_external_pledges_on_fund_id"
   end
 
   create_table "fulfillments", force: :cascade do |t|
@@ -168,9 +182,19 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_fulfill_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["audited"], name: "index_fulfillments_on_audited"
     t.index ["can_fulfill_type", "can_fulfill_id"], name: "index_fulfillments_on_can_fulfill_type_and_can_fulfill_id"
     t.index ["fulfilled"], name: "index_fulfillments_on_fulfilled"
+    t.index ["fund_id"], name: "index_fulfillments_on_fund_id"
+  end
+
+  create_table "funds", force: :cascade do |t|
+    t.string "name"
+    t.string "subdomain"
+    t.string "domain"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "notes", force: :cascade do |t|
@@ -178,6 +202,8 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "patient_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_notes_on_fund_id"
     t.index ["patient_id"], name: "index_notes_on_patient_id"
   end
 
@@ -228,7 +254,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "last_edited_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["clinic_id"], name: "index_patients_on_clinic_id"
+    t.index ["fund_id"], name: "index_patients_on_fund_id"
     t.index ["identifier"], name: "index_patients_on_identifier"
     t.index ["last_edited_by_id"], name: "index_patients_on_last_edited_by_id"
     t.index ["line"], name: "index_patients_on_line"
@@ -238,7 +266,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.index ["pledge_generated_by_id"], name: "index_patients_on_pledge_generated_by_id"
     t.index ["pledge_sent"], name: "index_patients_on_pledge_sent"
     t.index ["pledge_sent_by_id"], name: "index_patients_on_pledge_sent_by_id"
-    t.index ["primary_phone"], name: "index_patients_on_primary_phone", unique: true
+    t.index ["primary_phone", "fund_id"], name: "index_patients_on_primary_phone_and_fund_id", unique: true
     t.index ["urgent_flag"], name: "index_patients_on_urgent_flag"
   end
 
@@ -250,7 +278,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.bigint "can_support_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "fund_id"
     t.index ["can_support_type", "can_support_id"], name: "index_practical_supports_on_can_support_type_and_can_support_id"
+    t.index ["fund_id"], name: "index_practical_supports_on_fund_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -281,7 +311,9 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.inet "last_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.bigint "fund_id"
+    t.index ["email", "fund_id"], name: "index_users_on_email_and_fund_id", unique: true
+    t.index ["fund_id"], name: "index_users_on_fund_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -293,16 +325,31 @@ ActiveRecord::Schema.define(version: 2021_07_25_025609) do
     t.json "object"
     t.json "object_changes"
     t.datetime "created_at"
+    t.bigint "fund_id"
+    t.index ["fund_id"], name: "index_versions_on_fund_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "archived_patients", "clinics"
+  add_foreign_key "archived_patients", "funds"
   add_foreign_key "archived_patients", "users", column: "pledge_generated_by_id"
   add_foreign_key "archived_patients", "users", column: "pledge_sent_by_id"
+  add_foreign_key "call_list_entries", "funds"
   add_foreign_key "call_list_entries", "patients"
   add_foreign_key "call_list_entries", "users"
+  add_foreign_key "calls", "funds"
+  add_foreign_key "clinics", "funds"
+  add_foreign_key "configs", "funds"
+  add_foreign_key "events", "funds"
+  add_foreign_key "external_pledges", "funds"
+  add_foreign_key "fulfillments", "funds"
+  add_foreign_key "notes", "funds"
   add_foreign_key "patients", "clinics"
+  add_foreign_key "patients", "funds"
   add_foreign_key "patients", "users", column: "last_edited_by_id"
   add_foreign_key "patients", "users", column: "pledge_generated_by_id"
   add_foreign_key "patients", "users", column: "pledge_sent_by_id"
+  add_foreign_key "practical_supports", "funds"
+  add_foreign_key "users", "funds"
+  add_foreign_key "versions", "funds"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,17 +2,20 @@
 raise 'No running seeds in prod' unless [nil, 'Sandbox'].include? ENV['DARIA_FUND']
 
 # Clear out existing DB
-Config.destroy_all
-Event.destroy_all
-Call.destroy_all
-CallListEntry.destroy_all
-ExternalPledge.destroy_all
-Fulfillment.destroy_all
-Note.destroy_all
-Patient.destroy_all
-ArchivedPatient.destroy_all
-User.destroy_all
-Clinic.destroy_all
+ActsAsTenant.without_tenant do
+  Config.destroy_all
+  Event.destroy_all
+  Call.destroy_all
+  CallListEntry.destroy_all
+  ExternalPledge.destroy_all
+  Fulfillment.destroy_all
+  Note.destroy_all
+  Patient.destroy_all
+  ArchivedPatient.destroy_all
+  User.destroy_all
+  Clinic.destroy_all
+  Fund.destroy_all
+end
 
 # Do versioning
 PaperTrail.enabled = true
@@ -21,397 +24,414 @@ PaperTrail.enabled = true
 lines = %w[DC VA MD]
 note_text = 'This is a note ' * 10
 additional_note_text = 'Additional note ' * 10
+password = 'AbortionsAreAHumanRight1'
 
-# Create test users
-user = User.create! name: 'testuser (admin)', email: 'test@example.com',
-                    password: 'AbortionsAreAHumanRight1', password_confirmation: 'AbortionsAreAHumanRight1',
-                    role: :admin
-user2 = User.create! name: 'testuser2', email: 'test2@example.com',
-                     password: 'AbortionsAreAHumanRight1', password_confirmation: 'AbortionsAreAHumanRight1',
-                     role: :cm
-User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
-             password: 'AbortionsAreAHumanRight1', password_confirmation: 'AbortionsAreAHumanRight1',
-             role: :cm
+# Create a few test funds
+fund1 = Fund.create! name: 'CatFund',
+                     domain: 'catfund.org',
+                     subdomain: 'sandbox'
 
-# Default to user2 as the actor
-PaperTrail.request.whodunnit = user2.id
+fund2 = Fund.create! name: 'BigCatFund',
+                     domain: 'catfund.org',
+                     subdomain: 'catbox'
 
-# Create a few clinics
-Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '1600 Pennsylvania Ave',
-               city: 'Washington', state: 'DC', zip: '20500'
-Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '1400 Defense',
-               city: 'Arlington', state: 'VA', zip: '20301'
-Clinic.create! name: 'Sample Clinic with NAF', street_address: '815 V Street NW',
-               city: 'Washington', state: 'DC', zip: '20001', accepts_naf: true
-Clinic.create! name: 'Sample Clinic without NAF', street_address: '1811 14th Street NW',
-               city: 'Washington', state: 'DC', zip: '20009', accepts_naf: false, accepts_medicaid: true
+[fund1, fund2].each do |fund|
+  ActsAsTenant.with_tenant(fund) do
+    # Create test users
+    user = User.create! name: 'testuser (admin)', email: 'test@example.com',
+                        password: password, password_confirmation: password,
+                        role: :admin
+    user2 = User.create! name: 'testuser2', email: 'test2@example.com',
+                         password: password, password_confirmation: password,
+                         role: :cm
+    User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
+                 password: password, password_confirmation: password,
+                 role: :cm
 
-# Create user-settable configuration
-Config.create config_key: :insurance,
-              config_value: { options: ['DC Medicaid', 'MD Medicaid', 'VA Medicaid', 'Other Insurance'] }
-Config.create config_key: :external_pledge_source,
-              config_value: { options: ['Baltimore Abortion Fund', 'Metallica Abortion Fund'] }
-Config.create config_key: :pledge_limit_help_text,
-              config_value: { options: ['Pledge Limit Guidelines:', '1st trimester (7-12 weeks): $100', '2nd trimester (12-24 weeks): $300', 'Later care (25+ weeks): $600'] }
-Config.create config_key: :language,
-              config_value: { options: %w[Spanish French Korean] }
-Config.create config_key: :resources_url,
-              config_value: { options: ['https://www.petfinder.com/cats/'] }
-Config.create config_key: :practical_support_guidance_url,
-              config_value: { options: ['https://www.petfinder.com/dogs/'] }
-Config.create config_key: :referred_by,
-              config_value: { options: ['Metal band'] }
-Config.create config_key: :fax_service,
-              config_value: { options: ['www.yolofax.com'] }
-Config.create config_key: :start_of_week,
-              config_value: { options: ['Monday'] }
+    # Default to user2 as the actor
+    PaperTrail.request.whodunnit = user2.id
 
-# Create ten active patients with generic info.
-10.times do |i|
-  patient = Patient.create! name: "Patient #{i}",
-                            primary_phone: "123-123-123#{i}",
-                            initial_call_date: 3.days.ago,
-                            urgent_flag: i.even?,
-                            last_menstrual_period_weeks: (i + 1 * 2),
-                            last_menstrual_period_days: 3,
-                            line: 'DC'
+    # Create a few clinics
+    Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '1600 Pennsylvania Ave',
+                   city: 'Washington', state: 'DC', zip: '20500'
+    Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '1400 Defense',
+                   city: 'Arlington', state: 'VA', zip: '20301'
+    Clinic.create! name: 'Sample Clinic with NAF', street_address: '815 V Street NW',
+                   city: 'Washington', state: 'DC', zip: '20001', accepts_naf: true
+    Clinic.create! name: 'Sample Clinic without NAF', street_address: '1811 14th Street NW',
+                   city: 'Washington', state: 'DC', zip: '20009', accepts_naf: false, accepts_medicaid: true
 
-  # Create associated objects
-  case i
-  when 0
-    10.times do
-      patient.calls.create! status: :reached_patient,
-                            created_at: 3.days.ago
+    # Create user-settable configuration
+    Config.create config_key: :insurance,
+                  config_value: { options: ['DC Medicaid', 'MD Medicaid', 'VA Medicaid', 'Other Insurance'] }
+    Config.create config_key: :external_pledge_source,
+                  config_value: { options: ['Baltimore Abortion Fund', 'Metallica Abortion Fund'] }
+    Config.create config_key: :pledge_limit_help_text,
+                  config_value: { options: ['Pledge Limit Guidelines:', '1st trimester (7-12 weeks): $100', '2nd trimester (12-24 weeks): $300', 'Later care (25+ weeks): $600'] }
+    Config.create config_key: :language,
+                  config_value: { options: %w[Spanish French Korean] }
+    Config.create config_key: :resources_url,
+                  config_value: { options: ['https://www.petfinder.com/cats/'] }
+    Config.create config_key: :practical_support_guidance_url,
+                  config_value: { options: ['https://www.petfinder.com/dogs/'] }
+    Config.create config_key: :referred_by,
+                  config_value: { options: ['Metal band'] }
+    Config.create config_key: :fax_service,
+                  config_value: { options: ['www.yolofax.com'] }
+    Config.create config_key: :start_of_week,
+                  config_value: { options: ['Monday'] }
+
+    # Create ten active patients with generic info.
+    10.times do |i|
+      patient = Patient.create! name: "Patient #{i}",
+                                primary_phone: "123-123-123#{i}",
+                                initial_call_date: 3.days.ago,
+                                urgent_flag: i.even?,
+                                last_menstrual_period_weeks: (i + 1 * 2),
+                                last_menstrual_period_days: 3,
+                                line: lines.first
+
+      # Create associated objects
+      case i
+      when 0
+        10.times do
+          patient.calls.create! status: :reached_patient,
+                                created_at: 3.days.ago
+        end
+      when 1
+        PaperTrail.request(whodunnit: user.id) do
+          patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
+                          other_phone: '234-456-6789', other_contact_relationship: 'Sister'
+          patient.calls.create! status: :reached_patient,
+                                created_at: 14.hours.ago
+        end
+      when 2
+        # appointment one week from today && clinic selected
+        patient.update! name: 'Clinic and Appt - 2',
+                        zipcode: "20009",
+                        pronouns: 'she/they',
+                        clinic: Clinic.first,
+                        appointment_date: 2.days.from_now
+      when 3
+        # pledge submitted
+        patient.update! clinic: Clinic.first,
+                        appointment_date: 3.days.from_now,
+                        naf_pledge: 200,
+                        procedure_cost: 400,
+                        fund_pledge: 100,
+                        pledge_sent: true,
+                        patient_contribution: 100,
+                        zipcode: "06222",
+                        pronouns: 'ze/zir',
+                        name: 'Pledge submitted - 3'
+      when 4
+        PaperTrail.request(whodunnit: user.id) do
+          # With special circumstances
+          patient.update! name: 'Special Circumstances - 4',
+                          special_circumstances: ['Prison', 'Fetal anomaly']
+          # And a recent call on file
+          patient.calls.create! status: :left_voicemail
+        end
+      when 5
+        # Resolved without DCAF
+        patient.update! name: 'Resolved without DCAF - 5',
+                        resolved_without_fund: true
+      end
+
+      if i != 9
+        5.times do
+          patient.calls.create! status: :left_voicemail,
+                                created_at: 3.days.ago
+        end
+      end
+
+      # Add notes for most patients
+      unless [0, 1].include? i
+        patient.notes.create! full_text: note_text
+      end
+
+      if i.even?
+        patient.notes.create! full_text: additional_note_text
+      end
+
+      # Add select patients to call list for user
+      user.add_patient patient if [0, 1, 2, 3, 4, 5].include? i
+
+      patient.save
     end
-  when 1
-    PaperTrail.request(whodunnit: user.id) do
-      patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
-                      other_phone: '234-456-6789', other_contact_relationship: 'Sister'
-      patient.calls.create! status: :reached_patient,
-                            created_at: 14.hours.ago
+
+    # Add patients for reporting purposes - CSV exports, fulfillments, etc.
+    PaperTrail.request.whodunnit = user.id
+    10.times do |i|
+      patient = Patient.create!(
+        name: "Reporting Patient #{i}",
+        primary_phone: "321-0#{i}0-001#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: i.even?,
+        line: i.even? ? lines.first : lines.second,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now,
+        last_menstrual_period_weeks: 7,
+        last_menstrual_period_days: 7,
+        naf_pledge: 300,
+        fund_pledge: 50,
+        procedure_cost: 600,
+        pledge_sent: true,
+        patient_contribution: 100
+      )
+
+      next unless i.even?
+
+      patient.fulfillment.update fulfilled: true,
+                                 fund_payout: 4000,
+                                 procedure_date: 10.days.from_now
     end
-  when 2
-    # appointment one week from today && clinic selected
-    patient.update! name: 'Clinic and Appt - 2',
-                    zipcode: "20009",
-                    pronouns: 'she/they',
-                    clinic: Clinic.first,
-                    appointment_date: 2.days.from_now
-  when 3
-    # pledge submitted
-    patient.update! clinic: Clinic.first,
-                    appointment_date: 3.days.from_now,
-                    naf_pledge: 200,
-                    procedure_cost: 400,
-                    fund_pledge: 100,
-                    pledge_sent: true,
-                    patient_contribution: 100,
-                    zipcode: "06222",
-                    pronouns: 'ze/zir',
-                    name: 'Pledge submitted - 3'
-  when 4
-    PaperTrail.request(whodunnit: user.id) do
-      # With special circumstances
-      patient.update! name: 'Special Circumstances - 4',
-                      special_circumstances: ['Prison', 'Fetal anomaly']
-      # And a recent call on file
-      patient.calls.create! status: :left_voicemail
+
+    (1..5).each do |patient_number|
+      patient = Patient.create!(
+        name: "Reporting Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-002#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: patient_number.even?,
+        line: lines[patient_number % 3] || lines.first,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now
+      )
+
+      # reached within the past 30 days
+      5.times do
+        patient.calls.create! status: :reached_patient,
+                              created_at: (Time.now - rand(10).days)
+        patient.calls.create! status: :reached_patient,
+                              created_at: (Time.now - rand(10).days - 10.days)
+      end
     end
-  when 5
-    # Resolved without DCAF
-    patient.update! name: 'Resolved without DCAF - 5',
-                    resolved_without_fund: true
-  end
 
-  if i != 9
-    5.times do
-      patient.calls.create! status: :left_voicemail,
-                            created_at: 3.days.ago
+    (1..5).each do |patient_number|
+      patient = Patient.create!(
+        name: "Old Reporting Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-003#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: patient_number.even?,
+        line: lines[patient_number % 3] || lines.first,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now
+      )
+
+      5.times do
+        patient.calls.create! status: :reached_patient,
+                              created_at: (Time.now - rand(10).days - 6.months)
+      end
+    end
+
+    (1..5).each do |patient_number|
+      Patient.create!(
+        name: "Pledge Reporting Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-004#{rand(10)}",
+        initial_call_date: 3.days.ago,
+        urgent_flag: patient_number.even?,
+        line: lines[patient_number % 3] || lines.first,
+        clinic: Clinic.all.sample,
+        appointment_date: 10.days.from_now,
+        pledge_sent: true,
+        fund_pledge: 50
+      )
+    end
+
+    # Add patients for archiving purposes with ALL THE INFO
+    (1..2).each do |patient_number|
+      # initial create data from voicemail
+      patient = Patient.create!(
+        name: "Archive Dataful Patient #{patient_number}",
+        primary_phone: "321-0#{patient_number}0-005#{rand(10)}",
+        voicemail_preference: 'yes',
+        line: lines.first,
+        language: 'Spanish',
+        initial_call_date: 140.days.ago,
+        last_menstrual_period_weeks: 6,
+        last_menstrual_period_days: 5,
+        created_at: 140.days.ago
+      )
+
+      # Call, but no answer. leave a VM.
+      patient.calls.create status: :left_voicemail, created_at: 139.days.ago
+
+      # Call, which updates patient info, maybe flags urgent, make a note.
+      patient.calls.create status: :reached_patient, created_at: 138.days.ago
+
+      patient.update!(
+        # header info - hand filled in
+        appointment_date: 130.days.ago,
+
+        # patient info - hand filled in
+        age: 24,
+        race_ethnicity: 'Hispanic/Latino',
+        city: 'Washington',
+        state: 'DC',
+        county: 'Washington',
+        other_contact: 'Susie Q.',
+        other_phone: "555-0#{patient_number}0-0053",
+        other_contact_relationship: 'Mother',
+        employment_status: 'Student',
+        income: '$10,000-14,999',
+        household_size_adults: 3,
+        household_size_children: 2,
+        insurance: 'Other Insurance',
+        referred_by: 'Clinic',
+        special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
+
+        # abortion info - hand filled in
+        clinic: Clinic.all.sample,
+        referred_to_clinic: patient_number.odd?,
+        resolved_without_fund: patient_number.even?,
+
+        updated_at: 138.days.ago # not sure if this even works?
+      )
+
+      # toggle urgent, maybe
+      patient.update!(
+        urgent_flag: patient_number.odd?,
+        updated_at: 137.days.ago
+      )
+
+      # generate notes
+      patient.notes.create!(
+        full_text: 'One note, with iffy PII! This one was from the first call!',
+        created_at: 137.days.ago
+      )
+
+      # only continue for the unresolved patient(s)
+      next if patient.resolved_without_fund?
+
+      # another call. get abortion information, create pledges, a note.
+      patient.calls.create! status: :reached_patient, created_at: 136.days.ago
+
+      # abortion info - pledges - hand filled in
+      patient.update!(
+        procedure_cost: 555,
+        patient_contribution: 120,
+        naf_pledge: 120,
+        fund_pledge: 115,
+        pledge_sent: true,
+        pledge_generated_at: 133.days.ago,
+        updated_at: 133.days.ago
+      )
+      # generate external pledges
+      patient.external_pledges.create!(
+        source: 'Metallica Abortion Fund',
+        amount: 100,
+        created_at: 133.days.ago
+      )
+      patient.external_pledges.create!(
+        source: 'Baltimore Abortion Fund',
+        amount: 100,
+        created_at: 133.days.ago
+      )
+
+      # notes tab
+      PaperTrail.request(whodunnit: user2.id) do
+        patient.notes.create!(
+          full_text: 'Two note, maybe with iffy PII! From the second call.',
+          created_at: 133.days.ago
+        )
+      end
+
+      # fulfillment
+      patient.fulfillment.update!(
+        fulfilled: true,
+        procedure_date: 130.days.ago,
+        gestation_at_procedure: '11',
+        fund_payout: 555,
+        check_number: 4563,
+        date_of_check: 125.days.ago,
+        updated_at: 125.days.ago
+      )
+    end
+
+    (1..2).each do |patient_number|
+      # Create dropoff patients
+      patient = Patient.create!(
+        name: "Archive Dropoff Patient #{patient_number}",
+        primary_phone: "867-9#{patient_number}0-004#{rand(10)}",
+        voicemail_preference: 'yes',
+        line: lines.first,
+        language: 'Spanish',
+        initial_call_date: 640.days.ago,
+        last_menstrual_period_weeks: 6,
+        last_menstrual_period_days: 5,
+        created_at: 640.days.ago
+      )
+
+      # Call, but no answer. leave a VM.
+      patient.calls.create status: :left_voicemail, created_at: 639.days.ago
+
+      # Call, which updates patient info, maybe flags urgent, make a note.
+      patient.calls.create status: :reached_patient, created_at: 138.days.ago
+
+      # Patient 1 drops off immediately
+      next if patient_number.odd?
+
+      # We reach Patient 2
+      patient.update!(
+        # header info - hand filled in
+        appointment_date: 630.days.ago,
+
+        # patient info - hand filled in
+        age: 24,
+        race_ethnicity: 'Hispanic/Latino',
+        city: 'Washington',
+        state: 'DC',
+        county: 'Washington',
+        zipcode: "20009",
+        pronouns: 'they/them',
+        other_contact: 'Susie Q.',
+        other_phone: "555-6#{patient_number}0-0053",
+        other_contact_relationship: 'Mother',
+
+        employment_status: 'Student',
+        income: '$10,000-14,999',
+        household_size_adults: 3,
+        household_size_children: 2,
+        insurance: 'Other Insurance',
+        referred_by: 'Clinic',
+        special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
+
+        # abortion info - hand filled in
+        clinic: Clinic.all.sample,
+        referred_to_clinic: patient_number.odd?,
+        resolved_without_fund: patient_number.even?
+      )
+
+      # toggle urgent, maybe
+      patient.update!(
+        urgent_flag: patient_number.odd?,
+        updated_at: 637.days.ago
+      )
+
+      # generate notes
+      patient.notes.create!(
+        full_text: 'One note, with iffy PII! This one was from the first call!',
+        created_at: 637.days.ago
+      )
     end
   end
-
-  # Add notes for most patients
-  unless [0, 1].include? i
-    patient.notes.create! full_text: note_text
-  end
-
-  if i.even?
-    patient.notes.create! full_text: additional_note_text
-  end
-
-  # Add select patients to call list for user
-  user.add_patient patient if [0, 1, 2, 3, 4, 5].include? i
-
-  patient.save
-end
-
-# Add patients for reporting purposes - CSV exports, fulfillments, etc.
-PaperTrail.request.whodunnit = user.id
-10.times do |i|
-  patient = Patient.create!(
-    name: "Reporting Patient #{i}",
-    primary_phone: "321-0#{i}0-001#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: i.even?,
-    line: i.even? ? 'DC' : 'MD',
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now,
-    last_menstrual_period_weeks: 7,
-    last_menstrual_period_days: 7,
-    naf_pledge: 300,
-    fund_pledge: 50,
-    procedure_cost: 600,
-    pledge_sent: true,
-    patient_contribution: 100
-  )
-
-  next unless i.even?
-
-  patient.fulfillment.update fulfilled: true,
-                             fund_payout: 4000,
-                             procedure_date: 10.days.from_now
-end
-
-(1..5).each do |patient_number|
-  patient = Patient.create!(
-    name: "Reporting Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-002#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: patient_number.even?,
-    line: lines[patient_number % 3],
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now
-  )
-
-  # reached within the past 30 days
-  5.times do
-    patient.calls.create! status: :reached_patient,
-                          created_at: (Time.now - rand(10).days)
-    patient.calls.create! status: :reached_patient,
-                          created_at: (Time.now - rand(10).days - 10.days)
-  end
-end
-
-(1..5).each do |patient_number|
-  patient = Patient.create!(
-    name: "Old Reporting Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-003#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: patient_number.even?,
-    line: lines[patient_number % 3],
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now
-  )
-
-  5.times do
-    patient.calls.create! status: :reached_patient,
-                          created_at: (Time.now - rand(10).days - 6.months)
-  end
-end
-
-(1..5).each do |patient_number|
-  Patient.create!(
-    name: "Pledge Reporting Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-004#{rand(10)}",
-    initial_call_date: 3.days.ago,
-    urgent_flag: patient_number.even?,
-    line: lines[patient_number % 3],
-    clinic: Clinic.all.sample,
-    appointment_date: 10.days.from_now,
-    pledge_sent: true,
-    fund_pledge: 50
-  )
-end
-
-# Add patients for archiving purposes with ALL THE INFO
-(1..2).each do |patient_number|
-  # initial create data from voicemail
-  patient = Patient.create!(
-    name: "Archive Dataful Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-005#{rand(10)}",
-    voicemail_preference: 'yes',
-    line: 'DC',
-    language: 'Spanish',
-    initial_call_date: 140.days.ago,
-    last_menstrual_period_weeks: 6,
-    last_menstrual_period_days: 5,
-    created_at: 140.days.ago
-  )
-
-  # Call, but no answer. leave a VM.
-  patient.calls.create status: :left_voicemail, created_at: 139.days.ago
-
-  # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: :reached_patient, created_at: 138.days.ago
-
-  patient.update!(
-    # header info - hand filled in
-    appointment_date: 130.days.ago,
-
-    # patient info - hand filled in
-    age: 24,
-    race_ethnicity: 'Hispanic/Latino',
-    city: 'Washington',
-    state: 'DC',
-    county: 'Washington',
-    other_contact: 'Susie Q.',
-    other_phone: "555-0#{patient_number}0-0053",
-    other_contact_relationship: 'Mother',
-    employment_status: 'Student',
-    income: '$10,000-14,999',
-    household_size_adults: 3,
-    household_size_children: 2,
-    insurance: 'Other Insurance',
-    referred_by: 'Clinic',
-    special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
-
-    # abortion info - hand filled in
-    clinic: Clinic.all.sample,
-    referred_to_clinic: patient_number.odd?,
-    resolved_without_fund: patient_number.even?,
-
-    updated_at: 138.days.ago # not sure if this even works?
-  )
-
-  # toggle urgent, maybe
-  patient.update!(
-    urgent_flag: patient_number.odd?,
-    updated_at: 137.days.ago
-  )
-
-  # generate notes
-  patient.notes.create!(
-    full_text: 'One note, with iffy PII! This one was from the first call!',
-    created_at: 137.days.ago
-  )
-
-  # only continue for the unresolved patient(s)
-  next if patient.resolved_without_fund?
-
-  # another call. get abortion information, create pledges, a note.
-  patient.calls.create! status: :reached_patient, created_at: 136.days.ago
-
-  # abortion info - pledges - hand filled in
-  patient.update!(
-    procedure_cost: 555,
-    patient_contribution: 120,
-    naf_pledge: 120,
-    fund_pledge: 115,
-    pledge_sent: true,
-    pledge_generated_at: 133.days.ago,
-    updated_at: 133.days.ago
-  )
-  # generate external pledges
-  patient.external_pledges.create!(
-    source: 'Metallica Abortion Fund',
-    amount: 100,
-    created_at: 133.days.ago
-  )
-  patient.external_pledges.create!(
-    source: 'Baltimore Abortion Fund',
-    amount: 100,
-    created_at: 133.days.ago
-  )
-
-  # notes tab
-  PaperTrail.request(whodunnit: user2.id) do
-    patient.notes.create!(
-      full_text: 'Two note, maybe with iffy PII! From the second call.',
-      created_at: 133.days.ago
-    )
-  end
-
-  # fulfillment
-  patient.fulfillment.update!(
-    fulfilled: true,
-    procedure_date: 130.days.ago,
-    gestation_at_procedure: '11',
-    fund_payout: 555,
-    check_number: 4563,
-    date_of_check: 125.days.ago,
-    updated_at: 125.days.ago
-  )
-end
-
-(1..2).each do |patient_number|
-  # Create dropoff patients
-  patient = Patient.create!(
-    name: "Archive Dropoff Patient #{patient_number}",
-    primary_phone: "867-9#{patient_number}0-004#{rand(10)}",
-    voicemail_preference: 'yes',
-    line: 'DC',
-    language: 'Spanish',
-    initial_call_date: 640.days.ago,
-    last_menstrual_period_weeks: 6,
-    last_menstrual_period_days: 5,
-    created_at: 640.days.ago
-  )
-
-  # Call, but no answer. leave a VM.
-  patient.calls.create status: :left_voicemail, created_at: 639.days.ago
-
-  # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: :reached_patient, created_at: 138.days.ago
-
-  # Patient 1 drops off immediately
-  next if patient_number.odd?
-
-  # We reach Patient 2
-  patient.update!(
-    # header info - hand filled in
-    appointment_date: 630.days.ago,
-
-    # patient info - hand filled in
-    age: 24,
-    race_ethnicity: 'Hispanic/Latino',
-    city: 'Washington',
-    state: 'DC',
-    county: 'Washington',
-    zipcode: "20009",
-    pronouns: 'they/them',
-    other_contact: 'Susie Q.',
-    other_phone: "555-6#{patient_number}0-0053",
-    other_contact_relationship: 'Mother',
-
-    employment_status: 'Student',
-    income: '$10,000-14,999',
-    household_size_adults: 3,
-    household_size_children: 2,
-    insurance: 'Other Insurance',
-    referred_by: 'Clinic',
-    special_circumstances: ['', '', 'Homelessness', '', '', 'Other medical issue', '', '', ''],
-
-    # abortion info - hand filled in
-    clinic: Clinic.all.sample,
-    referred_to_clinic: patient_number.odd?,
-    resolved_without_fund: patient_number.even?
-  )
-
-  # toggle urgent, maybe
-  patient.update!(
-    urgent_flag: patient_number.odd?,
-    updated_at: 637.days.ago
-  )
-
-  # generate notes
-  patient.notes.create!(
-    full_text: 'One note, with iffy PII! This one was from the first call!',
-    created_at: 637.days.ago
-  )
 end
 
 # Log results
-puts "Seed completed! \n" \
-     "Inserted #{Config.count} Config objects. \n" \
-     "Inserted #{Event.count} Event objects. \n" \
-     "Inserted #{Call.count} Call objects. \n" \
-     "Inserted #{CallListEntry.count} CallListEntry objects. \n" \
-     "Inserted #{ExternalPledge.count} ExternalPledge objects. \n" \
-     "Inserted #{Fulfillment.count} Fulfillment objects. \n" \
-     "Inserted #{Note.count} Note objects. \n" \
-     "Inserted #{Patient.count} Patient objects. \n" \
-     "Inserted #{ArchivedPatient.count} ArchivedPatient objects. \n" \
-     "Inserted #{User.count} User objects. \n" \
-     "Inserted #{Clinic.count} Clinic objects. \n" \
-     'User credentials are as follows: ' \
-     "EMAIL: #{user.email} PASSWORD: AbortionsAreAHumanRight1"
+ActsAsTenant.without_tenant do
+  puts "Seed completed! \n" \
+       "Inserted #{Config.count} Config objects. \n" \
+       "Inserted #{Event.count} Event objects. \n" \
+       "Inserted #{Call.count} Call objects. \n" \
+       "Inserted #{CallListEntry.count} CallListEntry objects. \n" \
+       "Inserted #{ExternalPledge.count} ExternalPledge objects. \n" \
+       "Inserted #{Fulfillment.count} Fulfillment objects. \n" \
+       "Inserted #{Note.count} Note objects. \n" \
+       "Inserted #{Patient.count} Patient objects. \n" \
+       "Inserted #{ArchivedPatient.count} ArchivedPatient objects. \n" \
+       "Inserted #{User.count} User objects. \n" \
+       "Inserted #{Clinic.count} Clinic objects. \n" \
+       "Inserted #{Fund.count} Fund objects. \n" \
+       'User credentials are as follows: ' \
+       "EMAIL: #{User.where(role: :admin).first.email} PASSWORD: #{password}"
+end

--- a/test/factories/fund.rb
+++ b/test/factories/fund.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :fund do
+    sequence :name do |n|
+      "Fund #{n}"
+    end
+    sequence :subdomain do |n|
+      "fund#{n}"
+    end
+    domain { 'google' }
+    sequence :full_name do |n|
+      "Fund #{n} of Cat Town"
+    end
+    sequence :site_domain do |n|
+      "www.fund#{n}.pizza"
+    end
+    phone { '(939)-555-0113' }
+  end
+end

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class FundTest < ActiveSupport::TestCase
+  before do
+    @fund = Fund.first # created during setup
+  end
+
+  describe 'basic validations' do
+    it 'should build' do
+      assert create(:fund).valid?
+    end
+
+    [:name, :subdomain, :domain].each do |attrib|
+      it "should require #{attrib}" do
+        @fund[attrib] = nil
+        refute @fund.valid?
+      end
+
+      it "should be unique on #{attrib}" do
+        nonunique_fund = create :fund
+        nonunique_fund[attrib] = @fund[attrib]
+        refute nonunique_fund.valid?
+      end
+    end
+  end
+
+  describe 'scoping by fund' do
+    before { @fund2 = create :fund }
+
+    it 'should separate objects by fund' do
+      [@fund, @fund2].each do |fund|
+        ActsAsTenant.with_tenant(fund) do
+          create :patient
+        end
+      end
+
+      # The funds should see only one of them
+      ActsAsTenant.with_tenant(@fund) do
+        assert_equal 1, Patient.count
+        @pt1 = Patient.first
+      end
+      ActsAsTenant.with_tenant(@fund2) do
+        assert_equal 1, Patient.count
+        @pt2 = Patient.first
+      end
+      refute_equal @pt1.id, @pt2.id
+      refute_equal @pt1.fund_id, @pt2.fund_id
+
+      # But there should be two patients in db
+      ActsAsTenant.current_tenant = nil
+      ActsAsTenant.test_tenant = nil
+      assert_equal 2, Patient.count 
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,13 +27,27 @@ class ActiveSupport::TestCase
 
   before do
     Bullet.start_request
+    setup_tenant
   end
+
   after do
     Bullet.perform_out_of_channel_notifications if Bullet.notification?
     Bullet.end_request
+    teardown_tenant
   end
 
   parallelize(workers: :number_of_processors)
+
+  def setup_tenant
+    tenant = create :fund, name: 'DCAF'
+    ActsAsTenant.current_tenant = tenant
+    ActsAsTenant.test_tenant = tenant
+  end
+
+  def teardown_tenant
+    ActsAsTenant.current_tenant = nil
+    ActsAsTenant.test_tenant = nil
+  end
 
   def create_insurance_config
     insurance_options = ['DC Medicaid', 'Other state Medicaid']


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This sets up the acts_as_tenant gem, to enable us to do multitenancy. Essentially, it installs a gem that sets a default_scope to a particular fund_id by subdomain, aand then adds a fund_id to every table.

Deployment-wise, what this will mean in the immediate term is that every fund's instance will get turned into multitenant apps with only one tenant. We'll need to declare a brief downtime to reconfigure, but the two step plan is basically:

* Create a Fund object with the proper subdomain set
* Run some sql to set every row in every table's fund_id to 1

Since every fund will still be on their own instance for a minute (a multitenant application of one each, ha), we don't have to deal with ACTUAL multitenancy in practice, so we can deploy this in standalone. (Other work that needs to happen: deprecate the stuff in `_env_var_constants`; move line to a proper model.)

You can try out the migration strategy from a fresh seed:

```
git checkout main && rails db:drop db:create db:migrate db:seed && git checkout tenants-just-tenant && rails db:migrate
echo "Fund.create name: 'CatFund', domain: 'supercat', subdomain: 'fluffy' | rails c
sql="
begin;
update archived_patients set fund_id = 1;
update call_list_entries set fund_id = 1;
update calls set fund_id = 1;
update clinics set fund_id = 1;
update configs set fund_id = 1;
update events set fund_id = 1;
update external_pledges set fund_id = 1;
update fulfillments set fund_id = 1;
update notes set fund_id = 1;
update patients set fund_id = 1;
update practical_supports set fund_id = 1;
update users set fund_id = 1;
update versions set fund_id = 1;
commit;
"
echo $sql | rails db # now everything is properly scoped and retrievable
```

And the development environment:

* spin up the app as normal - git checkout tenants-just-tenant && rails db:drop db:create db:migrate db:seed then rails s and try logging in as normal - localhost:3000 - to confirm you can hit the first fund
* log in to the alt development tenant - http://catbox.lvh.me:3000 to confirm you can hit the second fund


This pull request makes the following changes:
* install acts_as_tenant gem
* scopes everything properly
* makes adjustments toget models to play nice with everything

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Bumps #1817 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
