### PR TITLE
Conditionally run artifact storage steps in test job

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -86,12 +86,14 @@ jobs:
       # Save artifacts
       - name: Store coverage artifact
         uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: code-coverage-report
           path: coverage
 
       - name: Store test artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: capybara-screenshots
           path: tmp/capybara/


### PR DESCRIPTION
We should always preserve the coverage artifacts. The screenshot artifacts, however, should only get stored when a job fails. Follow up from #2436 
