### PR TITLE
declare asset site url specifically via env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -54,6 +54,10 @@
       "description": "The app name you just selected plus .herokuapp.com. e.g. daria-xaf.herokuapp.com",
       "value": ""
     },
+    "ASSET_SITE_URL": {
+      "description": "Optional - domain set up to serve assets",
+      "value": ""
+    },
     "SENDGRID_USERNAME": {
       "description": "the sendgrid username for auth. Should always be `apikey`",
       "value": "apikey"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # Prevent host header injection
   config.action_controller.default_url_options = { host: ENV['SITE_URL'] }
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV['SITE_URL']
+  config.action_controller.asset_host = ENV['ASSET_SITE_URL'] || ENV['SITE_URL']
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,8 +11,8 @@ Rails.application.config.content_security_policy do |policy|
   policy.object_src  :none
   policy.font_src    :self, 'fonts.gstatic.com'
   policy.connect_src :self
-  policy.script_src  :self, :unsafe_eval
-  policy.style_src   :self, :unsafe_inline
+  policy.script_src  :self, "https://#{ENV['ASSET_SITE_URL'] || ENV['SITE_URL']}", :unsafe_eval
+  policy.style_src   :self, "https://#{ENV['ASSET_SITE_URL'] || ENV['SITE_URL']}", :unsafe_inline
 
   # Specify URI for violation reports
   policy.report_uri  "https://#{ENV['CSP_VIOLATION_URI']}/csp/reportOnly"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,14 +11,18 @@ Rails.application.config.content_security_policy do |policy|
   policy.object_src  :none
   policy.font_src    :self, 'fonts.gstatic.com'
   policy.connect_src :self
-  policy.script_src  :self, "https://#{ENV['ASSET_SITE_URL'] || ENV['SITE_URL']}", :unsafe_eval
-  policy.style_src   :self, "https://#{ENV['ASSET_SITE_URL'] || ENV['SITE_URL']}", :unsafe_inline
+  policy.script_src  :self, :unsafe_eval
+  policy.style_src   :self, :unsafe_inline
 
   # Specify URI for violation reports
   policy.report_uri  "https://#{ENV['CSP_VIOLATION_URI']}/csp/reportOnly"
 
   # If you are using webpack-dev-server then specify webpack-dev-server host
   policy.connect_src :self, :https, 'http://localhost:3035', 'ws://localhost:3035' if Rails.env.development?
+
+  # If ASSET_SITE_URL is set, allow that too
+  policy.script_src  :self, "https://#{ENV['ASSET_SITE_URL']}", :unsafe_eval    if ENV['ASSET_SITE_URL'].present?
+  policy.style_src   :self, "https://#{ENV['ASSET_SITE_URL']}", :unsafe_inline  if ENV['ASSET_SITE_URL'].present?
 end
 
 # If you are using UJS then enable automatic nonce generation


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

for multitenant, we need to be able to point the asset loader at a particular url; this lets us do that via environment variable, with a fallback to current behavior.

(This is because otherwise in a multitenant environment it'll try to point it at a domain that isn't set up.)

This pull request makes the following changes:
* lets us dynamically set up asset urls for multitenant envs

no view changes

It relates to the following issue #s: 
* Bumps #1817 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
