### PR TITLE
Use model attribute rather than env var for pledge generation

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,10 +29,6 @@
       "description": "domain you want emails to come from. Should be the domain configured with sendgrid. Usually dariaservices.com.",
       "value": "dariaservices.com"
     },
-    "DARIA_PLEDGE_GENERATOR_DISABLED": {
-      "description": "The PDF Pledge generator only works for DCAF for now",
-      "value": "true"
-    },
     "RAILS_LOG_TO_STDOUT": {
       "description": "set to true",
       "value": "true"

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -32,7 +32,7 @@
     </div>
 
     <div class="hide" data-step="3" data-title="<%= t('patient.pledge.step_three.title') %>">
-      <% unless ENV['DARIA_PLEDGE_GENERATOR_DISABLED'] %>
+      <% if current_tenant.pledge_generation_config.present? %>
         <p class="row"><%= t('patient.pledge.step_three.generated', fund: current_tenant.name) %></p>
         <p class="row">
           <%= t('patient.pledge.step_three.downloads') %> <%= fax_service %>

--- a/test/system/event_log_interaction_test.rb
+++ b/test/system/event_log_interaction_test.rb
@@ -62,11 +62,11 @@ class EventLogInteractionTest < ApplicationSystemTestCase
       find('#pledge-next').click
       wait_for_no_element 'Review this preview of your pledge'
 
-      assert has_text? 'Awesome, you generated a DCAF'
+      assert has_text? 'Submit and send your pledge'
       check 'I sent the pledge'
       wait_for_ajax
       find('#pledge-next').click
-      wait_for_no_element 'Awesome, you generated a DCAF'
+      wait_for_no_element 'Submit and send your pledge'
 
       visit authenticated_root_path
       within :css, '#activity_log_content' do

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -104,4 +104,24 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       refute has_link? 'Fulfillment'
     end
   end
+
+  describe 'displaying pledge generator input' do
+    it 'should obey the model setting' do
+      find('#submit-pledge-button').click
+      wait_for_element 'Patient name'
+      assert has_text? 'Confirm the following information is correct'
+      find('#pledge-next').click
+      wait_for_ajax
+      assert has_content? 'Please generate your pledge form and click next.'
+
+      ActsAsTenant.current_tenant.update pledge_generation_config: 'default'
+      visit edit_patient_path @patient
+      find('#submit-pledge-button').click
+      wait_for_element 'Patient name'
+      assert has_text? 'Confirm the following information is correct'
+      find('#pledge-next').click
+      wait_for_ajax
+      assert has_content? 'Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the fax to the clinic.'
+    end
+  end
 end

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -3,6 +3,7 @@ require 'application_system_test_case'
 # Tests around plege submission behavior
 class SubmitPledgeTest < ApplicationSystemTestCase
   before do
+    ActsAsTenant.current_tenant.update pledge_generation_config: 'default'
     @user = create :user, role: :data_volunteer
     @clinic = create :clinic
     @patient = create :patient, clinic: @clinic,
@@ -112,16 +113,16 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_text? 'Confirm the following information is correct'
       find('#pledge-next').click
       wait_for_ajax
-      assert has_content? 'Please generate your pledge form and click next.'
+      assert has_content? 'Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the fax to the clinic.'
 
-      ActsAsTenant.current_tenant.update pledge_generation_config: 'default'
+      ActsAsTenant.current_tenant.update pledge_generation_config: nil
       visit edit_patient_path @patient
       find('#submit-pledge-button').click
       wait_for_element 'Patient name'
       assert has_text? 'Confirm the following information is correct'
       find('#pledge-next').click
       wait_for_ajax
-      assert has_content? 'Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the fax to the clinic.'
+      assert has_content? 'Please generate your pledge form and click next.'
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We store this on the model now, so we should use it, eh?

(Note that 'default' in the test is a deliberate choice, coming soon!)

This pull request makes the following changes:
* use model attribute instead of env var for displaying pledge generator

no view changes

It relates to the following issue #s: 
* Fixes #2439

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
