### PR TITLE
add practical supports to db seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -168,6 +168,11 @@ fund2 = Fund.create! name: 'CatFund',
 
       if i.even?
         patient.notes.create! full_text: additional_note_text
+        patient.practical_supports.create! support_type: 'Advice', source: 'Counselor'
+      end
+
+      if i % 3 == 0
+        patient.practical_supports.create! support_type: 'Car rides', source: 'Neighbor'
       end
 
       # Add select patients to call list for user


### PR DESCRIPTION
This pull request makes the following changes:
* Adds a couple practical supports to patients created while seeding the test database for improved dev experience.

It relates to the following issue #s: 
* Fixes #[2193 ](https://github.com/DARIAEngineering/dcaf_case_management/issues/2193)

To test:
* Run `docker-compose run --rm web rails db:create db:migrate db:seed` to seed/re-seed your db.
* Then open a Rails console and run `PracticalSupport.all`. You should get back a non-empty array of practical supports.
