### PR TITLE
Explicitly declare form methods on patient edit page because for some reason they're trying to POST sometimes

### DIFF
--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -12,6 +12,7 @@
   <%= bootstrap_form_with model: patient,
                           html: { id: 'abortion-information-form-1' },
                           remote: true,
+                          method: 'patch',
                           class: 'edit_patient' do |f| %>
     <div class="row info-form">
       <div class="col info-form-left">

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -13,6 +13,7 @@
 
   <%= bootstrap_form_with model: patient,
                           html: { id: 'pledge_fulfillment_form' },
+                          method: 'patch',
                           remote: true do |f| %>
     <div class="row">
       <div class="col">

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -2,6 +2,7 @@
   <%= bootstrap_form_with model: patient,
                          html: { id: 'patient_dashboard_form' },
                          remote: true,
+                         method: 'patch',
                          class: 'edit_patient' do |f| %>
     <div class="row">
 

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -4,6 +4,7 @@
   <%= bootstrap_form_with model: patient,
                           html: { id: 'patient_information_form' },
                           remote: true,
+                          method: 'patch',
                           class: 'edit_patient' do |f| %>
     <div class="row">
       <div class="col info-form-left">

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -42,7 +42,11 @@
       <p class="row"><strong><%= t('patient.pledge.step_three.completed') %></strong></p>
 
       <div class="row">
-        <%= bootstrap_form_with model: patient, html: {class: 'edit_patient', id: 'pledge-create-modal-form'}, remote: true do |f| %>
+        <%= bootstrap_form_with model: patient,
+                                html: {class: 'edit_patient',
+                                id: 'pledge-create-modal-form'},
+                                method: 'patch',
+                                remote: true do |f| %>
           <%= f.check_box :pledge_sent, label: t('patient.pledge.step_three.sent_checkbox') %>
         <% end %>
       </div>
@@ -68,6 +72,7 @@
       <%= bootstrap_form_with model: @patient,
                               html: { id: 'cancel-pledge-form' },
                               remote: true,
+                              method: 'patch',
                               class: 'edit_patient' do |f| %>
         <%= f.hidden_field :pledge_sent, value: false %>
         <%= f.submit t('common.yes'), class: "btn btn-success js-btn-step float-right", id: 'cancel-pledge-submit'%>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

In certain cases, when I load a patient edit page I'm getting forms that POST to the patient route rather than PATCH (which causes failures). This is because method is set to a CSRF token, for some reason I cannot fathom - maybe a rails_bootstrap_form behavior or something? See:

![image](https://user-images.githubusercontent.com/3866868/144755427-128e39b3-fab8-4c70-aa2c-c01ec36c81af.png)

Here's what it should look like (note the proper hidden field `_method` value):

![image](https://user-images.githubusercontent.com/3866868/144755457-78bea929-5e8e-48d9-bfac-29130b601515.png)

I have no idea why this is doing this, but explicitly declaring method seems to resolve for me in firefox.

This pull request makes the following changes:
* explicitly declare method=patch on patient edit page forms

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
