### PR TITLE
redirect an env var is set, to point legacy systems to new urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,20 @@ class ApplicationController < ActionController::Base
   if Rails.env.development?
     before_action :confirm_tenant_set_development
   end
+  before_action :redirect_if_legacy
   before_action :confirm_tenant_set
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :prevent_caching_via_headers
   before_action :set_locale
   before_action :set_sentry_context
   before_action :set_paper_trail_whodunnit
+
+  # redirect to new system if config is set
+  def redirect_if_legacy
+    if ENV['REDIRECT_DESTINATION'].present?
+      redirect_to ENV['REDIRECT_DESTINATION']
+    end
+  end
 
   # Don't let any requests through without confirming a tenant is set.
   def confirm_tenant_set


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Hopefully one of the last bits of multitenant - this redirects to new urls if an env var is set. Plan is to temporarily keep the urls up for a month or two while people get used to the new one.

To test, `export REDIRECT_DESTINATION='https://www.google.com' and then try loading the app, and see yourself redirected.

This pull request makes the following changes:
* add REDIRECT_DESTINATION env var that will send people to new domains when they're set up

no view changes

It relates to the following issue #s: 
* Bumps #1817

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
