### PR TITLE
display line name rather than line, since this is a model now

### DIFF
--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -10,7 +10,7 @@ module Exportable
     "Archived?" => :archived?,
     "Has Alt Contact?" => :has_alt_contact,
     "Voicemail Preference" => :voicemail_preference,
-    "Line" => :line,
+    "Line" => :get_line,
     "Language" => :preferred_language,
     "Age" => :age_range,
     "State" => :state,
@@ -69,6 +69,10 @@ module Exportable
 
     # TODO test to confirm that specific blacklisted fields aren't being exported
   }.freeze
+
+  def get_line
+    line.try :name
+  end
 
   def fulfilled
     fulfillment.try :fulfilled

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -177,8 +177,8 @@ module Exportable
     practical_supports.map { |ps| "#{ps.source} - #{ps.support_type} - #{ps.confirmed? ? 'Confirmed' : 'Unconfirmed'}" }.join('; ')
   end
 
-  PATIENT_RELATIONS = [:clinic, :fulfillment, :external_pledges, :calls, :practical_supports, :notes]
-  ARCHIVED_PATIENT_RELATIONS = [:clinic, :fulfillment, :external_pledges, :calls, :practical_supports]
+  PATIENT_RELATIONS = [:line, :clinic, :fulfillment, :external_pledges, :calls, :practical_supports, :notes]
+  ARCHIVED_PATIENT_RELATIONS = [:line, :clinic, :fulfillment, :external_pledges, :calls, :practical_supports]
 
   class_methods do
     def csv_header


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Lines is a model now; we didn't fix it in the export though, so it's showing up as the obj. This fixes that and displays the name instead.

This pull request makes the following changes:
* treat Line like a model rather than  a db field in export, so it properly displays

no view change

It relates to the following issue #s: 
* Fixes #2458 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
