### PR TITLE
Fix patient archiving - swap ref on the the fulfillment obj like we do the others

### DIFF
--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -102,16 +102,16 @@ class ArchivedPatient < ApplicationRecord
       archived_patient.save!
     end
 
-    patient.fulfillment.update can_fulfill: archived_patient
+    patient.fulfillment.update! can_fulfill: archived_patient
 
     patient.calls.each do |call|
-      call.update can_call: archived_patient
+      call.update! can_call: archived_patient
     end
     patient.external_pledges.each do |ext_pledge|
-      ext_pledge.update can_pledge: archived_patient
+      ext_pledge.update! can_pledge: archived_patient
     end
     patient.practical_supports.each do |support|
-      support.update can_support: archived_patient
+      support.update! can_support: archived_patient
     end
 
     archived_patient.save!

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -95,13 +95,14 @@ class ArchivedPatient < ApplicationRecord
 
     )
 
-    archived_patient.build_fulfillment(patient.fulfillment.attributes.except('id')).save
     archived_patient.clinic_id = patient.clinic_id if patient.clinic_id
     archived_patient.line_id = patient.line_id
 
     PaperTrail.request(whodunnit: patient.created_by_id) do
       archived_patient.save!
     end
+
+    patient.fulfillment.update can_fulfill: archived_patient
 
     patient.calls.each do |call|
       call.update can_call: archived_patient

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -82,29 +82,36 @@ class ArchivedPatientTest < ActiveSupport::TestCase
     end
 
     it 'should have matching subobject data Patient and Archive Patient' do
+      # and that includes ids
+      call_ids = @patient.calls.pluck('id')
+      ext_pledge_ids = @patient.external_pledges.pluck('id')
+      psup_ids = @patient.practical_supports.pluck('id')
+      fulfillment_id = @patient.fulfillment.id
+      @archived_patient.reload
+      @patient.reload
+
       assert_equal 2, @archived_patient.calls.count
+      assert_equal call_ids, @archived_patient.calls.pluck('id')
+      assert_equal 0, @patient.calls.count
       assert_equal @user, @archived_patient.calls.first.created_by
       assert_equal @user2, @archived_patient.calls.last.created_by
 
+      assert_equal fulfillment_id, @archived_patient.fulfillment.id
       assert_equal @archived_patient.fulfillment.date_of_check,
-                   @patient.fulfillment.date_of_check
+                   3.days.ago.to_date
+      assert_nil @patient.fulfillment
 
       assert_equal 2, @archived_patient.external_pledges.count
+      assert_equal ext_pledge_ids, @archived_patient.external_pledges.pluck('id')
+      assert_equal 0, @patient.external_pledges.count
       assert_equal @user, @archived_patient.external_pledges.first.created_by
       assert_equal @user2, @archived_patient.external_pledges.last.created_by
 
       assert_equal 2, @archived_patient.practical_supports.count
+      assert_equal psup_ids, @archived_patient.practical_supports.pluck('id')
+      assert_equal 0, @patient.practical_supports.count
       assert_equal @user, @archived_patient.practical_supports.first.created_by
       assert_equal @user2, @archived_patient.practical_supports.last.created_by
-    end
-
-    it 'should have distinct subobjects for Patient and Archive Patient' do
-      assert_equal 0, @patient.calls.count
-      assert_equal 0, @patient.external_pledges.count
-      assert_equal 0, @patient.practical_supports.count
-
-      assert_not_equal @archived_patient.fulfillment.id,
-                       @patient.fulfillment.id
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

a little embarrassing to not see this before, but that's what working too much gets you. This takes the object-ref-swap approach we have in here now and applies it to fulfillment as well. It is _super_ weird that tests didn't catch this.

to try it out from a fresh seed:

```
ActsAsTenant.current_tenant = Fund.first
Patient.count # 39
ArchivedPatient.count # 0
ArchivedPatient.archive_eligible_patients!
Patient.count # 37
ArchivedPatient.count # 2
```

This pull request makes the following changes:
* copy over fulfillment obj when archiving

no view changes

It relates to the following issue #s: 
* Fixes #2423

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
