### PR TITLE
re-add codecov step to ci

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -91,6 +91,9 @@ jobs:
           name: code-coverage-report
           path: coverage
 
+      - name: Upload result to CodeCov
+        uses: codecov/codecov-action@v2
+
       - name: Store test artifacts
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We stopped codecoving when we moved to github actions in #2361 - this (hopefully) restores it.

This pull request makes the following changes:
* add codecov step to CI

no views

It relates to the following issue #s: 
* Fixes #2401 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
