### PR TITLE
remove refs to DCAF in seedfile

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,20 +29,20 @@ additional_note_text = 'Additional note ' * 10
 password = 'AbortionsAreAHumanRight1'
 
 # Create a few test funds
-fund1 = Fund.create! name: 'DCAF',
-                     domain: 'dcabortionfund.org',
+fund1 = Fund.create! name: 'SBF',
+                     domain: 'petfinder.com',
                      subdomain: 'sandbox',
-                     full_name: 'DC Abortion Fund',
-                     site_domain: 'www.dcabortionfund.org',
+                     full_name: 'Sand Box Fund',
+                     site_domain: 'www.petfinder.com',
                      phone: '202-452-7464'
 
 
 
 fund2 = Fund.create! name: 'CatFund',
-                     domain: 'catfund.org',
+                     domain: 'petfinder.com',
                      subdomain: 'catbox',
                      full_name: 'Cat Fund',
-                     site_domain: 'www.catfund.org',
+                     site_domain: 'www.petfinder.com',
                      phone: '(281) 330-8004'
 
 [fund1, fund2].each do |fund|
@@ -60,7 +60,7 @@ fund2 = Fund.create! name: 'CatFund',
     user2 = User.create! name: 'testuser2', email: 'test2@example.com',
                          password: password, password_confirmation: password,
                          role: :cm
-    User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
+    User.create! name: 'testuser3', email: 'test3@example.com',
                  password: password, password_confirmation: password,
                  role: :cm
 
@@ -149,8 +149,8 @@ fund2 = Fund.create! name: 'CatFund',
           patient.calls.create! status: :left_voicemail
         end
       when 5
-        # Resolved without DCAF
-        patient.update! name: 'Resolved without DCAF - 5',
+        # Resolved without Fund
+        patient.update! name: 'Resolved without assistance - 5',
                         resolved_without_fund: true
       end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

couple of changes to make sandbox generic

This pull request makes the following changes:
* Remove references to DCAF in seedfile

no view changes

It relates to the following issue #s: 
* bumps #1817 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
