### PR TITLE
Prepend bundle exec to ruby-audit run by CI

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Brakeman
         run: brakeman --exit-on-warn .
       - name: ruby-audit
-        run: ruby-audit check
+        run: bundle exec ruby-audit check
       - name: bundle-audit
         run: bundle-audit update; bundle-audit check
       - name: Zeitwerk


### PR DESCRIPTION
CI is [failing](https://github.com/DARIAEngineering/dcaf_case_management/runs/4771259669?check_suite_focus=true) on main, and this should fix why.