### PR TITLE
lonely operator against name, when created_by is null

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -14,7 +14,7 @@ module NotesHelper
     return nil if note.try(:full_text).blank?
     info = content_tag :p do
       content_tag(:strong) do
-        t('note.most_recent', by: "#{note.created_by.name}", at: "#{note.created_at.display_timestamp}")
+        t('note.most_recent', by: "#{note.created_by&.name}", at: "#{note.created_at.display_timestamp}")
       end
     end
     text = content_tag(:p) { note.full_text[0..400] }


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

hotfix a bug a fund is experiencing after transfer. this is like the only place where we aren't doing this safely I think.

This pull request makes the following changes:
* nil-check note created by name

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
