### PR TITLE
remove codecov references because I am mad at it

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -91,9 +91,6 @@ jobs:
           name: code-coverage-report
           path: coverage
 
-      - name: Upload result to CodeCov
-        uses: codecov/codecov-action@v2
-
       - name: Store test artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # DARIA (DCAF Case Manager)
 ![GithubActions Workflow](https://github.com/DARIAEngineering/dcaf_case_management/actions/workflows/test_dev_env.yml/badge.svg)
-[![codecov](https://codecov.io/gh/DARIAEngineering/dcaf_case_management/branch/main/graph/badge.svg?token=vnoVK0meeZ)](https://codecov.io/gh/DARIAEngineering/dcaf_case_management)
-
 
 [A deployed demo version of what's in the main branch is at: https://sandbox.dariaservices.com/](https://sandbox.dariaservices.com/)  
 User: test@example.com, Password: AbortionsAreAHumanRight1


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

no more codecov, this is too annoying to fix for what we get out of it

This pull request makes the following changes:
* remove codecov refs

no view changes 

It relates to the following issue #s: 
* Fixes #2401 (by not fixing it)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
