### PR TITLE
add deployment/ci explanation to docs

### DIFF
--- a/docs/TECH_STACK_INTRO.md
+++ b/docs/TECH_STACK_INTRO.md
@@ -10,7 +10,7 @@ If you're new to programming or Rails, RailsBridge is a non-profit that has writ
 ### PostgreSQL
 PostgreSQL is a relational database we use to store patient information. Data is stored in tables.
 
-You'll primarily interact with the database via [ActiveRecord](http://guides.rubyonrails.org/active_record_basics.html). Most 
+You'll primarily interact with the database via [ActiveRecord](http://guides.rubyonrails.org/active_record_basics.html). No need to write raw sql -- ActiveRecord handles the grimy stuff for us.
 
 ---
 
@@ -26,6 +26,14 @@ We love tests! All the tests can be found in the test directory, and it's a grea
 * [Capybara](http://teamcapybara.github.io/capybara/) is a Ruby integration testing library that can uses browser to fill in forms, click buttons, and generally interact with the app, and then verifies that things worked as we expected!
 * Here are [the Capybara docs](http://www.rubydoc.info/github/teamcapybara/capybara/master)
 * Generally we have CircleCI run these for us, so you don't need to worry about setting up Capybara unless you need to write system tests.
+
+---
+
+### Continuous Integration and Deployment
+
+Our continuous integration system is Github Actions. This runs tests and security scanners to make sure everything is in good shape (called a 'build'), and reports the results to a pull request, so we can see if it passes muster or not.
+
+When a build succeeds on the `main` branch, it deploys to the staging environment so we can try it out. We have this configured in Heroku so that it watches Github for changes, and deploys automatically. (Administrators handle deployment to production.)
 
 ---
 

--- a/docs/administering/DEPLOYMENT.md
+++ b/docs/administering/DEPLOYMENT.md
@@ -1,0 +1,8 @@
+# Deploying to production
+
+We have a heroku pipeline configured that sets up a staging and production environment. Deploying to staging is automatic, and deploying to production requires a manual button press in the Heroku dashboard.
+
+Staging is deployed when a build on `main` succeeds automagically. This is configured in Heroku via `Enable Automatic Deploys` and hopefully we never need to touch it.
+
+To deploy production, you'll need to log in to Heroku, open up the pipeline, and then hit the Promote to Production button. When you do this, you should [notify the DARIA updates listserv](https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/administering/ONBOARDING_A_NEW_FUND.md).
+


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Add a CI/deployment process explanation to the docs

This pull request makes the following changes:
* add a CI/deployment process explanation to the docs

no views

It relates to the following issue #s: 
* Fixes #2363

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
