### PR TITLE
Update nokogiri because of CVE-2021-30560

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '3.0.2'
 gem 'rails', '~> 6.1.4'
 gem 'puma', '~> 5.4' # roar
 gem 'sdoc', '~> 2.3.0', group: :doc
-gem 'nokogiri', '>= 1.11.1'
+gem 'nokogiri', '>= 1.13.2'
 gem 'tzinfo-data', require: false
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rexml' # not a ruby default in 3, but a requirement of bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       minitest (> 1.2.0)
       rails (>= 2.3.3)
     mini_mime (1.1.2)
-    mini_portile2 (2.7.1)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     minitest-optional_retry (0.0.2)
       minitest (~> 5.0)
@@ -227,8 +227,8 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
-    nokogiri (1.13.1)
-      mini_portile2 (~> 2.7.0)
+    nokogiri (1.13.2)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -469,7 +469,7 @@ DEPENDENCIES
   minitest-optional_retry
   minitest-spec-rails
   minitest-stub-const
-  nokogiri (>= 1.11.1)
+  nokogiri (>= 1.13.2)
   omniauth-google-oauth2 (~> 1.0.0)
   omniauth-rails_csrf_protection (~> 1.0)
   paper_trail (~> 12.0)


### PR DESCRIPTION
Build on main is currently red. This is why:
```
ruby-advisory-db:
  advisories:	545 advisories
  last updated:	2022-02-21 11:49:31 -0800
  commit:	31928e51e3886c99ee59ccbedc54072c7a96470f
Name: nokogiri
Version: 1.13.1
CVE: CVE-2021-30560
GHSA: GHSA-fq42-c5rg-92c2
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-fq42-c5rg-92c2
Title: Update packaged libxml2 (2.9.12 → 2.9.13) and libxslt (1.1.34 → 1.1.35)
Solution: upgrade to >= 1.13.2
```

Fix the build by upgrading nokogiri.