### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node": ">=16.13.0",
     "npm": ">=6.14.13"
   },
+  "license": "MIT",
   "resolutions": {
     "dot-prop": "^6.0.0",
     "eslint-utils": "^3.0.0",


### PR DESCRIPTION
We get are getting this warning during the docker build.

```
Step 13/22 : RUN yarn set version berry
 ---> Running in 560770d3858a
warning package.json: No license field
```

So yeah...add the license field to mitigate this.

Docs: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license