### PR TITLE
add matrix gem, which is required for builds and no longer in ruby stdlib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'tzinfo-data', require: false
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rexml' # not a ruby default in 3, but a requirement of bootsnap
 gem 'net-smtp', require: false # For compat reasons, can remove after rails 7
+gem 'matrix' # for compat reasons, required in builds
 
 # Asset pipeline
 gem 'webpacker', '~> 5.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,6 +477,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.8)
   loofah (>= 2.3.1)
+  matrix
   mini_backtrace
   minitest-optional_retry
   minitest-spec-rails


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Heroku builds are failing with:

```
/tmp/codon/tmp/buildpacks/50d5eddf222a9b7326028041d4e6509f915ccf2c/lib/language_pack/helpers/rake_runner.rb:100:in `load_rake_tasks!': Could not detect rake tasks (LanguagePack::Helpers::RakeRunner::CannotLoadRakefileError)
ensure you can run `$ bundle exec rake -P` against your app
and using the production group of your Gemfile.
rake aborted!
LoadError: cannot load such file -- matrix
```

turns out `matrix` got separated from the ruby stdlib but our heroku builds depend on it still, so re-adding it to our gemfile explicitly.

see https://github.com/gdelugre/origami/issues/81 for example

This pull request makes the following changes:
* add matrix gem to gemfile

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
