### PR TITLE
add net-pop to gemfile, since that's also out of ruby stdlib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,12 @@ gem 'nokogiri', '>= 1.13.2'
 gem 'tzinfo-data', require: false
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rexml' # not a ruby default in 3, but a requirement of bootsnap
-gem 'net-smtp', require: false # For compat reasons, can remove after rails 7
 gem 'matrix' # for compat reasons, required in builds
-gem 'net-pop' # for compat reasons, required in builds
+
+# Temporary compat gems until a new mail gem is released/rails 7 rolls out - see https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp
+gem 'net-pop', require: false # for compat reasons, required in builds
+gem 'net-imap', require: false # for compat reasons, required in builds
+gem 'net-smtp', require: false # for compat reasons, required in builds
 
 # Asset pipeline
 gem 'webpacker', '~> 5.4'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rexml' # not a ruby default in 3, but a requirement of bootsnap
 gem 'net-smtp', require: false # For compat reasons, can remove after rails 7
 gem 'matrix' # for compat reasons, required in builds
+gem 'net-pop' # for compat reasons, required in builds
 
 # Asset pipeline
 gem 'webpacker', '~> 5.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,10 @@ GEM
     msgpack (1.5.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -482,6 +486,7 @@ DEPENDENCIES
   minitest-optional_retry
   minitest-spec-rails
   minitest-stub-const
+  net-pop
   net-smtp
   nokogiri (>= 1.13.2)
   omniauth-google-oauth2 (~> 1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,10 @@ GEM
     msgpack (1.5.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
     net-pop (0.1.1)
       digest
       net-protocol
@@ -420,6 +424,7 @@ GEM
       sqreen-backport (~> 0.1.0)
     state_geo_tools (1.0.0)
     strong_password (0.0.10)
+    strscan (3.0.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
@@ -486,6 +491,7 @@ DEPENDENCIES
   minitest-optional_retry
   minitest-spec-rails
   minitest-stub-const
+  net-imap
   net-pop
   net-smtp
   nokogiri (>= 1.13.2)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

another one of these - heroku build is failing to start based on this thing's absence

This pull request makes the following changes:
* add net-pop gem to gemfile

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
