### PR TITLE
Bumps nokogiri past vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '3.1.1'
 gem 'rails', '~> 6.1.4'
 gem 'puma', '~> 5.4' # roar
 gem 'sdoc', '~> 2.3.0', group: :doc
-gem 'nokogiri', '>= 1.13.2'
+gem 'nokogiri', '>= 1.13.4'
 gem 'tzinfo-data', require: false
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rexml' # not a ruby default in 3, but a requirement of bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,10 +244,10 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.3)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
@@ -494,7 +494,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  nokogiri (>= 1.13.2)
+  nokogiri (>= 1.13.4)
   omniauth-google-oauth2 (~> 1.0.0)
   omniauth-rails_csrf_protection (~> 1.0)
   paper_trail (~> 12.0)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

bundle-audit is mad about nokogiri! I bumped to the suggested version and everything looks to be loading clean for me.

This pull request makes the following changes:
* nokogiri >= 1.13.4

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
