### PR TITLE
ignore known vulns while we wait for heroku to patch ruby

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Brakeman
         run: brakeman --exit-on-warn .
       - name: ruby-audit
-        run: bundle exec ruby-audit check
+        run: bundle exec ruby-audit check -i CVE-2022-28739 CVE-2022-28738 # remove ignores after ruby 3.1.2
       - name: bundle-audit
         run: bundle-audit update; bundle-audit check
       - name: Zeitwerk


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Ruby 3.1.1 has some not-really-scary vulnerabilities that are failing builds, and we're waiting for 3.1.2 to get up to speed on heroku for right now, so ignoring these for now. Just a build change. 

This pull request makes the following changes:
* ignore a specific pair of vulns for a bit

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
