### PR TITLE
split js into webpacker chunks

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <%= stylesheet_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag :application, media: 'all' %>
 
-    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
+    <%= javascript_packs_with_chunks_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag :application %>
 
     <%= content_for :render_async %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -16,5 +16,7 @@ config.resolve.alias = {
   jquery: "jquery/src/jquery",
 }
 
+environment.splitChunks();
+
 // export the updated config
 module.exports = environment;


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This takes advantage of webpack's chunking system to reduce the size of our builds. The short version is that it goes from a single import to this:

![image](https://user-images.githubusercontent.com/3866868/163753489-5b7984b6-ae7b-4085-985f-da767ecf158d.png)

which utilizes code splitting as described here: https://webpack.js.org/guides/code-splitting/ (warning: your eyes are going to glaze over)

I think there's possibly some further optimization we could do here if we were committed to getting build times REALLY low, but I don't think we need to fret about that right now, so let's take the free basket.

This pull request makes the following changes:
* splits our js into chunks using webpacker's nice clean system

no view changes (I checked the main call list and did a few interactions and we're cool)
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
