### PR TITLE
remove js-routes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'state_geo_tools' # state list
 
 # Stuff that we're targeting removal of
 gem 'figaro' # we handle secrets differently now
-gem 'js-routes', '1.4.9' # Not sure if this is used anymore
 
 # Stuff we're hardsetting because of security concerns
 gem 'loofah', '>= 2.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,9 +180,6 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    js-routes (1.4.9)
-      railties (>= 4)
-      sprockets-rails
     jwt (2.3.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -481,7 +478,6 @@ DEPENDENCIES
   i18n-tasks (~> 1.0.0)
   jquery-rails (~> 4.4.0)
   jquery-ui-rails
-  js-routes (= 1.4.9)
   kaminari (~> 1.2)
   launchy
   listen (>= 3.0.5, < 3.8)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require popper
 //= require jquery_ujs
 //= require jquery-ui
-//= require js-routes
 //= require bootstrap-sprockets
 //= require_tree .
 //= require_tree ../../../vendor/assets/javascripts/.

--- a/app/views/calls/create.js.erb
+++ b/app/views/calls/create.js.erb
@@ -1,4 +1,4 @@
-var isOnEditPage = location.pathname.indexOf(substring) !== 1;
+var isOnEditPage = location.pathname.indexOf('edit') !== 1;
 var isOnDashboard = location.pathname === '/';
 
 if (isOnEditPage) {

--- a/app/views/calls/create.js.erb
+++ b/app/views/calls/create.js.erb
@@ -10,7 +10,7 @@ if (URL.indexOf(substring) !== 1) {
     });
 }
 
-if (location.pathname == Routes.authenticated_root_path) {
+if (location.pathname === '/') {
   $('#call_list').html(
     '<%= escape_javascript(render partial: "dashboards/table_content",
                                   locals: { title: t("dashboard.partial_titles.call_list"),

--- a/app/views/calls/create.js.erb
+++ b/app/views/calls/create.js.erb
@@ -1,7 +1,7 @@
-var URL = location.pathname,
-    substring = "edit";
+var isOnEditPage = location.pathname.indexOf(substring) !== 1;
+var isOnDashboard = location.pathname === '/';
 
-if (URL.indexOf(substring) !== 1) {
+if (isOnEditPage) {
   $("#call_log").html("<%= escape_javascript(render partial: 'patients/call_log') %>")
     .promise().done(function() {
       $(".new-call").modal('hide')
@@ -10,7 +10,7 @@ if (URL.indexOf(substring) !== 1) {
     });
 }
 
-if (location.pathname === '/') {
+if (isOnDashboard) {
   $('#call_list').html(
     '<%= escape_javascript(render partial: "dashboards/table_content",
                                   locals: { title: t("dashboard.partial_titles.call_list"),


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We were only really using js-routes in one place, and it was to set behavior after logging calls. It added a `Route` top level obj to the js namespace. We don't _really_ need it since this is the only place we do conditional stuff based on page, as far as I know.

You can double-check this work by `git grep "Route"`.

big s/o to past us for heavy system tests that made figuring this out much easier than I thought it was going tobe!

This pull request makes the following changes:
* refactor to not need js-routes gem
* remove js-routes gem

no view changes
no issues, but see https://github.com/DARIAEngineering/dcaf_case_management/pull/2392

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
