### PR TITLE
Add Prefer not to answer, zeroes to dropdowns

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -111,7 +111,9 @@ module PatientsHelper
   end
 
   def household_size_options
-    (1..10).map { |i| i }.unshift [nil, nil]
+    (1..10).map { |i| i }
+           .unshift([t('common.prefer_not_to_answer'), -1])
+           .unshift([nil, nil])
   end
 
   def clinic_options

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -111,7 +111,7 @@ module PatientsHelper
   end
 
   def household_size_options
-    (1..10).map { |i| i }
+    (0..10).map { |i| i }
            .unshift([t('common.prefer_not_to_answer'), -1])
            .unshift([nil, nil])
   end

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -18,7 +18,8 @@ module PatientsHelper
       [ t('patient.helper.race.native_hawaiian_pacific_islander'), 'Native Hawaiian or Pacific Islander'],
       [ t('patient.helper.race.native_american'),                  'Native American'],
       [ t('patient.helper.race.mixed_race_ethnicity'),             'Mixed Race/Ethnicity'],
-      [ t('patient.helper.race.other'),                            'Other' ]
+      [ t('patient.helper.race.other'),                            'Other' ],
+      [ t('common.prefer_not_to_answer'),                          'Prefer not to answer']
     ]
   end
 
@@ -59,7 +60,9 @@ module PatientsHelper
       [ t('patient.helper.referred_by.prev_patient'),                 'Previous patient' ],
       [ t('patient.helper.referred_by.school'),                       'School' ],
       [ t('patient.helper.referred_by.sexual_assault_crisis_org'),    'Sexual assault crisis org' ],
-      [ t('patient.helper.referred_by.youth'),                        'Youth outreach' ], ]
+      [ t('patient.helper.referred_by.youth'),                        'Youth outreach' ],
+      [ t('common.prefer_not_to_answer'),                             'Prefer not to answer']
+    ]
     full_set = standard_options + Config.find_or_create_by(config_key: 'referred_by').options
 
     options_plus_current(full_set, current_value)
@@ -73,6 +76,7 @@ module PatientsHelper
       [ t('patient.helper.employment.unemployed'), 'Unemployed'],
       [ t('patient.helper.employment.odd_jobs'), 'Odd jobs'],
       [ t('patient.helper.employment.student'), 'Student'],
+      [ t('common.prefer_not_to_answer'), 'Prefer not to answer']
     ]
   end
 
@@ -80,6 +84,7 @@ module PatientsHelper
     standard_options = [
       [ t('patient.helper.insurance.none'), 'No insurance' ],
       [ t('patient.helper.insurance.unknown'), 'Don\'t know' ],
+      [ t('common.prefer_not_to_answer'), 'Prefer not to answer']
       [ t('patient.helper.insurance.other'), 'Other (add to notes)' ],
     ]
     full_set = [nil] + Config.find_or_create_by(config_key: 'insurance').options + standard_options
@@ -100,7 +105,8 @@ module PatientsHelper
      [ t('patient.helper.income.45_to_50'), '$45,000-49,999'],
      [ t('patient.helper.income.50_to_60'), '$50,000-59,999'],
      [ t('patient.helper.income.60_to_75'), '$60,000-74,999'],
-     [ t('patient.helper.income.75_plus'), '$75,000 or more']
+     [ t('patient.helper.income.75_plus'), '$75,000 or more'],
+     [ t('common.prefer_not_to_answer'), 'Prefer not to answer']
     ]
   end
 

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -84,7 +84,7 @@ module PatientsHelper
     standard_options = [
       [ t('patient.helper.insurance.none'), 'No insurance' ],
       [ t('patient.helper.insurance.unknown'), 'Don\'t know' ],
-      [ t('common.prefer_not_to_answer'), 'Prefer not to answer']
+      [ t('common.prefer_not_to_answer'), 'Prefer not to answer'],
       [ t('patient.helper.insurance.other'), 'Other (add to notes)' ],
     ]
     full_set = [nil] + Config.find_or_create_by(config_key: 'insurance').options + standard_options

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -88,7 +88,7 @@ module Exportable
 
   def get_household_size_children
     if is_a?(Patient)
-      household_size_children
+      household_size_children == -1 ? 'Prefer not to answer' : household_size_children
     else
       nil
     end
@@ -96,7 +96,7 @@ module Exportable
 
   def get_household_size_adults
     if is_a?(Patient)
-      household_size_adults
+      household_size_adults == -1 ? 'Prefer not to answer' : household_size_adults
     else
       nil
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,7 @@ en:
     notes: Notes
     patient: Patient
     phone: Phone
+    prefer_not_to_answer: Prefer not to answer
     save: Save
     search: Search
     status: Status
@@ -152,7 +153,6 @@ en:
     weeks_days: "%{weeks} weeks, %{days} days"
     weeks_days_short: "%{weeks}w %{days}d"
     'yes': 'Yes'
-    prefer_not_to_answer: Prefer not to answer
   configs:
     config:
       current_options: 'Current options are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,7 @@ en:
     weeks_days: "%{weeks} weeks, %{days} days"
     weeks_days_short: "%{weeks}w %{days}d"
     'yes': 'Yes'
+    prefer_not_to_answer: Prefer not to answer
   configs:
     config:
       current_options: 'Current options are:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -152,6 +152,7 @@ es:
     weeks_days: "%{weeks} semanas, %{days} días"
     weeks_days_short: "%{weeks}s %{days}d"
     'yes': Sí
+    prefer_not_to_answer: Prefiere no contestar
   configs:
     config:
       current_options: 'Las opciones actuales son:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -145,6 +145,7 @@ es:
     notes: Notas
     patient: Patiente
     phone: Teléfono
+    prefer_not_to_answer: Prefiere no contestar
     save: Guardar
     search: Buscar
     status: Estatus
@@ -152,7 +153,6 @@ es:
     weeks_days: "%{weeks} semanas, %{days} días"
     weeks_days_short: "%{weeks}s %{days}d"
     'yes': Sí
-    prefer_not_to_answer: Prefiere no contestar
   configs:
     config:
       current_options: 'Las opciones actuales son:'

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -34,6 +34,7 @@ class PatientsHelperTest < ActionView::TestCase
         expected_insurance_options_array = [nil, 'DC Medicaid', 'Other state Medicaid',
                                     [ 'No insurance', 'No insurance' ],
                                     [ 'Don\'t know', 'Don\'t know' ],
+                                    [ 'Prefer not to answer', 'Prefer not to answer'],
                                     [ 'Other (add to notes)', 'Other (add to notes)'] ]
         assert_same_elements insurance_options, expected_insurance_options_array
       end
@@ -42,6 +43,7 @@ class PatientsHelperTest < ActionView::TestCase
         expected_insurance_options_array = [nil, 'DC Medicaid', 'Other state Medicaid',
                                     [ 'No insurance', 'No insurance' ],
                                     [ 'Don\'t know', 'Don\'t know' ],
+                                    [ 'Prefer not to answer', 'Prefer not to answer'],
                                     [ 'Other (add to notes)', 'Other (add to notes)'],
                                     'Friendship' ]
         assert_same_elements expected_insurance_options_array,
@@ -58,6 +60,7 @@ class PatientsHelperTest < ActionView::TestCase
         expected_insurance_array = [nil,
                                    [ 'No insurance', 'No insurance' ],
                                    [ 'Don\'t know', 'Don\'t know' ],
+                                   [ 'Prefer not to answer', 'Prefer not to answer'],
                                    [ 'Other (add to notes)', 'Other (add to notes)'] ]
         assert_same_elements @options, expected_insurance_array
         assert Config.find_by(config_key: 'insurance')
@@ -241,6 +244,7 @@ class PatientsHelperTest < ActionView::TestCase
       ["School", "School"],
       ["Sexual assault crisis org", "Sexual assault crisis org"],
       ["Youth outreach", "Youth outreach"],
+      [ 'Prefer not to answer', 'Prefer not to answer'],
       "Metal band"
     ]
 

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -244,7 +244,7 @@ class PatientsHelperTest < ActionView::TestCase
       ["School", "School"],
       ["Sexual assault crisis org", "Sexual assault crisis org"],
       ["Youth outreach", "Youth outreach"],
-      [ 'Prefer not to answer', 'Prefer not to answer'],
+      ['Prefer not to answer', 'Prefer not to answer'],
       "Metal band"
     ]
 

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -58,5 +58,25 @@ class PatientTest::Exportable < PatientTest
         assert_equal @patient.preferred_language, 'Spanish'
       end
     end
+
+    describe 'household size tests' do
+      it 'should return prefer not to answer with -1' do
+        @patient.update household_size_children: -1, household_size_adults: -1
+        assert_equal 'Prefer not to answer', @patient.get_household_size_children
+        assert_equal 'Prefer not to answer', @patient.get_household_size_adults
+      end
+
+      it 'should return number otherwise' do
+        @patient.update household_size_children: 4, household_size_adults: 3
+        assert_equal 4, @patient.get_household_size_children
+        assert_equal 3, @patient.get_household_size_adults
+      end
+
+      it 'should null out for archived patients' do
+        archived = create :archived_patient
+        assert_nil archived.get_household_size_children
+        assert_nil archived.get_household_size_adults
+      end
+    end
   end
 end

--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -41,6 +41,7 @@ class UpdatingConfigsTest < ApplicationSystemTestCase
         visit edit_patient_path(@patient)
         assert has_select? 'Patient insurance', options: ['', 'Yolo', 'Goat', 'Something',
                                                           'No insurance', "Don't know",
+                                                          'Prefer not to answer',
                                                           'Other (add to notes)']
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Add `Prefer not to answer` to a set of dropdrowns.

The only rough spot here is the integer fields - I'm doing a little bit of cheating here and assigning 'no answer' a -1, and then parsing that in the exportable model. Felt nicer than switching the datatype.

This pull request makes the following changes:
* Add `prefer not to answer` to several dropdowns
* Adjust exportable module to handle prefer not to answer values of -1

![image](https://user-images.githubusercontent.com/3866868/165421541-38a0a35e-5c55-499d-9223-43ba29689da6.png)

![image](https://user-images.githubusercontent.com/3866868/165421658-e0da4c0e-8c6a-419d-a367-b2ad7578da7d.png)


It relates to the following issue #s: 
* Fixes #2503
* Fixes #2502

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
