### PR TITLE
Cleanup Patient History

### DIFF
--- a/app/lib/paper_trail_version.rb
+++ b/app/lib/paper_trail_version.rb
@@ -51,6 +51,10 @@ class PaperTrailVersion < PaperTrail::Version
     object_changes['urgent_flag']&.last == true
   end
 
+  def self.destroy_old
+    PaperTrailVersion.where("created_at < ?", 1.year.ago).destroy_all
+  end
+
   private
 
   def format_fieldchange(key, value)

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -102,6 +102,8 @@ class ArchivedPatient < ApplicationRecord
       archived_patient.save!
     end
 
+    patient.versions.destroy_all
+
     patient.fulfillment.update! can_fulfill: archived_patient
 
     patient.calls.each do |call|

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -7,6 +7,9 @@ task nightly_cleanup: :environment do
   Event.destroy_old_events
   puts "#{Time.now} -- destroyed old events"
 
+  PaperTrailVersion.destroy_old
+  puts "#{Time.now} -- destroyed old audit objects"
+
   if Time.zone.now.monday?
     # Run these events weekly
     Clinic.update_all_coordinates

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -81,6 +81,10 @@ class ArchivedPatientTest < ActiveSupport::TestCase
       assert_equal @archived_patient.clinic_id, @patient.clinic_id
     end
 
+    it 'should delete papertrail objects' do
+      assert_empty @patient.versions
+    end
+
     it 'should have matching subobject data Patient and Archive Patient' do
       # and that includes ids
       call_ids = @patient.calls.pluck('id')

--- a/test/models/paper_trail_version_test.rb
+++ b/test/models/paper_trail_version_test.rb
@@ -70,7 +70,7 @@ class PaperTrailVersionTest < ActiveSupport::TestCase
 
     it 'should delete old objects' do
       with_versioning do
-        # create a patient in the past... shoudl create a papertrail version
+        # create a patient in the past... will create a papertrail version
         Timecop.freeze(2.years.ago) do
           create :patient, name: 'Patient from long ago',
                             primary_phone: '444-555-6666'

--- a/test/models/paper_trail_version_test.rb
+++ b/test/models/paper_trail_version_test.rb
@@ -67,6 +67,18 @@ class PaperTrailVersionTest < ActiveSupport::TestCase
                      'pledge_generated_at' => { original: '(empty)', modified: (Time.zone.now + 5.days).strftime('%m/%d/%Y') }
                    }
     end
+
+    it 'should delete old objects' do
+      # count of audit objects should decrease by 1
+      assert_difference 'PaperTrailVersion.count', -1 do
+        with_versioning do
+          # make one of the audits really old
+          @track.created_at = 2.years.ago
+          
+          PaperTrailVersion.destroy_old
+        end
+      end
+    end
   end
 
   # ensure that paper trail is versioning properly


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Some housekeeping on `PaperTrail` audit objects.

This pull request makes the following changes:
* When a patient is archived, also destroy all associated `PaperTrail` versions
* During `nightly_cleanup`, delete any `PaperTrail` objects > 1 year old. 

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1974
* Bumps #Y

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
