### PR TITLE
Remove actual fund refs from test suite

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,7 +82,7 @@ fund2 = Fund.create! name: 'CatFund',
     Config.create config_key: :insurance,
                   config_value: { options: ['DC Medicaid', 'MD Medicaid', 'VA Medicaid', 'Other Insurance'] }
     Config.create config_key: :external_pledge_source,
-                  config_value: { options: ['Baltimore Abortion Fund', 'Metallica Abortion Fund'] }
+                  config_value: { options: ['Texas Amalgamated Abortion Services (TAAS)', 'Metallica Abortion Fund'] }
     Config.create config_key: :pledge_limit_help_text,
                   config_value: { options: ['Pledge Limit Guidelines:', '1st trimester (7-12 weeks): $100', '2nd trimester (12-24 weeks): $300', 'Later care (25+ weeks): $600'] }
     Config.create config_key: :language,
@@ -349,7 +349,7 @@ fund2 = Fund.create! name: 'CatFund',
         created_at: 133.days.ago
       )
       patient.external_pledges.create!(
-        source: 'Baltimore Abortion Fund',
+        source: 'Texas Amalgamated Abortion Services (TAAS)',
         amount: 100,
         created_at: 133.days.ago
       )

--- a/test/controllers/external_pledges_controller_test.rb
+++ b/test/controllers/external_pledges_controller_test.rb
@@ -41,7 +41,7 @@ class ExternalPledgesControllerTest < ActionDispatch::IntegrationTest
   describe 'update method' do
     before do
       with_versioning(@user) do
-        @patient.external_pledges.create source: 'Baltimore Abortion Fund',
+        @patient.external_pledges.create source: 'Metallica Abortion Fund',
                                          amount: 100
         @pledge = @patient.external_pledges.first
         @pledge_edits = { source: 'Edited Pledge' }
@@ -84,7 +84,7 @@ class ExternalPledgesControllerTest < ActionDispatch::IntegrationTest
 
   describe 'destroy' do
     before do
-      @patient.external_pledges.create source: 'Baltimore Abortion Fund',
+      @patient.external_pledges.create source: 'Metallica Abortion Fund',
                                        amount: 100
       @pledge = @patient.external_pledges.first
     end

--- a/test/helpers/calls_helper_test.rb
+++ b/test/helpers/calls_helper_test.rb
@@ -17,7 +17,7 @@ class CallsHelperTest < ActionView::TestCase
 
     it 'returns voicemail ok notifier text if vm pref is set to no' do
       @patient.voicemail_preference = 'yes'
-      assert_match(/Okay to identify as DCAF/,
+      assert_match(/Okay to identify as CATF/,
                    display_voicemail_link_with_warning(@patient))
       assert_match(/I left a voicemail for the patient/,
                    display_voicemail_link_with_warning(@patient))
@@ -25,7 +25,7 @@ class CallsHelperTest < ActionView::TestCase
 
     it 'returns voicemail not specified text if vm pref is set not spec' do
       @patient.voicemail_preference = 'not_specified'
-      assert_match(/Do not identify as DCAF/,
+      assert_match(/Do not identify as CATF/,
                    display_voicemail_link_with_warning(@patient))
       assert_match(/I left a voicemail for the patient/,
                    display_voicemail_link_with_warning(@patient))

--- a/test/helpers/external_pledges_helper_test.rb
+++ b/test/helpers/external_pledges_helper_test.rb
@@ -3,20 +3,20 @@ require 'test_helper'
 class ExternalPledgesHelperTest < ActionView::TestCase
   describe 'options generators' do
     before do
-      create :config, config_key: 'external_pledge_source',
-                      config_value: { options: ['Baltimore Abortion Fund', 'Tiller Fund (NNAF)', 'NYAAF (New York)'] }
+      create_external_pledge_source_config
       @options = external_pledge_source_options
     end
 
     it 'should spit out an array of available other funds' do
-      assert_includes @options, 'Baltimore Abortion Fund'
+      assert_includes @options, 'Metallica Abortion Fund'
       assert @options.class == Array
     end
 
     it 'should include the whole list of options' do
-      expected_external_pledges_array = ["Baltimore Abortion Fund",
-        "Tiller Fund (NNAF)",
-        "NYAAF (New York)",
+      expected_external_pledges_array = [
+        'Metallica Abortion Fund',
+        'Texas Amalgamated Abortion Services (TAAS)',
+        'Cat Town Abortion Fund (CTAF)',
         ["Clinic discount", "Clinic discount"],
         ["Other funds (see notes)","Other funds (see notes)"]]
       assert_same_elements @options, expected_external_pledges_array
@@ -25,16 +25,13 @@ class ExternalPledgesHelperTest < ActionView::TestCase
     it 'should remove preselected options' do
       @patient = create :patient
 
-      @patient.external_pledges.create source: 'Baltimore Abortion Fund',
+      @patient.external_pledges.create source: 'Metallica Abortion Fund',
                                        amount: 100
-      #create :external_pledge, source: 'Baltimore Abortion Fund',
-      #                         amount: 100,
-      #                         patient: @patient
 
       refute_includes available_pledge_source_options_for(@patient),
-                      'Baltimore Abortion Fund'
+                      'Metallica Abortion Fund'
       assert_includes available_pledge_source_options_for(@patient),
-                      'NYAAF (New York)'
+                      'Cat Town Abortion Fund (CTAF)'
     end
   end
 

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -76,7 +76,7 @@ class PatientsHelperTest < ActionView::TestCase
         nil,
         ["#{@active.name} (#{@active.city}, #{@active.state})", @active.id, { data: { naf: false, medicaid: false }}],
         ['--- INACTIVE CLINICS ---', nil, { disabled: true }],
-        ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
+        ["(Not currently working with CATF) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
       ]
 
       assert_same_elements clinic_options, expected_clinic_array
@@ -227,7 +227,7 @@ class PatientsHelperTest < ActionView::TestCase
       nil,
       ["Clinic", "Clinic"],
       ["Crime victim advocacy center", "Crime victim advocacy center"],
-      ["DCAF website or social media", "DCAF website or social media"],
+      ["CATF website or social media", "CATF website or social media"],
       ["Domestic violence crisis/intervention org", "Domestic violence crisis/intervention org"],
       ["Family member", "Family member"],
       ["Friend", "Friend"],

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -62,10 +62,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       it 'should include the option set' do
         expected = [
           nil,
-          'DC Abortion Fund',
-          'Baltimore Abortion Fund',
-          'Tiller Fund (NNAF)',
-          'NYAAF (New York)',
+          'Cat Fund',
+          'Metallica Abortion Fund',
+          'Texas Amalgamated Abortion Services (TAAS)',
+          'Cat Town Abortion Fund (CTAF)',
           ['Patient', 'Patient'],
           ['Clinic', 'Clinic'],
           ['Other (see notes)', 'Other (see notes)'],
@@ -83,7 +83,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
 
         expected = [
           nil,
-          'DC Abortion Fund',
+          'Cat Fund',
           ['Patient', 'Patient'],
           ['Clinic', 'Clinic'],
           ['Other (see notes)', 'Other (see notes)'],
@@ -98,7 +98,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       it 'should push orphaned value onto the end' do
         expected = [
           nil,
-          'DC Abortion Fund',
+          'Cat Fund',
           ['Patient', 'Patient'],
           ['Clinic', 'Clinic'],
           ['Other (see notes)', 'Other (see notes)'],
@@ -122,7 +122,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       end
 
     it 'should return a link if config set' do
-      expected_link = '<a target="_blank" href="https://www.yahoo.com">DCAF practical support guidance</a>'
+      expected_link = '<a target="_blank" href="https://www.yahoo.com">CATF practical support guidance</a>'
       assert_equal expected_link, practical_support_guidance_link
     end
   end

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -60,7 +60,7 @@ class ArchivedPatientTest < ActiveSupport::TestCase
 
       with_versioning(@user2) do
         @patient.calls.create status: :reached_patient
-        @patient.external_pledges.create source: 'Baltimore Abortion Fund',
+        @patient.external_pledges.create source: 'Metallica Abortion Fund',
                                          amount: 100
         @patient.practical_supports.create support_type: 'Louder Metallica tickets',
                     source: 'Metallica'

--- a/test/models/patient/statusable_test.rb
+++ b/test/models/patient/statusable_test.rb
@@ -63,7 +63,7 @@ class PatientTest::Statusable < PatientTest
         assert_equal Patient::STATUSES[:needs_appt][:key], @patient.status
       end
 
-      it 'should update to "Resolved Without DCAF" if patient is resolved' do
+      it 'should update to "Resolved Without CATF" if patient is resolved' do
         @patient.resolved_without_fund = true
         assert_equal Patient::STATUSES[:resolved][:key], @patient.status
       end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -592,7 +592,7 @@ class PatientTest < ActiveSupport::TestCase
       @patient.fund_pledge = nil
       @patient.pledge_sent = true
       refute @patient.valid?
-      assert_equal ["DCAF pledge field cannot be blank"], @patient.errors.messages[:pledge_sent]
+      assert_equal ["CATF pledge field cannot be blank"], @patient.errors.messages[:pledge_sent]
     end
 
     it 'should not validate pledge_sent if the clinic name is blank' do
@@ -615,7 +615,7 @@ class PatientTest < ActiveSupport::TestCase
       @patient.appointment_date = nil
       @patient.pledge_sent = true
       refute @patient.valid?
-      assert_equal ["DCAF pledge field cannot be blank", 'Clinic name cannot be blank', 'Appointment date cannot be blank'],
+      assert_equal ["CATF pledge field cannot be blank", 'Clinic name cannot be blank', 'Appointment date cannot be blank'],
       @patient.errors.messages[:pledge_sent]
     end
 
@@ -623,7 +623,7 @@ class PatientTest < ActiveSupport::TestCase
       refute @patient.pledge_info_present?
       @patient.fund_pledge = nil
       assert @patient.pledge_info_present?
-      assert_equal ["DCAF pledge field cannot be blank"], @patient.pledge_info_errors
+      assert_equal ["CATF pledge field cannot be blank"], @patient.pledge_info_errors
     end
 
     it 'should update sent by and sent at when sending the pledge' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -25,7 +25,7 @@ class UserTest < ActiveSupport::TestCase
       assert_not @user.valid?
       assert_equal 'Password must include at least one lowercase letter, ' \
                    'one uppercase letter, and one digit. Forbidden words ' \
-                   'include DCAF and password.',
+                   'include CATF and password.',
                    @user.errors.messages[:password].first
     end
 
@@ -39,12 +39,12 @@ class UserTest < ActiveSupport::TestCase
     end
 
     it 'should not allow the name of the fund' do
-      @user.password = 'AbortionsAreAHumanRight1DCAF'
-      @user.password_confirmation = 'AbortionsAreAHumanRight1DCAF'
+      @user.password = 'AbortionsAreAHumanRight1CATF'
+      @user.password_confirmation = 'AbortionsAreAHumanRight1CATF'
       assert_not @user.valid?
       assert_equal 'Password must include at least one lowercase letter, ' \
                    'one uppercase letter, and one digit. Forbidden words ' \
-                   'include DCAF and password.',
+                   'include CATF and password.',
                    @user.errors.messages[:password].first
     end
 

--- a/test/omniauth_helper.rb
+++ b/test/omniauth_helper.rb
@@ -6,7 +6,7 @@ module OmniauthMocker
       'uid' => '111696567596812172783',
       'info' => {
         'email' => email,
-        'first_name' => 'DCAF',
+        'first_name' => 'DARIA',
         'last_name' => 'Testing',
         'image' => 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg'
       },

--- a/test/system/accountant_workflow_test.rb
+++ b/test/system/accountant_workflow_test.rb
@@ -169,7 +169,7 @@ class AccountantWorkflowTest < ApplicationSystemTestCase
         assert has_content? "Clinic: #{@clinic.name}"
 
         # And should let you update it
-        fill_in 'DCAF payout', with: '999'
+        fill_in 'CATF payout', with: '999'
         fill_in 'Check #', with: 'BB8'
         find('h2').click # Click the header to get the field to save
         wait_for_ajax

--- a/test/system/clinic_management_test.rb
+++ b/test/system/clinic_management_test.rb
@@ -83,7 +83,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
 
       visit edit_patient_path @patient
       click_link 'Abortion Information'
-      select "(Not currently working with DCAF) - #{@clinic.name}", from: 'patient_clinic_id'
+      select "(Not currently working with CATF) - #{@clinic.name}", from: 'patient_clinic_id'
       assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
     end
   end
@@ -91,7 +91,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
   private
 
   def fill_in_all_clinic_fields
-    new_clinic_name = 'Games Done Quick Throw a Benefit for DCAF'
+    new_clinic_name = 'Games Done Quick Throw a Benefit for Abortion Funds'
     fill_in 'Name', with: new_clinic_name
     fill_in 'Street address', with: '123 Fake Street'
     fill_in 'City', with: 'Yolo'
@@ -109,7 +109,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
   end
 
   def assert_fields_have_proper_content
-    assert has_field? 'Name', with: 'Games Done Quick Throw a Benefit for DCAF'
+    assert has_field? 'Name', with: 'Games Done Quick Throw a Benefit for Abortion Funds'
     assert has_field? 'Street address', with: '123 Fake Street'
     assert has_field? 'City', with: 'Yolo'
     assert_equal 'TX', find('#clinic_state').value

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -30,7 +30,7 @@ class DataEntryTest < ApplicationSystemTestCase
       select 'DC', from: 'patient_state'
       fill_in 'County', with: 'Wash'
       fill_in 'Zipcode', with: '20009'
-      fill_in 'DCAF pledge', with: '100'
+      fill_in 'CATF pledge', with: '100'
       fill_in 'Age', with: '30'
       select 'Other', from: 'patient_race_ethnicity'
       select @clinic.name, from: 'patient_clinic_id'
@@ -102,7 +102,7 @@ class DataEntryTest < ApplicationSystemTestCase
         assert has_field? 'Abortion cost', with: '200'
         assert has_field? 'Patient contribution', with: '150'
         assert has_field? 'National Abortion Federation pledge', with: '50'
-        assert has_field? 'DCAF pledge', with: '100'
+        assert has_field? 'CATF pledge', with: '100'
         assert has_checked_field? 'Referred to clinic'
         assert has_checked_field? 'Ultrasound completed?'
       end
@@ -134,7 +134,7 @@ class DataEntryTest < ApplicationSystemTestCase
       fill_in 'City', with: 'Washington'
       select 'DC', from: 'patient_state'
       fill_in 'County', with: 'Wash'
-      fill_in 'DCAF pledge', with: '99'
+      fill_in 'CATF pledge', with: '99'
       fill_in 'Fund pledged at', with: 80.days.ago.strftime('%m/%d/%Y')
       fill_in 'Age', with: '30'
       select 'Other', from: 'patient_race_ethnicity'

--- a/test/system/pledge_fulfillment_test.rb
+++ b/test/system/pledge_fulfillment_test.rb
@@ -47,7 +47,7 @@ class PledgeFulfillmentTest < ApplicationSystemTestCase
       assert has_link? 'Pledge Fulfillment'
       click_link 'Pledge Fulfillment'
       assert has_text? "Clinic: #{@clinic.name}"
-      assert has_text? 'DCAF Pledge Amount: $500'
+      assert has_text? 'CATF Pledge Amount: $500'
       assert has_text? 'Procedure date'
       assert has_text? 'Check #'
     end

--- a/test/system/practical_support_behaviors_test.rb
+++ b/test/system/practical_support_behaviors_test.rb
@@ -58,7 +58,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
 
     it 'should save if valid and changed' do
       within :css, '#practical-support-entries' do
-        select 'DC Abortion Fund', from: 'practical_support_source'
+        select 'CAT Fund', from: 'practical_support_source'
         check 'Confirmed'
       end
 
@@ -67,7 +67,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
       reload_page_and_click_link 'Practical Support'
       within :css, '#practical-support-entries' do
         assert_equal 'lodging', find('#practical_support_support_type').text
-        assert_equal 'DC Abortion Fund', find('#practical_support_source').value
+        assert_equal 'CAT Fund', find('#practical_support_source').value
         assert_equal '100.45', find('#practical_support_amount').value
         assert has_checked_field? 'Confirmed'
       end

--- a/test/system/practical_support_behaviors_test.rb
+++ b/test/system/practical_support_behaviors_test.rb
@@ -58,7 +58,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
 
     it 'should save if valid and changed' do
       within :css, '#practical-support-entries' do
-        select 'CAT Fund', from: 'practical_support_source'
+        select 'Cat Fund', from: 'practical_support_source'
         check 'Confirmed'
       end
 
@@ -67,7 +67,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
       reload_page_and_click_link 'Practical Support'
       within :css, '#practical-support-entries' do
         assert_equal 'lodging', find('#practical_support_support_type').text
-        assert_equal 'CAT Fund', find('#practical_support_source').value
+        assert_equal 'Cat Fund', find('#practical_support_source').value
         assert_equal '100.45', find('#practical_support_amount').value
         assert has_checked_field? 'Confirmed'
       end

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -39,11 +39,11 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       find('#pledge-next').click
       wait_for_no_element 'Review this preview of your pledge'
 
-      assert has_text? 'Awesome, you generated a DCAF'
+      assert has_text? 'Awesome, you generated a CATF'
       check 'I sent the pledge'
       wait_for_ajax
       find('#pledge-next').click
-      wait_for_no_element 'Awesome, you generated a DCAF'
+      wait_for_no_element 'Awesome, you generated a CATF'
 
       wait_for_ajax
       wait_for_element 'Patient information'

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -138,14 +138,14 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     before do
       click_link 'Abortion Information'
       select @clinic.name, from: 'patient_clinic_id'
-      check 'Resolved without assistance from DCAF'
+      check 'Resolved without assistance from CATF'
       check 'Referred to clinic'
       check 'Ultrasound completed?'
 
       fill_in 'Abortion cost', with: '300'
       fill_in 'Patient contribution', with: '200'
       fill_in 'National Abortion Federation pledge', with: '50'
-      fill_in 'DCAF pledge', with: '25'
+      fill_in 'CATF pledge', with: '25'
       fill_in 'Baltimore Abortion Fund pledge', with: '25', match: :prefer_exact
       fill_in 'Abortion cost', with: '300'
       click_away_from_field
@@ -164,21 +164,21 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       find('#outstanding-balance').has_text?('$19950')
       fill_in 'Baltimore Abortion Fund pledge', with: '0', match: :prefer_exact
       find('#outstanding-balance').has_text?('$19975')
-      fill_in 'DCAF pledge', with: '0'
+      fill_in 'CATF pledge', with: '0'
       find('#outstanding-balance').has_text?('$20000')
     end
 
     it 'should alter the abortion information' do
       within :css, '#abortion_information' do
         assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
-        assert has_checked_field?('Resolved without assistance from DCAF')
+        assert has_checked_field?('Resolved without assistance from CATF')
         assert has_checked_field?('Referred to clinic')
         assert has_checked_field?('Ultrasound completed?')
 
         assert has_field? 'Abortion cost', with: '300'
         assert has_field? 'Patient contribution', with: '200'
         assert has_field? 'National Abortion Federation pledge', with: '50'
-        assert has_field? 'DCAF pledge', with: '25'
+        assert has_field? 'CATF pledge', with: '25'
         assert has_field? 'Baltimore Abortion Fund pledge', with: '25'
       end
     end
@@ -306,7 +306,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       wait_for_ajax
 
       select '12 weeks', from: 'Weeks along at procedure'
-      fill_in 'DCAF payout', with: '100'
+      fill_in 'CATF payout', with: '100'
       wait_for_ajax
 
       fill_in 'Check #', with: '444-22'
@@ -329,7 +329,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
                           with: 2.days.from_now.strftime('%Y-%m-%d')
         assert_equal '12',
                      find('#patient_fulfillment_attributes_gestation_at_procedure').value
-        assert has_field? 'DCAF payout', with: 100
+        assert has_field? 'CATF payout', with: 100
         assert has_field? 'Check #', with: '444-22'
         assert has_checked_field? 'Fulfillment audited?'
 

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -8,7 +8,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     @admin = create :user, role: :admin
     @clinic = create :clinic
     @patient = create :patient, line: @line
-    @patient.external_pledges.create source: 'Baltimore Abortion Fund',
+    @patient.external_pledges.create source: 'Metallica Abortion Fund',
                                      amount: 100
     @ext_pledge = @patient.external_pledges.first
     create_external_pledge_source_config
@@ -146,7 +146,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       fill_in 'Patient contribution', with: '200'
       fill_in 'National Abortion Federation pledge', with: '50'
       fill_in 'CATF pledge', with: '25'
-      fill_in 'Baltimore Abortion Fund pledge', with: '25', match: :prefer_exact
+      fill_in 'Metallica Abortion Fund pledge', with: '25', match: :prefer_exact
       fill_in 'Abortion cost', with: '300'
       click_away_from_field
       reload_page_and_click_link 'Abortion Information'
@@ -162,7 +162,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       find('#outstanding-balance').has_text?('$19900')
       fill_in 'National Abortion Federation pledge', with: '0'
       find('#outstanding-balance').has_text?('$19950')
-      fill_in 'Baltimore Abortion Fund pledge', with: '0', match: :prefer_exact
+      fill_in 'Metallica Abortion Fund pledge', with: '0', match: :prefer_exact
       find('#outstanding-balance').has_text?('$19975')
       fill_in 'CATF pledge', with: '0'
       find('#outstanding-balance').has_text?('$20000')
@@ -179,7 +179,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'Patient contribution', with: '200'
         assert has_field? 'National Abortion Federation pledge', with: '50'
         assert has_field? 'CATF pledge', with: '25'
-        assert has_field? 'Baltimore Abortion Fund pledge', with: '25'
+        assert has_field? 'Metallica Abortion Fund pledge', with: '25'
       end
     end
   end

--- a/test/system/voicemail_preference_in_call_modal_test.rb
+++ b/test/system/voicemail_preference_in_call_modal_test.rb
@@ -31,7 +31,7 @@ class VoicemailPreferenceInCallModalTest < ApplicationSystemTestCase
       end
 
       it 'should have warning text and a link' do
-        assert has_text? 'Voicemail OK; Do not identify as DCAF'
+        assert has_text? 'Voicemail OK; Do not identify as CATF'
         assert has_link? 'I left a voicemail for the patient'
       end
     end
@@ -44,7 +44,7 @@ class VoicemailPreferenceInCallModalTest < ApplicationSystemTestCase
       end
 
       it 'should have goahead text and a link' do
-        assert has_text? 'Voicemail OK; Okay to identify as DCAF'
+        assert has_text? 'Voicemail OK; Okay to identify as CATF'
         assert has_link? 'I left a voicemail for the patient'
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ class ActiveSupport::TestCase
   parallelize(workers: :number_of_processors) unless ENV['DOCKER']
 
   def setup_tenant
-    tenant = create :fund, name: 'DCAF', full_name: 'DC Abortion Fund'
+    tenant = create :fund, name: 'CATF', full_name: 'Cat Fund'
     ActsAsTenant.current_tenant = tenant
     ActsAsTenant.test_tenant = tenant
   end
@@ -58,9 +58,9 @@ class ActiveSupport::TestCase
   end
 
   def create_external_pledge_source_config
-    ext_pledge_options = ['Baltimore Abortion Fund',
-                          'Tiller Fund (NNAF)',
-                          'NYAAF (New York)']
+    ext_pledge_options = ['Metallica Abortion Fund',
+                          'Texas Amalgamated Abortion Services (TAAS)',
+                          'Cat Town Abortion Fund (CTAF)']
     create :config, config_key: 'external_pledge_source',
                     config_value: { options: ext_pledge_options }
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Most of our tests feature DCAF and a few of its peers as test fixtures. This replaces them with plausible but fake stubs.

This pull request makes the following changes:
* fake abortion funds in test suite

no view changes

It relates to the following issue #s: 
* Bumps #2552 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
