### PR TITLE
Rework call list to remove part of last note and include Initial Call Date instead

### DIFF
--- a/app/models/concerns/notetakeable.rb
+++ b/app/models/concerns/notetakeable.rb
@@ -2,13 +2,6 @@
 module Notetakeable
   extend ActiveSupport::Concern
 
-  def most_recent_note_display_text
-    note_text = most_recent_note.try(:full_text).to_s
-    display_note = note_text[0..30]
-    display_note << '...' if note_text.length > 31
-    display_note
-  end
-
   def most_recent_note
     notes.order('created_at DESC').limit(1).first
   end

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -12,7 +12,7 @@
         <th scope="col"><!-- handle/spacer --></th>
         <th scope="col"><%= t 'common.phone' %></th>
         <th scope="col"><%= t 'common.name' %></th>
-        <%= th_autosortable t('activerecord.patient.initial_call_date'), 'string', local_assigns %>
+        <%= th_autosortable t('activerecord.attributes.patient.initial_call_date'), 'string', local_assigns %>
         <th scope="col"><%= t 'common.weeks_along_short' %></th>
         <%= th_autosortable t('common.status'), 'string', local_assigns %>
         <%= th_autosortable t('common.appointment_date_short'), 'string', local_assigns %>

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -12,10 +12,10 @@
         <th scope="col"><!-- handle/spacer --></th>
         <th scope="col"><%= t 'common.phone' %></th>
         <th scope="col"><%= t 'common.name' %></th>
+        <%= th_autosortable t('activerecord.patient.initial_call_date'), 'string', local_assigns %>
         <th scope="col"><%= t 'common.weeks_along_short' %></th>
         <%= th_autosortable t('common.status'), 'string', local_assigns %>
         <%= th_autosortable t('common.appointment_date_short'), 'string', local_assigns %>
-        <th scope="col"><%= t 'common.notes' %></th>
         <th scope="col"><!-- add/delete from call list --></th>
         <th scope="col"><!-- call --></th>
       </tr>
@@ -35,6 +35,8 @@
           <td><%= patient.primary_phone_display %></td>
           <td><%= link_to patient.name, edit_patient_path(patient) %></td>
 
+          <td><%= patient.initial_call_date.display_date %></td>
+
           <td>
             <%= t 'common.weeks_days_short',
                   weeks: patient.last_menstrual_period_now_weeks,
@@ -43,7 +45,6 @@
 
           <td><%= patient.status %></td>
           <td><%= patient.appointment_date_display %></td>
-          <td><%= patient.most_recent_note_display_text %> <%= plus_sign_icon(patient.most_recent_note) %></td>
 
           <% if table_type == 'completed_calls' || table_type == 'urgent_cases' %>
             <td class="blank-td"></td>

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -424,18 +424,6 @@ class PatientTest < ActiveSupport::TestCase
       end
     end
 
-    describe 'most_recent_note_display_text method' do
-      before do
-        @note = create :note, patient: @patient,
-                              full_text: (1..100).map(&:to_s).join('')
-      end
-
-      it 'returns 34 characters of the notes text' do
-        assert_equal 34, @patient.most_recent_note_display_text.length
-        assert_match /^1234/, @patient.most_recent_note_display_text
-      end
-    end
-
     describe 'destroy_associated_events method' do
       it 'should nuke associated events on patient destroy' do
         assert_difference 'Event.count', -1 do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds a sortable Initial Call Date column to the call list, and drops last note (which hasn't worked right for awhile; part of our justification for dropping it is that nobody has complained in that time). Last note will still show up on the new call flow.

This pull request makes the following changes:
* Add initial call date to call list
* Remove last note from call list

![image](https://user-images.githubusercontent.com/3866868/166179919-6fc328c5-11e9-4f8c-97e6-0b483dba97c9.png)

It relates to the following issue #s: 
* Fixes https://github.com/DARIAEngineering/dcaf_case_management/issues/2501

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
