### PR TITLE
Commits schema updates for integer over bigint

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,9 +49,9 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
     t.datetime "pledge_generated_at"
     t.datetime "pledge_sent_at"
     t.boolean "textable"
-    t.bigint "clinic_id"
-    t.bigint "pledge_generated_by_id"
-    t.bigint "pledge_sent_by_id"
+    t.integer "clinic_id"
+    t.integer "pledge_generated_by_id"
+    t.integer "pledge_sent_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "fund_id"
@@ -65,8 +65,8 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
   end
 
   create_table "call_list_entries", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "patient_id", null: false
+    t.integer "user_id", null: false
+    t.integer "patient_id", null: false
     t.string "line_legacy"
     t.integer "order_key", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
   create_table "calls", force: :cascade do |t|
     t.integer "status", null: false
     t.string "can_call_type", null: false
-    t.bigint "can_call_id", null: false
+    t.integer "can_call_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "fund_id"
@@ -168,7 +168,7 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
     t.integer "amount"
     t.boolean "active"
     t.string "can_pledge_type", null: false
-    t.bigint "can_pledge_id", null: false
+    t.integer "can_pledge_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "fund_id"
@@ -185,7 +185,7 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
     t.date "date_of_check"
     t.boolean "audited"
     t.string "can_fulfill_type", null: false
-    t.bigint "can_fulfill_id", null: false
+    t.integer "can_fulfill_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "fund_id"
@@ -217,7 +217,7 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
 
   create_table "notes", force: :cascade do |t|
     t.string "full_text", null: false
-    t.bigint "patient_id"
+    t.integer "patient_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "fund_id"
@@ -266,10 +266,10 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
     t.datetime "pledge_generated_at"
     t.datetime "pledge_sent_at"
     t.boolean "textable"
-    t.bigint "clinic_id"
-    t.bigint "pledge_generated_by_id"
-    t.bigint "pledge_sent_by_id"
-    t.bigint "last_edited_by_id"
+    t.integer "clinic_id"
+    t.integer "pledge_generated_by_id"
+    t.integer "pledge_sent_by_id"
+    t.integer "last_edited_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "fund_id"
@@ -295,7 +295,7 @@ ActiveRecord::Schema.define(version: 2021_12_19_044530) do
     t.boolean "confirmed"
     t.string "source", null: false
     t.string "can_support_type"
-    t.bigint "can_support_id"
+    t.integer "can_support_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "fund_id"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I keep seeing this change when I'm doing the build, so opening this PR to figure out if we want it, or want to figure out how to keep bigints

This pull request makes the following changes:
* runs the build & seed
* commits the schema changes


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
