### PR TITLE
Adds back the Notes preview on table view

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,15 +1,5 @@
 # Functions related to displaying notes
 module NotesHelper
-  def plus_sign_icon(note)
-    return nil unless note && note.try(:full_text).length > 31
-    note = tag(:i, class: 'fas fa-plus-circle',
-                   title: t('note.most_recent_no_user'),
-                   aria: { hidden: true },
-                   data: { toggle: 'popover', placement: 'bottom', content: note.full_text })
-    sr = tag(:span, class: 'sr-only', text: 'Full note')
-    safe_join([note, sr], '')
-  end
-
   def display_note_text_for(note)
     return nil if note.try(:full_text).blank?
     info = content_tag :p do

--- a/app/javascript/styles/tables.scss
+++ b/app/javascript/styles/tables.scss
@@ -24,7 +24,7 @@ table.border-side {
 
   tr {
     td {
-      font-size: 17px;
+      font-size: 16px;
       padding: 10px 0px !important;
     }
   }

--- a/app/models/concerns/notetakeable.rb
+++ b/app/models/concerns/notetakeable.rb
@@ -2,6 +2,13 @@
 module Notetakeable
   extend ActiveSupport::Concern
 
+  def most_recent_note_display_text
+    note_text = most_recent_note.try(:full_text).to_s
+    display_note = note_text[0..20]
+    display_note << '…' if note_text.length > 21
+    display_note
+  end
+
   def most_recent_note
     notes.order('created_at DESC').limit(1).first
   end

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -16,6 +16,7 @@
         <th scope="col"><%= t 'common.weeks_along_short' %></th>
         <%= th_autosortable t('common.status'), 'string', local_assigns %>
         <%= th_autosortable t('common.appointment_date_short'), 'string', local_assigns %>
+        <th scope="col"><%= t 'common.notes' %></th>
         <th scope="col"><!-- add/delete from call list --></th>
         <th scope="col"><!-- call --></th>
       </tr>
@@ -45,6 +46,7 @@
 
           <td><%= patient.status %></td>
           <td><%= patient.appointment_date_display %></td>
+          <td><%= patient.most_recent_note_display_text %> </td>
 
           <% if table_type == 'completed_calls' || table_type == 'urgent_cases' %>
             <td class="blank-td"></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,7 +286,6 @@ en:
       sign_out: Sign Out
   note:
     most_recent: 'Most recent note from %{by} at %{at}:'
-    most_recent_no_user: Most recent note
   patient:
     abortion_information:
       clinic_section:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -286,7 +286,6 @@ es:
       sign_out: Desconectar
   note:
     most_recent: 'La nota más reciente de %{by} en %{at}:'
-    most_recent_no_user: La nota más reciente
   patient:
     abortion_information:
       clinic_section:

--- a/test/helpers/notes_helper_test.rb
+++ b/test/helpers/notes_helper_test.rb
@@ -3,19 +3,6 @@ require 'test_helper'
 class NotesHelperTest < ActionView::TestCase
   include ERB::Util
 
-  describe 'plus sign glyphicon method' do
-    it 'should return nil if the text is under 40 char' do
-      under_40_char = create :note, full_text: 'yolo goat'
-      assert_nil plus_sign_icon under_40_char
-    end
-
-    it 'should return a glyphicon if the text is over 40 char' do
-      over_40_char = create :note, full_text: 'this is 40 character or ' \
-                                              'so cats are great so fluffy'
-      refute_nil plus_sign_icon over_40_char
-    end
-  end
-
   describe 'display_note_text_for method' do
     it 'should return nil if note does not have text' do
       note = build :note, full_text: nil

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -424,6 +424,21 @@ class PatientTest < ActiveSupport::TestCase
       end
     end
 
+
+    describe 'most_recent_note_display_text method' do
+      before do
+        @note = create :note, patient: @patient,
+          full_text: (1..100).map(&:to_s).join('')
+      end
+
+      it 'returns 22 characters of the notes text' do
+        assert_equal 22, @patient.most_recent_note_display_text.length
+        assert_match /^1234/, @patient.most_recent_note_display_text
+      end
+    end
+
+
+
     describe 'destroy_associated_events method' do
       it 'should nuke associated events on patient destroy' do
         assert_difference 'Event.count', -1 do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns out a fund uses the Notes preview as a core part of their flow! Adding that back.

This pull request makes the following changes:
* Adds back the Notes column & related code removed in #2569 
  * No longer offers the (nonfunctional) `+`
  * Uses the unicode … instead of ...
  * Deletes dead code from removing the `+`
* Shrinks Table font from 17px->16px

![image](https://user-images.githubusercontent.com/6129479/167316905-78c477a5-a0f5-4148-b133-838fcd0061e3.png)

It relates to the following issue #s: 
* Related to #2501 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
