### PR TITLE
scroll flashes; adjust css

### DIFF
--- a/app/javascript/styles/flash.scss
+++ b/app/javascript/styles/flash.scss
@@ -4,10 +4,19 @@
 @import './_variables';
 
 #flash {
-  position: absolute;
+  position: fixed;
+  top: 0;
+  padding-top: 0.5em;
+  left: 0;
   width: 100%;
-  z-index: 999;
+  z-index: 1100;
   transition-duration: .5s;
+  pointer-events: none;
+}
+
+div.flash-message {
+  margin: auto;
+  pointer-events: auto;
 }
 
 #error_explanation {

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,5 +1,5 @@
 <div id='flash'>
-  <div class="col-sm-10">
+  <div class="col-sm-10 flash-message">
   <% flash.each do |name, msg| %>
     <% if name != 'timedout' && msg.length > 0 %>
       <div class="alert alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -77,6 +77,8 @@ module IntegrationHelper
   end
 
   def click_away_from_field
+    # close the flash
+    find('#flash button.close')&.click
     find('nav').click
     wait_for_ajax
   end

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -77,8 +77,12 @@ module IntegrationHelper
   end
 
   def click_away_from_field
-    # close the flash
-    find('#flash button.close')&.click
+    # close the flash if it's in the way
+    begin
+      find('#flash button.close')&.click
+    rescue Capybara::ElementNotFound
+    end
+
     find('nav').click
     wait_for_ajax
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This changes makes feedback flashes (user input save confirmation, errors) always show up, even if you scroll the page. Before, flashes were stuck at the top of the page, so if you were on a very tall page and making changes at the bottom, you might miss feedback.

This pull request makes the following changes:
* Makes flashes `position: fixed` rather than `absolute`
* Fixes centering of flashes

(If there are changes to the views, please include a screenshot so we know what to look for!)

Example success:

<img width="1423" alt="Screen Shot 2022-05-13 at 12 03 20" src="https://user-images.githubusercontent.com/7085805/168323560-e34dcdd8-fbc7-4a31-a157-0e130495b037.png">

Example error:

<img width="990" alt="Screen Shot 2022-05-13 at 12 03 52" src="https://user-images.githubusercontent.com/7085805/168323562-416dfe11-a28e-4632-a807-c2b288466384.png">


It relates to the following issue #s: 
* Fixes #2429
* Bumps #Y

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
