### PR TITLE
add test for previously-skipped patient method

### DIFF
--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -348,7 +348,10 @@ class PatientTest < ActiveSupport::TestCase
 
       describe 'trim_shared_patients method' do
         it 'should trim shared patients after they have been inactive or resolved' do
-          skip "test not implemented for patient#trim_shared_patients"
+          @patient.update shared_flag: true
+          @patient.update resolved_without_fund: true
+          Patient.trim_shared_patients
+          assert_not @patient.shared_flag
         end
       end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Test the `trim_shared_patients` method, which we had been skipping.
* Replaces #2583 (now using the new `shared` rather than `flagged` language)

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2575 
* Bumps #Y

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
