### PR TITLE
add foreman gem + use bin/dev instead of rails s

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ group :development do
   # Security scanners that also run in CI. They run with bundle exec.
   gem 'ruby_audit', require: false #
   gem 'bundler-audit', require: false
+
+  # Run jsbundling and cssbundling along with rails via bin/dev and Procfile.dev
+  gem 'foreman'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
     ffi (1.15.5)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
+    foreman (0.87.2)
     geokit (1.13.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -447,6 +448,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   figaro
+  foreman
   geokit
   i18n-tasks (~> 1.0.0)
   jsbundling-rails

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ run-generate:
 g: run-generate ## Runs the rails generator
 
 run-rails:
-	bundle exec rails server
+	bundle exec bin/dev
 s: run-rails ## Starts the rails server
 
 run-tests:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -89,7 +89,7 @@ We use Postgres around these parts. Installation will differ based on your OS.
 
 ### Then, showtime
 
-* Run the command `rails server` to start the rails server
+* Run the command `bin/dev` to start the rails server
 * You are officially ready to go! Navigate your browser to `http://localhost:3000`. You can log in with the user `test@example.com` and the password `AbortionsAreAHumanRight1`.
 
 ## Security


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

friendship ended with `rails s`; `bin/dev` is my new best friend

(also sets up the foreman gem which is required here)

This pull request makes the following changes:
* add foreman gem, to run bin/dev
* sets bin/dev instead of rails s where appropriate (in the makefile and bare metal spinup instructions)

no view changes

It relates to the following issue #s: 
* Fixes https://github.com/DARIAEngineering/dcaf_case_management/issues/2601

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
