### PR TITLE
R7: try turning on executor around test case

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -45,7 +45,7 @@ Rails.application.config.active_support.cache_format_version = 7.0
 # This makes test cases behave closer to an actual request or job.
 # Several features that are normally disabled in test, such as Active Record query cache
 # and asynchronous queries will then be enabled.
-# Rails.application.config.active_support.executor_around_test_case = true
+Rails.application.config.active_support.executor_around_test_case = true
 
 # Define the isolation level of most of Rails internal state.
 # If you use a fiber based server or job processor, you should set it to `:fiber`.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turning on this setting makes rails test cases behave a little more server-y, supposedly. Shouldn't have a prod effect.

This pull request makes the following changes:
* turn on the new test setting default

no view changes

It relates to the following issue #s: 
* Bumps #2642

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
