### PR TITLE
R7: turn on new setting to raise on open redirs

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -73,7 +73,7 @@ Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true
 Rails.application.config.active_record.partial_inserts = false
 #
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
-# Rails.application.config.action_controller.raise_on_open_redirects = true
+Rails.application.config.action_controller.raise_on_open_redirects = true
 
 # Change the variant processor for Active Storage.
 # Changing this default means updating all places in your code that


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Open redirects is a security risk, and this new setting will raise errors. This is a nice security enhancement!

This pull request makes the following changes:
* turn on the raise if empty redirect setting

no view changes

It relates to the following issue #s: 
* Bumps #2462 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
