### PR TITLE
r7: enable parameter wrapping by default in controllers

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -97,7 +97,7 @@ Rails.application.config.action_controller.raise_on_open_redirects = true
 # Enable parameter wrapping for JSON.
 # Previously this was set in an initializer. It's fine to keep using that initializer if you've customized it.
 # To disable parameter wrapping entirely, set this config to `false`.
-# Rails.application.config.action_controller.wrap_parameters_by_default = true
+Rails.application.config.action_controller.wrap_parameters_by_default = true
 
 # Specifies whether generated namespaced UUIDs follow the RFC 4122 standard for namespace IDs provided as a
 # `String` to `Digest::UUID.uuid_v3` or `Digest::UUID.uuid_v5` method calls.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Follow new defaults for params wrapping. You can read all about this at https://api.rubyonrails.org/v5.1.7/classes/ActionController/ParamsWrapper.html but I can't say I recommend it.

This pull request makes the following changes:
* turn on params wrapping default

no view changes

It relates to the following issue #s: 
* Bumps #2462

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
