### PR TITLE
r7: follow default on actionmailer timeouts

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -53,7 +53,7 @@ Rails.application.config.active_support.executor_around_test_case = true
 # Rails.application.config.active_support.isolation_level = :thread
 
 # Set both the `:open_timeout` and `:read_timeout` values for `:smtp` delivery method.
-# Rails.application.config.action_mailer.smtp_timeout = 5
+Rails.application.config.action_mailer.smtp_timeout = 5
 
 # The ActiveStorage video previewer will now use scene change detection to generate
 # better preview images (rather than the previous default of using the first frame


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

ActionMailer is getting some timeouts by default, this change follows that standard.

This pull request makes the following changes:
* turn on actionmailer timeouts by default

no view changes

It relates to the following issue #s: 
* Bumps #2462 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
