### PR TITLE
final round of safe DCAF -> DARIAs

### DIFF
--- a/.github/CONTRIBUTING
+++ b/.github/CONTRIBUTING
@@ -13,4 +13,4 @@
 
 ### Security Practices
 
-* Please see [this document](https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) for good security practices
+* Please see [this document](https://github.com/DARIAEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) for good security practices

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Feel free to hit any of us up with questions about the project, we're nice!
 ### tl;dr
 * We are best reached via the [Code for DC slack](https://codefordc.org/resources/slack.html)
 * We run on forks and pull requests
-* Our [list of issues in Github](https://github.com/colinxfleming/dcaf_case_management/issues) is our project's remaining TODO list
+* Our [list of issues in Github](https://github.com/DARIAEngineering/dcaf_case_management/issues) is our project's remaining TODO list
 * Post in an issue when you're starting work on something, so @colinxfleming can keep track of it and so we don't duplicate work
 * We <3 new people and beginners
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "DARIA Case Manager",
   "description": "A Rails-based case management system for abortion funds",
-  "repository": "https://github.com/DCAFEngineering/dcaf_case_management",
+  "repository": "https://github.com/DARIAEngineering/dcaf_case_management",
   "scripts": {
     "postdeploy": "bundle exec rails db:migrate"
   },

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module DcafCaseManagement
+module DARIA
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

final round of DCAF -> DARIAs before repo rename.

This pull request makes the following changes:
* git grep -i "dcaf" then change the stuff that isn't `dcaf_case_management`

no view changes

It relates to the following issue #s: 
* Bumps https://github.com/DARIAEngineering/dcaf_case_management/issues/2552

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
