### PR TITLE
Add email to clinics; display of a clinic's email/fax number when sending a pledge

### DIFF
--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -49,8 +49,8 @@ class ClinicsController < ApplicationController
 
   def clinic_params
     clinic_params = [:name, :street_address, :city, :state, :zip,
-                     :phone, :fax, :active, :accepts_naf, :accepts_medicaid,
-                     :gestational_limit]
+                     :phone, :fax, :active, :email_for_pledges,
+                     :accepts_naf, :accepts_medicaid, :gestational_limit]
     cost_params = (5..30).map { |i| "costs_#{i}wks".to_sym }
 
     params.require(:clinic).permit(

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -5,4 +5,9 @@ module FooterHelper
     fax_uri = UriService.new(fax)
     link_to fax_uri.uri, fax_uri.uri.to_s, target: '_blank', rel: 'noopener nofollow' if fax_uri.uri
   end
+
+  def clinic_pledge_email(patient)
+    email = patient.clinic&.email_for_pledges
+    link_to email, 'mailto:' + email, target: '_blank'
+  end
 end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -5,9 +5,4 @@ module FooterHelper
     fax_uri = UriService.new(fax)
     link_to fax_uri.uri, fax_uri.uri.to_s, target: '_blank', rel: 'noopener nofollow' if fax_uri.uri
   end
-
-  def clinic_pledge_email(patient)
-    email = patient.clinic&.email_for_pledges
-    link_to email, 'mailto:' + email, target: '_blank'
-  end
 end

--- a/app/helpers/pledges_helper.rb
+++ b/app/helpers/pledges_helper.rb
@@ -15,4 +15,14 @@ module PledgesHelper
       t('patient.menu.cancel_pledge')
     end
   end
+
+  def clinic_pledge_email(patient)
+    email = patient.clinic&.email_for_pledges
+    link_to email, 'mailto:' + email, target: '_blank'
+  end
+
+  def clinic_pledge_fax(patient)
+    fax = patient.clinic&.fax
+    fax
+  end
 end

--- a/app/helpers/pledges_helper.rb
+++ b/app/helpers/pledges_helper.rb
@@ -18,6 +18,7 @@ module PledgesHelper
 
   def clinic_pledge_email(patient)
     email = patient.clinic&.email_for_pledges
+    return unless email
     link_to email, 'mailto:' + email, target: '_blank'
   end
 

--- a/app/services/pledge_form_generator.rb
+++ b/app/services/pledge_form_generator.rb
@@ -92,6 +92,18 @@ class PledgeFormGenerator
       contact_email: 'info@yellowhammerfund.org',
       billing_email: 'billing@yellowhammer.org',
       img: 'yhf_logo.png'
+    },
+    'Test Fund' => {
+      addr: [
+        'Test Fund',
+        '42 Wallaby Way',
+        'Sydney Australia NSW'
+      ],
+      width: 200,
+      height: nil,
+      img: 'dcaf_logo.png',
+      contact_email: 'info@testfund.net',
+      billing_email: 'billing@testfund.net'
     }
   }
 

--- a/app/services/pledge_form_generator.rb
+++ b/app/services/pledge_form_generator.rb
@@ -93,18 +93,6 @@ class PledgeFormGenerator
       billing_email: 'billing@yellowhammer.org',
       img: 'yhf_logo.png'
     },
-    'Test Fund' => {
-      addr: [
-        'Test Fund',
-        '42 Wallaby Way',
-        'Sydney Australia NSW'
-      ],
-      width: 200,
-      height: nil,
-      img: 'dcaf_logo.png',
-      contact_email: 'info@testfund.net',
-      billing_email: 'billing@testfund.net'
-    }
   }
 
   private

--- a/app/views/clinics/_clinic_form.html.erb
+++ b/app/views/clinics/_clinic_form.html.erb
@@ -12,6 +12,9 @@
       <%= f.text_field :fax,
                        autocomplete: 'off',
                        pattern: "[0-9]{10}|[0-9]{3}\.[0-9]{3}\.[0-9]{4}|[0-9]{3}[-][0-9]{3}[-][0-9]{4}" %>
+      <%= f.email_field :email_for_pledges,
+                       autocomplete: 'off',
+                       help: t('clinics.form.email_help') %>
       <%= f.check_box :accepts_naf,
                        autocomplete: 'off',
                        label: t('activerecord.attributes.clinic.accepts_naf') %>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -37,21 +37,22 @@
         <p class="row">
           <%= t('patient.pledge.step_three.downloads') %>
         </p>
+      <% end %>
 
-        <% if patient.clinic&.email_for_pledges.present? %>
+      <p class="row"><%= t('patient.pledge.step_three.submit') %></p>
+      <% if patient.clinic&.email_for_pledges.present? %>
+        <p class="row">
+          <%= clinic_pledge_email(patient) %>
+        </p>
+      <% else %>
+        <% if patient.clinic&.fax.present? %>
           <p class="row">
-            <%= clinic_pledge_email(patient) %>
-          </p>
-        <% else %>
-          <% if patient.clinic&.fax.present? %>
-            <p class="row">
-              <%= t('patient.pledge.step_three.clinic_fax') %>:&nbsp;<b><%= clinic_pledge_fax(patient) %></b>
-            </p>
-          <% end %>
-          <p class="row">
-            <%= t('patient.pledge.step_three.fax_service') %>:&nbsp;<%= fax_service %>
+            <%= t('patient.pledge.step_three.clinic_fax') %>:&nbsp;<b><%= clinic_pledge_fax(patient) %></b>
           </p>
         <% end %>
+        <p class="row">
+          <%= t('patient.pledge.step_three.fax_service') %>:&nbsp;<%= fax_service %>
+        </p>
       <% end %>
 
       <p class="row"><strong><%= t('patient.pledge.step_three.completed') %></strong></p>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -36,12 +36,22 @@
         <p class="row"><%= t('patient.pledge.step_three.generated', fund: current_tenant.name) %></p>
         <p class="row">
           <%= t('patient.pledge.step_three.downloads') %>
-          <% if patient.clinic&.email_for_pledges.present? %>
-              <%= clinic_pledge_email(patient) %>
-          <% elsif fax_service.present? %>
-              <%= fax_service %>
-          <% end %>
         </p>
+
+        <% if patient.clinic&.email_for_pledges.present? %>
+          <p class="row">
+            <%= clinic_pledge_email(patient) %>
+          </p>
+        <% else %>
+          <% if patient.clinic&.fax.present? %>
+            <p class="row">
+              Clinic fax:&nbsp;<strong><%= clinic_pledge_fax(patient) %></strong>
+            </p>
+          <% end %>
+          <p class="row">
+            Fax service:&nbsp;<%= fax_service %>
+          </p>
+        <% end %>
       <% end %>
 
       <p class="row"><strong><%= t('patient.pledge.step_three.completed') %></strong></p>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -35,7 +35,12 @@
       <% if current_tenant.pledge_generation_config.present? %>
         <p class="row"><%= t('patient.pledge.step_three.generated', fund: current_tenant.name) %></p>
         <p class="row">
-          <%= t('patient.pledge.step_three.downloads') %> <%= fax_service %>
+          <%= t('patient.pledge.step_three.downloads') %>
+          <% if patient.clinic&.email_for_pledges.present? %>
+              <%= clinic_pledge_email(patient) %>
+          <% elsif fax_service.present? %>
+              <%= fax_service %>
+          <% end %>
         </p>
       <% end %>
 

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -45,11 +45,11 @@
         <% else %>
           <% if patient.clinic&.fax.present? %>
             <p class="row">
-              Clinic fax:&nbsp;<strong><%= clinic_pledge_fax(patient) %></strong>
+              <%= t('patient.pledge.step_three.clinic_fax') %>:&nbsp;<b><%= clinic_pledge_fax(patient) %></b>
             </p>
           <% end %>
           <p class="row">
-            Fax service:&nbsp;<%= fax_service %>
+            <%= t('patient.pledge.step_three.fax_service') %>:&nbsp;<%= fax_service %>
           </p>
         <% end %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
         active: Active
         city: City
         distance: Distance
+        email_for_pledges: Email for Pledges
         fax: Fax
         gestational_limit: Gestational limit (in days)
         location: Location
@@ -125,6 +126,7 @@ en:
       active_help: Are we actively working with this clinic?
       add_clinic: Add clinic
       costs_weeks: Costs at %{week} weeks
+      email_help: Email this clinic uses to receive pledges. If fax preferred, leave this field blank.
       save_changes: Save changes
       zip_help: To exclude this clinic from Clinic Finder searches, give it the ZIP code 99999.
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -462,14 +462,14 @@ en:
         title: 'Confirm the following information is correct:'
       step_three:
         completed: Once you've completed the pledging process, please use the check box below to indicate your pledge has been sent.
-        downloads: 'Your pledge should appear in your computer''s downloads. Find the document and  submit the pledge for your client here:'
+        downloads: 'Your pledge should appear in your computer''s downloads. Find the document and submit the pledge for your client here:'
         generated: Awesome, you generated a %{fund} Pledge! Thanks!
         sent_checkbox: I sent the pledge
         title: 'Submit and send your pledge:'
       step_two:
         blank_name_error: You need to enter your name in the box to sign and download the pledge
         form_disabled: Please generate your pledge form and click next.
-        generate_note: Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the fax to the clinic.
+        generate_note: Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the pledge to the clinic.
         generate_pledge_button: Generate your pledge
         sign_pledge: 'Enter your name in this box to sign your pledge:'
         title: 'Generate your pledge form:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -463,10 +463,11 @@ en:
       step_three:
         clinic_fax: Clinic fax
         completed: Once you've completed the pledging process, please use the check box below to indicate your pledge has been sent.
-        downloads: 'Your pledge should appear in your computer''s downloads. Find the document and submit the pledge for your client here:'
+        downloads: Your pledge should appear in your computer's downloads.
         fax_service: Fax service
         generated: Awesome, you generated a %{fund} Pledge! Thanks!
         sent_checkbox: I sent the pledge
+        submit: 'Submit the pledge for your client here:'
         title: 'Submit and send your pledge:'
       step_two:
         blank_name_error: You need to enter your name in the box to sign and download the pledge

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,8 +461,10 @@ en:
         pledge_amount: 'Pledge amount:'
         title: 'Confirm the following information is correct:'
       step_three:
+        clinic_fax: Clinic fax
         completed: Once you've completed the pledging process, please use the check box below to indicate your pledge has been sent.
         downloads: 'Your pledge should appear in your computer''s downloads. Find the document and submit the pledge for your client here:'
+        fax_service: Fax service
         generated: Awesome, you generated a %{fund} Pledge! Thanks!
         sent_checkbox: I sent the pledge
         title: 'Submit and send your pledge:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -23,6 +23,7 @@ es:
         active: Activo
         city: Ciudad
         distance: Distancia
+        email_for_pledges: Email para promesas
         fax: Fax
         gestational_limit: Límite gestacional (en días)
         location: Ubicación
@@ -125,6 +126,7 @@ es:
       active_help: "¿Estamos trabajando activamente con esta clínica?"
       add_clinic: Añadir clinica
       costs_weeks: Costos en %{week} semanas
+      email_help: Email que esta clínica usa para recibir promesas. Si prefiere fax, deje este campo en blanco.
       save_changes: Guardar cambios
       zip_help: Para excluir esta clínica de las búsquedas de Clinic Finder, dale el código postal 99999.
     index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -469,7 +469,7 @@ es:
       step_two:
         blank_name_error: Debe ingresar su nombre en el cuadro para firmar y descargar la promesa
         form_disabled: Por favor genere el documento de promesa y haga clic en siguiente.
-        generate_note: Tenga en cuenta que esto NO envía su promesa a la clínica! Haga clic en la página siguiente después de generar el documento para indicar que ha enviado el fax a la clínica.
+        generate_note: Tenga en cuenta que esto NO envía su promesa a la clínica! Haga clic en la página siguiente después de generar el documento para indicar que ha enviado la promesa a la clínica.
         generate_pledge_button: Genera la promesa
         sign_pledge: 'Ingrese su nombre en este cuadro para firmar su promesa:'
         title: 'Genere el documento de promesa:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -463,10 +463,11 @@ es:
       step_three:
         clinic_fax: Fax de la clínica
         completed: Una vez que haya completado el proceso de envio, indique aquí que se ha enviado la promesa.
-        downloads: 'Su documento de promesa aparecerá en las descargas de su computadora. Encuentre el documento y envíe la promesa para su cliente aquí:'
+        downloads: Su documento de promesa aparecerá en las descargas de su computadora.
         fax_service: Servicio de fax
         generated: Impresionante, ¡generaste una promesa de %{fund}! ¡Gracias!
         sent_checkbox: Yo envié la promesa
+        submit: 'Envíe la promesa para su cliente aquí:'
         title: 'Descarga y envíe su promesa:'
       step_two:
         blank_name_error: Debe ingresar su nombre en el cuadro para firmar y descargar la promesa

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -461,8 +461,10 @@ es:
         pledge_amount: 'Cantidad de la promesa:'
         title: 'Confirme que la siguiente información es correcta:'
       step_three:
+        clinic_fax: Fax de la clínica
         completed: Una vez que haya completado el proceso de envio, indique aquí que se ha enviado la promesa.
         downloads: 'Su documento de promesa aparecerá en las descargas de su computadora. Encuentre el documento y envíe la promesa para su cliente aquí:'
+        fax_service: Servicio de fax
         generated: Impresionante, ¡generaste una promesa de %{fund}! ¡Gracias!
         sent_checkbox: Yo envié la promesa
         title: 'Descarga y envíe su promesa:'

--- a/db/migrate/20220702015900_add_email_for_pledges_to_clinics.rb
+++ b/db/migrate/20220702015900_add_email_for_pledges_to_clinics.rb
@@ -1,0 +1,5 @@
+class AddEmailForPledgesToClinics < ActiveRecord::Migration[7.0]
+  def change
+    add_column :clinics, :email_for_pledges, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_08_184141) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_02_015900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_08_184141) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
+    t.string "email_for_pledges"
     t.index ["fund_id"], name: "index_clinics_on_fund_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,16 +35,14 @@ fund1 = Fund.create! name: 'SBF',
                      subdomain: 'sandbox',
                      full_name: 'Sand Box Fund',
                      site_domain: 'www.petfinder.com',
-                     phone: '202-452-7464',
-                     pledge_generation_config: 'Test Fund'
+                     phone: '202-452-7464'
 
 fund2 = Fund.create! name: 'CatFund',
                      domain: 'petfinder.com',
                      subdomain: 'catbox',
                      full_name: 'Cat Fund',
                      site_domain: 'www.petfinder.com',
-                     phone: '(281) 330-8004',
-                     pledge_generation_config: 'Test Fund'
+                     phone: '(281) 330-8004'
 
 [fund1, fund2].each do |fund|
   ActsAsTenant.with_tenant(fund) do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,16 +35,16 @@ fund1 = Fund.create! name: 'SBF',
                      subdomain: 'sandbox',
                      full_name: 'Sand Box Fund',
                      site_domain: 'www.petfinder.com',
-                     phone: '202-452-7464'
-
-
+                     phone: '202-452-7464',
+                     pledge_generation_config: 'Test Fund'
 
 fund2 = Fund.create! name: 'CatFund',
                      domain: 'petfinder.com',
                      subdomain: 'catbox',
                      full_name: 'Cat Fund',
                      site_domain: 'www.petfinder.com',
-                     phone: '(281) 330-8004'
+                     phone: '(281) 330-8004',
+                     pledge_generation_config: 'Test Fund'
 
 [fund1, fund2].each do |fund|
   ActsAsTenant.with_tenant(fund) do

--- a/test/helpers/pledges_helper_test.rb
+++ b/test/helpers/pledges_helper_test.rb
@@ -9,4 +9,24 @@ class PledgesHelperTest < ActionView::TestCase
       end
     end
   end
+
+  describe 'contact info methods' do
+    describe 'clinic pledge email' do
+      TEST_EMAIL_ADDRESS = "test.address@example.org"
+      before do
+        @clinic = create :clinic
+        @clinic.email_for_pledges = TEST_EMAIL_ADDRESS
+  
+        @patient = create :patient
+        @patient.clinic = @clinic
+      end
+  
+      it 'should return the email for a clinic, given a patient' do
+        email_link = clinic_pledge_email(@patient)
+        # make sure we generate a link with the mailto href,
+        # and also display the email in the link body.
+        assert_match /href="mailto:#{TEST_EMAIL_ADDRESS}".*>#{TEST_EMAIL_ADDRESS}<\/a>/, email_link
+      end
+    end
+  end
 end

--- a/test/helpers/pledges_helper_test.rb
+++ b/test/helpers/pledges_helper_test.rb
@@ -11,17 +11,26 @@ class PledgesHelperTest < ActionView::TestCase
   end
 
   describe 'contact info methods' do
-    describe 'clinic pledge email' do
-      TEST_EMAIL_ADDRESS = "test.address@example.org"
-      before do
-        @clinic = create :clinic
-        @clinic.email_for_pledges = TEST_EMAIL_ADDRESS
+    before do
+      @clinic = create :clinic
   
-        @patient = create :patient
-        @patient.clinic = @clinic
+      @patient = create :patient
+      @patient.clinic = @clinic
+    end
+
+    it 'should return nil if no email' do
+      assert_nil clinic_pledge_email(@patient)
+    end
+
+    describe 'populated email case' do
+      TEST_EMAIL_ADDRESS = "test.address@example.org"
+      
+      before do
+        @clinic.email_for_pledges = TEST_EMAIL_ADDRESS
+        @clinic.save!
       end
   
-      it 'should return the email for a clinic, given a patient' do
+      it "should a mailto link for the clinic's email, given a patient" do
         email_link = clinic_pledge_email(@patient)
         # make sure we generate a link with the mailto href,
         # and also display the email in the link body.

--- a/test/system/clinic_management_test.rb
+++ b/test/system/clinic_management_test.rb
@@ -105,6 +105,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
     (5..30).each do |i|
       fill_in "Costs at #{i} weeks", with: i
     end
+    fill_in 'Email for Pledges', with: 'pledges@gdqtabaf.net'
     new_clinic_name
   end
 
@@ -122,5 +123,6 @@ class ClinicManagementTest < ApplicationSystemTestCase
     (5..30).each do |i|
       assert has_field? "Costs at #{i} weeks", with: i
     end
+    assert has_field? 'Email for Pledges', with: 'pledges@gdqtabaf.net'
   end
 end

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -40,6 +40,8 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       wait_for_no_element 'Review this preview of your pledge'
 
       assert has_text? 'Awesome, you generated a CATF'
+      # default - no email; show fax
+      assert has_text? fax_service
       check 'I sent the pledge'
       wait_for_ajax
       find('#pledge-next').click
@@ -51,6 +53,25 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_text? Patient::STATUSES[:pledge_sent][:key]
       assert has_link? 'Fulfillment'
       assert has_link? 'Cancel pledge'
+    end
+
+    it 'should show clinic email if exists' do
+      @clinic.email_for_pledges = "pledges@catfund.biz"
+
+      find('#submit-pledge-button').click
+      wait_for_element 'Patient name'
+      assert has_text? 'Confirm the following information is correct'
+      find('#pledge-next').click
+      wait_for_ajax
+
+      wait_for_no_element 'Confirm the following information is correct'
+      assert has_text? 'Generate your pledge form'
+      find('#pledge-next').click
+      wait_for_no_element 'Review this preview of your pledge'
+
+      assert has_text? 'Awesome, you generated a CATF'
+      # now we should see the email
+      assert has_text? "pledges@catfund.biz"
     end
 
     it 'should render after opening call modal' do

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -113,7 +113,7 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_text? 'Confirm the following information is correct'
       find('#pledge-next').click
       wait_for_ajax
-      assert has_content? 'Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the fax to the clinic.'
+      assert has_content? 'Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the pledge to the clinic.'
 
       ActsAsTenant.current_tenant.update pledge_generation_config: nil
       visit edit_patient_path @patient

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -56,33 +56,10 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_link? 'Cancel pledge'
     end
 
-    it 'should render after opening call modal' do
-      click_link 'Call Log'
-      wait_for_element 'Record new call'
-      wait_for_element "Call #{@patient.name} now:"
-
-      find('#submit-pledge-button').click
-      wait_for_element 'Patient name'
-      assert has_text? 'Confirm the following information is correct'
-      find('#pledge-next').click
-      wait_for_ajax
-
-      wait_for_no_element 'Confirm the following information is correct'
-      assert has_text? 'Generate your pledge form'
-    end
-  end
-
-  describe 'clinic contact info' do
-    before do
-      @clinic.email_for_pledges = "pledges@catfund.biz"
-
-      @patient.update pledge_sent: false
-      
-      visit edit_patient_path @patient
-      wait_for_element 'Patient information'
-    end
-
     it 'should show clinic email instead of fax' do
+      @clinic.email_for_pledges = "pledges@catfund.biz"
+      @clinic.save!
+
       find('#submit-pledge-button').click
       wait_for_element 'Patient name'
       assert has_text? 'Confirm the following information is correct'
@@ -96,8 +73,24 @@ class SubmitPledgeTest < ApplicationSystemTestCase
 
       assert has_text? 'Awesome, you generated a CATF'
       # now we should see the email
+      
       assert has_text? "pledges@catfund.biz"
       refute has_text? "Fax service"
+    end
+
+    it 'should render after opening call modal' do
+      click_link 'Call Log'
+      wait_for_element 'Record new call'
+      wait_for_element "Call #{@patient.name} now:"
+
+      find('#submit-pledge-button').click
+      wait_for_element 'Patient name'
+      assert has_text? 'Confirm the following information is correct'
+      find('#pledge-next').click
+      wait_for_ajax
+
+      wait_for_no_element 'Confirm the following information is correct'
+      assert has_text? 'Generate your pledge form'
     end
   end
 

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -27,6 +27,10 @@ class SubmitPledgeTest < ApplicationSystemTestCase
   end
 
   describe 'submitting a pledge' do
+    before do
+      @clinic.fax = "202-867-5309"
+    end
+
     it 'should let you mark a pledge submitted' do
       find('#submit-pledge-button').click
       wait_for_element 'Patient name'
@@ -41,7 +45,7 @@ class SubmitPledgeTest < ApplicationSystemTestCase
 
       assert has_text? 'Awesome, you generated a CATF'
       # default - no email; show fax
-      assert has_text? fax_service
+      assert has_text? "Fax: 202-867-5309"
       check 'I sent the pledge'
       wait_for_ajax
       find('#pledge-next').click

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -1,6 +1,8 @@
 require 'application_system_test_case'
 
 class UpdatePatientInfoTest < ApplicationSystemTestCase
+  extend Minitest::OptionalRetry
+
   before do
     @line = create :line
     @line2 = create :line


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Adds an email field to clinics
* Makes that field editable in the clinic page
* Displays that email on the pledge screen
* If no email, displays the clinic's fax number. If no fax number, just displays the fund's fax service URL.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2528 
 
For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
