### PR TITLE
upgrade html sanitizer for cve-2022-32209

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'figaro' # we handle secrets differently now
 
 # Stuff we're hardsetting because of security concerns
 gem 'loofah', '>= 2.3.1'
-gem 'rails-html-sanitizer', '>= 1.0.4'
+gem 'rails-html-sanitizer', '>= 1.4.3'
 
 group :development do
   gem 'i18n-tasks', '~> 1.0.0' # check and clean i18n keys

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails-i18n (7.0.3)
       i18n (>= 0.7, < 2)
@@ -476,7 +476,7 @@ DEPENDENCIES
   rack-attack (~> 6.6.0)
   rack-test (>= 0.6.3)
   rails (~> 7.0.0)
-  rails-html-sanitizer (>= 1.0.4)
+  rails-html-sanitizer (>= 1.4.3)
   rails-i18n (~> 7.0)
   render_async (~> 2.1)
   rexml


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* upgrades `rails-html-sanitizer`
* (another change here)
* (etc)

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #X
* Bumps #Y

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
