### PR TITLE
#2514 fix bug where it stopped reporting the sum of pledges

### DIFF
--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -166,7 +166,7 @@ module Exportable
   end
 
   def external_pledge_sum
-    external_pledges.inject { |x, acc = 0| acc = x.try(:amount) || 0}
+    external_pledges.sum(:amount)
   end
 
   def all_external_pledges

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -5,6 +5,18 @@ class PatientTest::Exportable < PatientTest
   describe 'export concern methods' do
     before { @patient = create :patient }
 
+    describe "exportable pledges sum" do
+      it "returns 0 if no pledges" do
+        assert_equal @patient.external_pledge_sum, 0
+      end
+
+      it "returns sum of pledges when they exist" do
+        @patient.external_pledges.create attributes_for(:external_pledge, amount: 100)
+        @patient.external_pledges.create attributes_for(:external_pledge, amount: 200)
+        assert_equal @patient.external_pledge_sum, 300
+      end
+    end
+
     describe 'age range tests' do
       it 'should return the right age for numbers' do
         @patient.age = nil


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This fixes a bug where it was returning a list of the external pledges instead of summing up the value. 

previous code before what i think is an oops is:

  sum = 0
    all_pledges = external_pledges.all
    
    all_pledges.each do |pledge|
      sum += pledge.try :amount
    end
    sum

i think right now, given the fact we have amount on external_pledges, we can just lean on the sum function in activerecord. Added tests to account for what i think are the cases, since i think we just deal with USD. 

It relates to the following issue #s: 
* Fixes #2514

For reviewer:

