### PR TITLE
Fixing the JS container, CI, and dev env

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -9,20 +9,20 @@ on:
       - main
 
 jobs:
-  # dockercheck:
-  #   name: Verify docker build
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v3
-  #     - name: Bring up containers
-  #       run: |
-  #         docker-compose build
-  #         docker-compose run --rm web rails db:create db:migrate db:seed
-  #         docker-compose up -d
-  #         sleep 30
-  #         docker-compose logs -t
-  #         docker ps -a | (! grep Exited ) # Return a non-zero exit code if any of the containers are stopped
+  dockercheck:
+    name: Verify docker build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Bring up containers
+        run: |
+          docker-compose build
+          docker-compose run --rm web rails db:create db:migrate db:seed
+          docker-compose up -d
+          sleep 30
+          docker-compose logs -t
+          docker ps -a | (! grep Exited ) # Return a non-zero exit code if any of the containers are stopped
 
   build:
     name: Run tests

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,14 +12,12 @@ If you see a spot in the docs that's confusing or could be improved, please pay 
 
 For the rest of the setup, you have two options: Docker, or installing everything locally. We recommend Docker if you're comfortable with its ecosystem.
 
-## Docker (currently broken)
-
-WARNING: Docker builds are [not currently supported](https://github.com/DARIAEngineering/dcaf_case_management/issues/2606). See the instructions for `Local Environment` setup below.
+## Docker
 
 We've dockerized this app, to manage the dependencies and save us some headache. If you've got [Docker installed already](https://docs.docker.com/engine/installation/), you can be up and running with three commands:
 
 * `docker-compose build # (this may say 'uses an image, skipping' a few times, that's OK)`
-* `docker-compose run --rm web rails db:create db:migrate db:seed # to populate the database`
+* `docker-compose run --rm web rails db:drop db:create db:migrate db:seed # to populate the database`
 * `docker-compose up`
 
 The last command will take a moment and should print a number of things. When it's ready

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "packageManager": "yarn@3.2.2",
   "scripts": {
-    "build": "esbuild ./app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
+    "build": "./node_modules/esbuild/bin/esbuild ./app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
     "build:css": "sass ./app/assets/stylesheets/application.bootstrap.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
   }
 }


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Kicking the js and css commands until:
 - [ ] the bare metal env starts up
 - [x] the docker dev starts up
 - [x] the dev CI passes

Pulling hot reloading into another issue.

This pull request makes the following changes:
* Fix JS container exiting: use the path to the esbuild command - $PATH doesnt know about it in container
* Fix the CI build: the JS fix was the issue here, uncommenting the workflow

It relates to the following issue #s: 
* Bumps #2606 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
