### PR TITLE
Allow staging deploys from branches

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy-staging:


### PR DESCRIPTION
Right now, there is no way to test things on sandbox from a branch on Github. Sometimes, doing a sandbox deploy from a branch is required for stuff like #2694.