### PR TITLE
Don't allow CMs to change fulfillment attributes

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -152,10 +152,12 @@ class PatientsController < ApplicationController
   OTHER_PARAMS = [:shared_flag, :initial_call_date, :pledge_sent].freeze
 
   def patient_params
-    params.require(:patient).permit(
-      [].concat(PATIENT_DASHBOARD_PARAMS, PATIENT_INFORMATION_PARAMS,
-                ABORTION_INFORMATION_PARAMS, OTHER_PARAMS, FULFILLMENT_PARAMS)
+    permitted_params = [].concat(
+      PATIENT_DASHBOARD_PARAMS, PATIENT_INFORMATION_PARAMS,
+      ABORTION_INFORMATION_PARAMS, OTHER_PARAMS
     )
+    permitted_params.concat(FULFILLMENT_PARAMS) if current_user.admin?
+    params.require(:patient).permit(permitted_params)
   end
 
   def render_csv

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -156,7 +156,7 @@ class PatientsController < ApplicationController
       PATIENT_DASHBOARD_PARAMS, PATIENT_INFORMATION_PARAMS,
       ABORTION_INFORMATION_PARAMS, OTHER_PARAMS
     )
-    permitted_params.concat(FULFILLMENT_PARAMS) if current_user.admin?
+    permitted_params.concat(FULFILLMENT_PARAMS) if current_user.allowed_data_access?
     params.require(:patient).permit(permitted_params)
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Prevents CM users (all non-admins, to be accurate) from changing fulfillment attributes.

This pull request makes the following changes:
* Uses strong params to ignore nested `fulfillment_attributes` when creating or updating patients, except for admin users.
* Adds tests on `PatientsController#create` and `#update` to make sure we don't regress.

<!--
(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #X
* Bumps #Y
-->

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
