### PR TITLE
Reset session on password reset

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -319,5 +319,5 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
-  # config.sign_in_after_change_password = true
+  config.sign_in_after_change_password = false
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Signs user out on password change to prevent unauthorized account access when session/password is leaked.

This pull request makes the following changes:
* Flips devise's `config.sign_in_after_change_password` option to `false`. This causes user to be signed out on password change, invalidating the session and redirecting to the sign in page. A message is displayed: "Your account has been updated successfully, but since your password was changed, you need to sign in again.".

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
