### PR TITLE
Refine throttling on password and auth routes

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -30,7 +30,7 @@ class Rack::Attack
   # Throttle all requests by IP (60rpm)
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
-  throttle('req/ip', :limit => 300, :period => 5.minutes) do |req|
+  throttle('req/ip', :limit => 60, :period => 60.seconds) do |req|
     req.ip # unless req.path.start_with?('/assets')
   end
 
@@ -64,6 +64,27 @@ class Rack::Attack
     if req.path == '/users/sign_in' && req.post?
       # return the email if present, nil otherwise
       req.params['user_email'].presence
+    end
+  end
+
+  # Throttle requests to password routes by ip
+  throttle('password/ip', :limit => 5, :period => 20.seconds) do |req|
+    if req.path.start_with?('/users/password')
+      req.ip
+    end
+  end
+
+  # Throttle requests to password routes by email
+  throttle('password/email', :limit => 5, :period => 20.seconds) do |req|
+    if req.path.start_with?('/users/password')
+      req.params['user_email'].presence
+    end
+  end
+
+  # Throttle requests to auth routes by ip
+  throttle('auth/ip', :limit => 5, :period => 20.seconds) do |req|
+    if req.path.start_with?('/users/auth')
+      req.ip
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Sets dedicated rate limits on key authentication and password routes to protect against attacks or spamming. Also narrows window for checking the general ip rate limit.

This pull request makes the following changes:
* Add throttling rules for /users/auth routes and /users/password routes
* Check ip limit every 10 seconds instead of every 5 minutes. The 60rpm limit stays the same, it's just checked more often (10 requests / 10 seconds vs. 300 requests / 300 seconds).
* Clear rails cache between rack-attack tests so we don't have to worry about ips or emails conflicting across tests.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
