### PR TITLE
add tests for hide budget bar functionality

### DIFF
--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -197,6 +197,26 @@ class ConfigTest < ActiveSupport::TestCase
       end
     end
 
+    describe '#hide_budget_bar?' do
+      it 'can return true' do
+        c = Config.find_or_create_by(config_key: 'hide_budget_bar')
+        c.config_value = { options: ["Yes"] }
+        c.save!
+        assert(Config.hide_budget_bar? == true)
+      end
+
+      it 'can return false' do
+        c = Config.find_or_create_by(config_key: 'hide_budget_bar')
+        c.config_value = { options: ["No"] }
+        c.save!
+        assert(Config.hide_budget_bar? == false)
+      end
+
+      it "returns false by default" do
+        assert(Config.hide_budget_bar? == false)
+      end
+    end
+
     describe '#start_day' do
       it 'should return the day of week as a symbol' do
         assert_equal :monday, Config.start_day

--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -203,9 +203,7 @@ class UpdatingConfigsTest < ApplicationSystemTestCase
         fill_in 'config_options_hide_budget_bar', with: 'yes'
         click_button 'Update options for Hide budget bar'
         visit authenticated_root_path
-        within :css, '#overview' do
-          refute has_content? 'Budget for'
-        end
+        refute has_content? 'Budget for'
 
         visit configs_path
         fill_in 'config_options_hide_budget_bar', with: ''

--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -197,5 +197,25 @@ class UpdatingConfigsTest < ApplicationSystemTestCase
         end
       end
     end
+
+    describe 'updating a config - hide budget bar' do
+      it 'should toggle the budget bar on the dashboard' do
+        fill_in 'config_options_hide_budget_bar', with: 'yes'
+        click_button 'Update options for Hide budget bar'
+        visit authenticated_root_path
+        within :css, '#overview' do
+          refute has_content? 'Budget for'
+        end
+
+        visit configs_path
+        fill_in 'config_options_hide_budget_bar', with: ''
+        click_button 'Update options for Hide budget bar'        
+        visit authenticated_root_path
+        within :css, '#overview' do
+          assert has_content? 'Budget for'
+        end
+      end
+
+    end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

fast follow from https://github.com/DARIAEngineering/dcaf_case_management/pull/2696

This pull request makes the following changes:
* add model and system test for hide budget bar functionality

no view changes

It relates to the following issue #s: 
* bumps https://github.com/DARIAEngineering/dcaf_case_management/issues/2688

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
