### PR TITLE
Sanitize strings before exporting csv

### DIFF
--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -157,7 +157,16 @@ module Exportable
     value = public_send(field)
     if value.is_a?(Array)
       # Use simpler serialization for Array values than the default (`to_s`)
-      value.reject(&:blank?).join(', ')
+      sanitize(value.reject(&:blank?).join(', '))
+    else
+      sanitize(value)
+    end
+  end
+
+  def sanitize(value)
+    if value.is_a?(String) && value.start_with?(/\s*[=@+\-\t\r]/)
+      # Escape certain special characters to prevent formula injection.
+      "'#{value}"
     else
       value
     end

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -14,7 +14,8 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
                       name: 'Susie Everyteen',
                       primary_phone: '123-456-7890',
                       other_phone: '333-444-5555',
-                      line: @line
+                      line: @line,
+                      city: '=injected_formula'
     @archived_patient = create :archived_patient,
                                line: @line,
                                initial_call_date: 400.days.ago
@@ -77,6 +78,14 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
       refute_match @patient.name.to_s, response.body
       refute_match @patient.primary_phone.to_s, response.body
       refute_match @patient.other_phone.to_s, response.body
+    end
+
+    it 'should escape fields with attempted formula injection' do
+      sign_in @data_volunteer
+      get patients_path(format: :csv)
+      lines = response.body.split("\n").reject(&:blank?)
+      # A single quote at the beginning indicates it's escaped.
+      assert_match "'=injected_formula", lines[1]
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Escape string fields containing formulas before exporting to prevent [CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection).

* I opted for doing this directly in the export instead adding validation to the individual fields. This way there's no risk of forgetting this validation when a new field is added.
* I found formulas still executing with leading whitespace, so that's why it's included in the regex. Tested the regex with a number of examples with rubular. Included tab and carriage return because they were listed alongside the other formula characters in the OWASP documentation linked above.
* If we wanted to be even more aggressive, the CSV module has an option to force quotes on all fields. That would be more comprehensive but I opted for the more targeted approach because quotes everywhere seems potentially annoying for the CSV user.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
