### PR TITLE
Add validation to ensure numeric fields are not negative

### DIFF
--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -35,6 +35,11 @@ class ArchivedPatient < ApplicationRecord
             presence: true
   validates :appointment_date, format: /\A\d{4}-\d{1,2}-\d{1,2}\z/,
                                allow_blank: true
+  validates :procedure_cost, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
+  validates :fund_pledge,
+            :naf_pledge,
+            :patient_contribution,
+            numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0 }
   validates_associated :fulfillment
 
   # Archive & delete audited patients who called a several months ago, or any

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -35,8 +35,10 @@ class ArchivedPatient < ApplicationRecord
             presence: true
   validates :appointment_date, format: /\A\d{4}-\d{1,2}-\d{1,2}\z/,
                                allow_blank: true
-  validates :procedure_cost, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
-  validates :fund_pledge,
+  validates :last_menstrual_period_weeks,
+            :last_menstrual_period_days,
+            :procedure_cost,
+            :fund_pledge,
             :naf_pledge,
             :patient_contribution,
             numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0 }

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -15,6 +15,20 @@ class Clinic < ApplicationRecord
     where(gestational_limit: nil).or(where(gestational_limit: gestation..))
   }
 
+  # Validations
+  COSTS = [
+    :costs_5wks, :costs_6wks, :costs_7wks, :costs_8wks, :costs_9wks,
+    :costs_10wks, :costs_11wks, :costs_12wks, :costs_13wks, :costs_14wks,
+    :costs_15wks, :costs_16wks, :costs_17wks, :costs_18wks, :costs_19wks,
+    :costs_20wks, :costs_21wks, :costs_22wks, :costs_23wks, :costs_24wks,
+    :costs_25wks, :costs_26wks, :costs_27wks, :costs_28wks, :costs_29wks,
+    :costs_30wks
+  ].freeze
+
+  validates :gestational_limit, *COSTS, numericality: { only_integer: true,
+                                                        allow_nil: true,
+                                                        greater_than_or_equal_to: 0 }
+
   # Callbacks
   before_save :update_coordinates, if: :address_changed?
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,7 +17,7 @@ class Event < ApplicationRecord
   # Validations
   validates :event_type, :cm_name, :patient_name, :patient_id, :line, presence: true
   validates :pledge_amount,
-            presence: true, numericality: { only_integer: true, greater_than: 0 },
+            presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 },
             if: :pledged?
 
   def icon

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,9 @@ class Event < ApplicationRecord
 
   # Validations
   validates :event_type, :cm_name, :patient_name, :patient_id, :line, presence: true
-  validates :pledge_amount, presence: true, if: :pledged?
+  validates :pledge_amount,
+            presence: true, numericality: { only_integer: true, greater_than: 0 },
+            if: :pledged?
 
   def icon
     case event_type

--- a/app/models/external_pledge.rb
+++ b/app/models/external_pledge.rb
@@ -15,5 +15,5 @@ class ExternalPledge < ApplicationRecord
   # Validations
   validates :source, :amount, presence: true
   validates :source, uniqueness: { scope: [:active, :can_pledge] }
-  validates :amount, numericality: { only_integer: true, greater_than: 0 }
+  validates :amount, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/app/models/external_pledge.rb
+++ b/app/models/external_pledge.rb
@@ -15,4 +15,5 @@ class ExternalPledge < ApplicationRecord
   # Validations
   validates :source, :amount, presence: true
   validates :source, uniqueness: { scope: [:active, :can_pledge] }
+  validates :amount, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -9,6 +9,9 @@ class Fulfillment < ApplicationRecord
   # Relationships
   belongs_to :can_fulfill, polymorphic: true
 
+  # Validations
+  validates :fund_payout, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
+
   # Methods
   def gestation_at_procedure_display
     I18n.t('accountants.table_content.weeks_at_procedure_display', gestation: gestation_at_procedure) if gestation_at_procedure.present?

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -10,7 +10,9 @@ class Fulfillment < ApplicationRecord
   belongs_to :can_fulfill, polymorphic: true
 
   # Validations
-  validates :fund_payout, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
+  validates :fund_payout, :gestation_at_procedure, numericality: { only_integer: true,
+                                                                   allow_nil: true,
+                                                                   greater_than_or_equal_to: 0 }
 
   # Methods
   def gestation_at_procedure_display

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -60,8 +60,13 @@ class Patient < ApplicationRecord
                                allow_blank: true
   validate :confirm_appointment_after_initial_call
   validate :pledge_sent, :pledge_info_presence, if: :updating_pledge_sent?
-  validates :procedure_cost, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
-  validates :fund_pledge,
+  validates :last_menstrual_period_weeks,
+            :last_menstrual_period_days,
+            :age,
+            :household_size_children,
+            :household_size_adults,
+            :procedure_cost,
+            :fund_pledge,
             :naf_pledge,
             :patient_contribution,
             numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0 }

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -60,6 +60,11 @@ class Patient < ApplicationRecord
                                allow_blank: true
   validate :confirm_appointment_after_initial_call
   validate :pledge_sent, :pledge_info_presence, if: :updating_pledge_sent?
+  validates :procedure_cost, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
+  validates :fund_pledge,
+            :naf_pledge,
+            :patient_contribution,
+            numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0 }
   validates_associated :fulfillment
 
   # validation for standard US zipcodes


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds validation on numeric fields to ensure negative amounts of money aren't allowed.

Adds validation to the following fields:
* fulfillments
    * fund_payout
* patients
    * fund_pledge
    * naf_pledge
    * patient_contribution
    * procedure_cost
* archived_patients
    * fund_pledge
    * naf_pledge
    * patient_contribution
    * procedure_cost
* external_pledges
    * amount
* events
    * pledge_amount


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
