### PR TITLE
Validate user name format

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,12 @@ class User < ApplicationRecord
   # email presence validated through Devise
   validates_uniqueness_to_tenant :email, allow_blank: true, if: :email_changed?
   validates :name, :role, :email, presence: true
+  validates :name,
+            format: {
+              with: /\A[^0-9`!@#\$%\^&*+_=.\/]*\z/,
+              message: "may not include numbers or the following symbols: `!@#$%^&*+_=./"
+            },
+            if: :name_changed?
   validates_format_of :email, with: Devise::email_regexp
   validate :secure_password, if: :updating_password?
   # i18n-tasks-use t('errors.messages.password.password_strength')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,10 +56,10 @@ fund2 = Fund.create! name: 'CatFund',
     user = User.create! name: 'testuser (admin)', email: 'test@example.com',
                         password: password, password_confirmation: password,
                         role: :admin
-    user2 = User.create! name: 'testuser2', email: 'test2@example.com',
+    user2 = User.create! name: 'testuser two', email: 'test2@example.com',
                          password: password, password_confirmation: password,
                          role: :cm
-    User.create! name: 'testuser3', email: 'test3@example.com',
+    User.create! name: 'testuser three', email: 'test3@example.com',
                  password: password, password_confirmation: password,
                  role: :cm
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -120,6 +120,28 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
       assert_includes response.body, 'can&#39;t be blank'
     end
+
+    it 'should succeed for valid name' do
+      ["Mary-Jane O'Reilly", 'John Smith Jones', 'Renée Dupont'].each do |name|
+        attributes = attributes_for(:user)
+        attributes[:name] = name
+        assert_difference 'User.count', 1 do
+          post users_path, params: { user: attributes }
+        end
+        assert_equal name, User.last.name
+      end
+    end
+
+    it 'should fail with error message for invalid name' do
+      ['wikipedia.org', '*****', 'asdf@email.com'].each do |name|
+        attributes = attributes_for(:user)
+        attributes[:name] = name
+        assert_no_difference 'User.count' do
+          post users_path, params: { user: attributes }
+        end
+        assert_includes response.body, 'may not include numbers or the following symbols'
+      end
+    end
   end
 
   describe 'update method' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Add validation on "name" field for user model.

This pull request makes the following changes:
* Adds regex for validating name format
* Adds a test to ensure we're still allowing valid names with special characters like dashes and accent marks
* Adds a test for notable invalid cases: injecting a website name, accidentally supplying an email address in the name field

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
