### PR TITLE
Auto-assign xmunoz as a reviewer to renovate bot PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "reviewers": ["xmunoz"]
 }


### PR DESCRIPTION
Docs: https://docs.renovatebot.com/configuration-options/#reviewers

This is so I get a notification and can action it in a timely way.