### PR TITLE
Change seed value for fax service

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,7 +92,7 @@ fund2 = Fund.create! name: 'CatFund',
     Config.create config_key: :referred_by,
                   config_value: { options: ['Metal band'] }
     Config.create config_key: :fax_service,
-                  config_value: { options: ['www.yolofax.com'] }
+                  config_value: { options: ['https://www.efax.com'] }
     Config.create config_key: :start_of_week,
                   config_value: { options: ['Monday'] }
 

--- a/test/helpers/footer_helper_test.rb
+++ b/test/helpers/footer_helper_test.rb
@@ -6,8 +6,8 @@ class FooterHelperTest < ActionView::TestCase
   describe 'fax service' do
     it 'should return the config' do
       fax_link_html = fax_service
-      assert_match 'href="https://www.yolofax.com"', fax_link_html
-      assert_match '>https://www.yolofax.com</a>', fax_link_html
+      assert_match 'href="https://www.efax.com"', fax_link_html
+      assert_match '>https://www.efax.com</a>', fax_link_html
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,7 +82,7 @@ class ActiveSupport::TestCase
 
   def create_fax_service_config
     create :config, config_key: 'fax_service',
-                    config_value: { options: ['http://www.yolofax.com'] }
+                    config_value: { options: ['http://www.efax.com'] }
   end
 
   def with_versioning(user = nil)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Changes fax service seed value to the url of a real fax service. I used a fax service url instead of petsfinder because there's no other text in the UI to identify it as the fax service value. I saw efax elsewhere in the code, and I figured using something other than petfinder makes it easier to connect the link in the UI back to its source location in the code when developing/debugging.

Screenshot of development version of site after change:
![image](https://user-images.githubusercontent.com/8826880/199056952-267cbed6-ac26-4aeb-baaa-e25063e2cbc3.png)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
