### PR TITLE
Enable old password checking and session limiting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'activerecord-session_store'
 
 # Our authentication library is devise, with oauth2 for google signin
 gem 'devise', '~> 4.8'
+gem 'devise-security'
 gem 'omniauth-google-oauth2', '~> 1.1.1'
 gem "omniauth-rails_csrf_protection", '~> 1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-security (0.17.0)
+      devise (>= 4.3.0)
     digest (3.1.0)
     docile (1.4.0)
     dotenv (2.7.6)
@@ -453,6 +455,7 @@ DEPENDENCIES
   capybara-screenshot
   cssbundling-rails
   devise (~> 4.8)
+  devise-security
   dotenv-rails
   factory_bot_rails
   faker

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
           :trackable,
           :lockable,
           :timeoutable,
+          :password_archivable,
+          :session_limitable,
           :omniauthable, omniauth_providers: [:google_oauth2]
   # :validatable, # We override this to accommodate tenancy
   # :rememberable

--- a/config/initializers/devise_security.rb
+++ b/config/initializers/devise_security.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+Devise.setup do |config|
+  # ==> Security Extension
+  # Configure security extension for devise
+
+  # Should the password expire (e.g 3.months)
+  # config.expire_password_after = false
+
+  # Need 1 char each of: A-Z, a-z, 0-9, and a punctuation mark or symbol
+  # You may use "digits" in place of "digit" and "symbols" in place of
+  # "symbol" based on your preference
+  # config.password_complexity = { digit: 1, lower: 1, symbol: 1, upper: 1 }
+
+  # How many passwords to keep in archive
+  # config.password_archiving_count = 5
+
+  # Deny old passwords (true, false, number_of_old_passwords_to_check)
+  # Examples:
+  # config.deny_old_passwords = false # allow old passwords
+  # config.deny_old_passwords = true # will deny all the old passwords
+  # config.deny_old_passwords = 3 # will deny new passwords that matches with the last 3 passwords
+  # config.deny_old_passwords = true
+
+  # enable email validation for :secure_validatable. (true, false, validation_options)
+  # dependency: see https://github.com/devise-security/devise-security/blob/master/README.md#e-mail-validation
+  # config.email_validation = true
+
+  # captcha integration for recover form
+  # config.captcha_for_recover = true
+
+  # captcha integration for sign up form
+  # config.captcha_for_sign_up = true
+
+  # captcha integration for sign in form
+  # config.captcha_for_sign_in = true
+
+  # captcha integration for unlock form
+  # config.captcha_for_unlock = true
+
+  # captcha integration for confirmation form
+  # config.captcha_for_confirmation = true
+
+  # Time period for account expiry from last_activity_at
+  # config.expire_after = 90.days
+
+  # Allow password to equal the email
+  # config.allow_passwords_equal_to_email = false
+end

--- a/config/initializers/devise_security.rb
+++ b/config/initializers/devise_security.rb
@@ -13,14 +13,14 @@ Devise.setup do |config|
   # config.password_complexity = { digit: 1, lower: 1, symbol: 1, upper: 1 }
 
   # How many passwords to keep in archive
-  # config.password_archiving_count = 5
+  config.password_archiving_count = 5
 
   # Deny old passwords (true, false, number_of_old_passwords_to_check)
   # Examples:
   # config.deny_old_passwords = false # allow old passwords
   # config.deny_old_passwords = true # will deny all the old passwords
   # config.deny_old_passwords = 3 # will deny new passwords that matches with the last 3 passwords
-  # config.deny_old_passwords = true
+  config.deny_old_passwords = true
 
   # enable email validation for :secure_validatable. (true, false, validation_options)
   # dependency: see https://github.com/devise-security/devise-security/blob/master/README.md#e-mail-validation

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -1,0 +1,42 @@
+en:
+  errors:
+    messages:
+      taken_in_past: 'was used previously.'
+      equal_to_current_password: 'must be different than the current password.'
+      equal_to_email: 'must be different than the email.'
+      password_complexity:
+        digit:
+          one: must contain at least one digit
+          other: must contain at least %{count} digits
+        lower:
+          one: must contain at least one lower-case letter
+          other: must contain at least %{count} lower-case letters
+        symbol:
+          one: must contain at least one punctuation mark or symbol
+          other: must contain at least %{count} punctuation marks or symbols
+        upper:
+          one: must contain at least one upper-case letter
+          other: must contain at least %{count} upper-case letters
+  devise:
+    invalid_captcha: 'The captcha input was invalid.'
+    invalid_security_question: 'The security question answer was invalid.'
+    paranoid_verify:
+      code_required: 'Please enter the code our support team provided'
+    paranoid_verification_code:
+      updated: Verification code accepted
+      show:
+        submit_verification_code: Submit verification code
+        verification_code: Verification code
+        submit: Submit
+    password_expired:
+      updated: 'Your new password is saved.'
+      change_required: 'Your password is expired. Please renew your password.'
+      show:
+        renew_your_password: Renew your password
+        current_password: Current password
+        new_password: New password
+        new_password_confirmation: Confirm new password
+        change_my_password: Change my password
+    failure:
+      session_limited: 'Your login credentials were used in another browser. Please sign in again to continue in this browser.'
+      expired: 'Your account has expired due to inactivity. Please contact the site administrator.'

--- a/config/locales/devise.security_extension.es.yml
+++ b/config/locales/devise.security_extension.es.yml
@@ -1,0 +1,30 @@
+es:
+  errors:
+    messages:
+      taken_in_past: 'la contraseña fue usada previamente, por favor elige otra.'
+      equal_to_current_password: 'tiene que ser diferente a la contraseña actual.'
+      equal_to_email: 'tiene que ser diferente al email'
+      password_complexity:
+        digit:
+          one: tiene que contener al menos un dígito
+          other: tiene que contener al menos %{count} dígitos
+        lower:
+          one: tiene que contener al menos una minúscula
+          other: tiene que contener al menos %{count} minúsculas
+        symbol:
+          one: tiene que contener al menos un signo de puntuación
+          other: tiene que contener al menos %{count} signos de puntuación
+        upper:
+          one: tiene que contener al menos una mayúscula
+          other: tiene que contener al menos %{count} mayúsculas
+  devise:
+    invalid_captcha: 'El captcha ingresado es inválido.'
+    invalid_security_question: 'La respuesta a la pregunta de seguridad fue incorrecta.'
+    paranoid_verify:
+      code_required: 'Por favor ingrese el código provisto por nuestro equipo de soporte'
+    password_expired:
+      updated: 'Su nueva contraseña ha sido guardada.'
+      change_required: 'Su contraseña ha expirado. Por favor renueve su contraseña.'
+    failure:
+      session_limited: 'Sus credenciales de inicio de sesión fueron usadas en otro navegador. Por favor inicie sesión nuevamente para continuar en este navegador.'
+      expired: 'Su cuenta ha expirado debido a inactividad. Por favor contacte al administrador de la aplicación.'

--- a/db/migrate/20221031171553_create_old_passwords.rb
+++ b/db/migrate/20221031171553_create_old_passwords.rb
@@ -1,0 +1,14 @@
+# Creates old_passwords table to support devise-security's :password_archivable module.
+# See https://github.com/devise-security/devise-security#password-archivable
+class CreateOldPasswords < ActiveRecord::Migration[7.0]
+  def change
+    create_table :old_passwords do |t|
+      t.string :encrypted_password, null: false
+      t.string :password_archivable_type, null: false
+      t.integer :password_archivable_id, null: false
+      t.string :password_salt
+      t.datetime :created_at
+    end
+    add_index :old_passwords, [:password_archivable_type, :password_archivable_id], name: 'index_password_archivable'
+  end
+end

--- a/db/migrate/20221031173736_add_unique_session_id_to_users.rb
+++ b/db/migrate/20221031173736_add_unique_session_id_to_users.rb
@@ -1,0 +1,7 @@
+# Add unique_session_id to users to support devise-security :session_limitable module.
+# See https://github.com/devise-security/devise-security#session-limitable
+class AddUniqueSessionIdToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :unique_session_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -229,6 +229,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_02_172033) do
     t.index ["patient_id"], name: "index_notes_on_patient_id"
   end
 
+  create_table "old_passwords", force: :cascade do |t|
+    t.string "encrypted_password", null: false
+    t.string "password_archivable_type", null: false
+    t.integer "password_archivable_id", null: false
+    t.string "password_salt"
+    t.datetime "created_at"
+    t.index ["password_archivable_type", "password_archivable_id"], name: "index_password_archivable"
+  end
+
   create_table "patients", force: :cascade do |t|
     t.string "name", null: false
     t.string "primary_phone", null: false
@@ -354,6 +363,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_02_172033) do
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at", precision: nil
     t.bigint "fund_id"
+    t.string "unique_session_id"
     t.string "session_validity_token"
     t.index ["email", "fund_id"], name: "index_users_on_email_and_fund_id", unique: true
     t.index ["fund_id"], name: "index_users_on_fund_id"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds the [devise-security](https://github.com/devise-security/devise-security#session-limitable) devise extension and enables these modules:
* `:password_archivable` - saves used passwords in an old_passwords table for history checks (prevent reusing passwords)
* `:session_limitable` - ensures that there is only one session usable per account at once

The password functionality requires a new table `old_passwords`, and the session functionality requires a new field in the users table `unique_session_id`. The session field could be a bit confusing since it's separate from the existing `sessions` table, so I added a comment to the migration file adding it that should hopefully clarify why it's there for future readers.

Message after submitting password update form with previously used password:
![image](https://user-images.githubusercontent.com/8826880/199098745-e16c372e-5f1a-4768-ae3a-c7ccb8ee2b77.png)

Message in original browser after logging in as the same user in a different browser:
![image](https://user-images.githubusercontent.com/8826880/199098829-ce50b269-d24a-49ab-bccc-a74aca065309.png)

Fixes issues:
* https://github.com/DARIAEngineering/dcaf_case_management/issues/1460

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
