### PR TITLE
Validate field length on various fields

### DIFF
--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -34,6 +34,8 @@ class Clinic < ApplicationRecord
 
   # Validations
   validates :name, :street_address, :city, :state, :zip, presence: true
+  validates :name, :street_address, :city, :state, :zip, :phone, :fax, :email_for_pledges,
+            length: { maximum: 150 }
   validates_uniqueness_to_tenant :name
 
   # Methods

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -52,6 +52,19 @@ class Config < ApplicationRecord
   }.freeze
 
   VALIDATIONS = {
+    insurance:
+      [:validate_length],
+    external_pledge_source:
+      [:validate_length],
+    pledge_limit_help_text:
+      [:validate_length],
+    practical_support:
+      [:validate_length],
+    referred_by:
+      [:validate_length],
+    voicemail:
+      [:validate_length],
+
     start_of_week:
       [:validate_singleton, :validate_start_of_week],
 
@@ -60,7 +73,7 @@ class Config < ApplicationRecord
 
     budget_bar_max:
       [:validate_singleton, :validate_number],
-    
+
     resources_url:
       [:validate_singleton, :validate_url],
     fax_service:
@@ -74,7 +87,7 @@ class Config < ApplicationRecord
       [:validate_singleton, :validate_patient_archive],
     shared_reset:
       [:validate_singleton, :validate_shared_reset],
-      
+
     hide_budget_bar:
       [:validate_singleton, :validate_yes_or_no],
   }.freeze
@@ -203,11 +216,14 @@ class Config < ApplicationRecord
     def validate_url
       maybe_url = options.last
       return if maybe_url.blank?
-      
+
+      return false unless maybe_url.length <= 300
+
       url = UriService.new(maybe_url).uri
 
       # uriservice returns nil if there's a problem.
       return false if !url
+
 
       config_value['options'] = [url]
       return true
@@ -251,5 +267,14 @@ class Config < ApplicationRecord
 
     def validate_shared_reset
       validate_number && options.last.to_i.between?(SHARED_MIN_DAYS, SHARED_MAX_DAYS)
+    end
+
+    def validate_length
+      total_length = 0
+      options.each do |option|
+        total_length += option.length
+        return false if total_length > 4000
+      end
+      true
     end
 end

--- a/app/models/external_pledge.rb
+++ b/app/models/external_pledge.rb
@@ -14,6 +14,6 @@ class ExternalPledge < ApplicationRecord
 
   # Validations
   validates :source, :amount, presence: true
-  validates :source, uniqueness: { scope: [:active, :can_pledge] }
+  validates :source, uniqueness: { scope: [:active, :can_pledge] }, length: { maximum: 150 }
   validates :amount, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -13,6 +13,7 @@ class Fulfillment < ApplicationRecord
   validates :fund_payout, :gestation_at_procedure, numericality: { only_integer: true,
                                                                    allow_nil: true,
                                                                    greater_than_or_equal_to: 0 }
+  validates :check_number, length: { maximum: 150 }
 
   # Methods
   def gestation_at_procedure_display

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -3,5 +3,5 @@ class Line < ApplicationRecord
 
   # Validations
   validates_uniqueness_to_tenant :name
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 150 }
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -9,5 +9,5 @@ class Note < ApplicationRecord
   belongs_to :patient
 
   # Validations
-  validates :full_text, presence: true
+  validates :full_text, presence: true, length: { maximum: 4000 }
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -44,7 +44,7 @@ class Patient < ApplicationRecord
 
   # Validations
   # Worry about uniqueness to tenant after porting line info.
-  # validates_uniqueness_to_tenant :primary_phone 
+  # validates_uniqueness_to_tenant :primary_phone
   validates :name,
             :primary_phone,
             :initial_call_date,
@@ -70,6 +70,10 @@ class Patient < ApplicationRecord
             :naf_pledge,
             :patient_contribution,
             numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0 }
+  validates :name, :primary_phone, :other_contact, :other_phone, :other_contact_relationship,
+            :voicemail_preference, :language, :pronouns, :city, :state, :county, :zipcode,
+            :race_ethnicity, :employment_status, :insurance, :income, :referred_by, :solidarity_lead,
+            length: { maximum: 150 }
   validates_associated :fulfillment
 
   # validation for standard US zipcodes

--- a/app/models/pledge_config.rb
+++ b/app/models/pledge_config.rb
@@ -6,4 +6,6 @@ class PledgeConfig < ApplicationRecord
                         :phone,
                         :address1,
                         :address2
+  validates :contact_email, :billing_email, :phone, :logo_url, :address1, :address2,
+            length: { maximum: 150 }
 end

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -9,7 +9,7 @@ class PracticalSupport < ApplicationRecord
   belongs_to :can_support, polymorphic: true
 
   # Validations
-  validates :source, :support_type, presence: true
+  validates :source, :support_type, presence: true, length: { maximum: 150 }
   validates :support_type, uniqueness: { scope: :can_support }
   validates :amount, 
               allow_nil: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ApplicationRecord
   validate :secure_password, if: :updating_password?
   # i18n-tasks-use t('errors.messages.password.password_strength')
   validates :password, password_strength: {use_dictionary: true}, if: :updating_password?
+  validates :name, :line, :email, length: { maximum: 150 }
 
   # To accommodate tenancy, we use our own devise validations
   # See https://github.com/heartcombo/devise/blob/master/lib/devise/models/validatable.rb

--- a/test/models/paper_trail_version_test.rb
+++ b/test/models/paper_trail_version_test.rb
@@ -98,7 +98,7 @@ class PaperTrailVersionTest < ActiveSupport::TestCase
       assert_equal 1, @config.versions.count
       assert_difference '@config.versions.count', 1 do
         with_versioning do
-          @config.update config_value: { options: 'Metallica' }
+          @config.update config_value: { options: ['Metallica'] }
         end
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds validation to various fields to protect against huge values being submitted.

This pull request makes the following changes:
* Adds basic max length validations on a number of fields
* Adds length checks on free-input config options
* Adds length checks on special circumstances

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
