### PR TITLE
Logout user on email change

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,6 +41,7 @@ class UsersController < ApplicationController
     # i18n-tasks-use t('activerecord.attributes.user.role')
     if @user.update user_params
       flash[:notice] = t('flash.user_update_success')
+      @user.force_logout if @user.email_previously_changed?
       redirect_to users_path
     else
       error_content = @user.errors.full_messages.to_sentence

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,6 +123,10 @@ class User < ApplicationRecord
         .limit(SEARCH_LIMIT)
   end
 
+  def force_logout
+    update_attribute(:session_validity_token, nil)
+  end
+
   private
 
   def verify_password_complexity

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -294,6 +294,17 @@ Devise.setup do |config|
     manager.failure_app = CustomFailure
   end
 
+  Warden::Manager.after_set_user except: :fetch do |user, warden, opts|
+    user.update_attribute(:session_validity_token, Devise.friendly_token) if user.session_validity_token.nil?
+    warden.raw_session["validity_token"] = user.session_validity_token
+  end
+
+  Warden::Manager.after_fetch do |user, warden, opts|
+    unless user.session_validity_token == warden.raw_session["validity_token"]
+      warden.logout
+    end
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/db/migrate/20221102172033_add_session_validity_token_to_users.rb
+++ b/db/migrate/20221102172033_add_session_validity_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddSessionValidityTokenToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :session_validity_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_27_160232) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_02_172033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -354,6 +354,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_27_160232) do
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at", precision: nil
     t.bigint "fund_id"
+    t.string "session_validity_token"
     t.index ["email", "fund_id"], name: "index_users_on_email_and_fund_id", unique: true
     t.index ["fund_id"], name: "index_users_on_fund_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Logout user when admin changes their email.

This pull request makes the following changes:
* Devise doesn't have options for configuring this out of the box, so this change implements the solution from [this stackoverflow answer](https://stackoverflow.com/a/29214116) instead. Adds a session validation token to the user table, and a method for removing the token on the user. Then calls the method when a user's email is updated to invalidate their session.


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
