### PR TITLE
Prevent locked accounts from accessing user profile

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  prepend_before_action :confirm_user_not_disabled!
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /users/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /users
+  # def update
+  #   super
+  # end
+
+  # GET /users/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  private
+
+  def confirm_user_not_disabled!
+    if current_user&.disabled_by_fund?
+      flash[:danger] = t('flash.account_locked')
+      sign_out current_user
+    end
+  end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,8 +61,8 @@ Rails.application.routes.draw do
   # Auth routes
   root :to => redirect('/users/sign_in')
   as :user do
-    get '/users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'
-    put '/users' => 'devise/registrations#update', as: 'registration'
+    get '/users/edit' => 'users/registrations#edit', as: 'edit_user_registration'
+    put '/users' => 'users/registrations#update', as: 'registration'
   end
 
   match '/404' => 'errors#error_404', via: [:get, :post, :put, :patch]


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds the locked account check to the `/users/edit` and `/users` routes to prevent locked accounts from viewing or updating their user profile.

This pull request makes the following changes:
* used devise controller generator to generate registration controller.
* Added locked account check to newly generated controller

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
