### PR TITLE
household_size_adults/children can legit be -1

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -63,13 +63,12 @@ class Patient < ApplicationRecord
   validates :last_menstrual_period_weeks,
             :last_menstrual_period_days,
             :age,
-            :household_size_children,
-            :household_size_adults,
             :procedure_cost,
             :fund_pledge,
             :naf_pledge,
             :patient_contribution,
             numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0 }
+  validates :household_size_adults, :household_size_children, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: -1 }
   validates :name, :primary_phone, :other_contact, :other_phone, :other_contact_relationship,
             :voicemail_preference, :language, :pronouns, :city, :state, :county, :zipcode,
             :race_ethnicity, :employment_status, :insurance, :income, :referred_by, :solidarity_lead,


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

we validate these differently - -1 means 'prefer not to answer' for these fields

reported by a fund

This pull request makes the following changes:
* allow values of -1 for household_size_adults / household_size_children

no views
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
