### PR TITLE
Budget bar statistics

### DIFF
--- a/app/controllers/concerns/budget_bar_calculable.rb
+++ b/app/controllers/concerns/budget_bar_calculable.rb
@@ -1,11 +1,12 @@
 module BudgetBarCalculable
   extend ActiveSupport::Concern
+  include BudgetBarHelper
 
   def budget_bar_calculations(line)
     expenditures = Patient.pledged_status_summary line
     default_cash_ceiling = Config.budget_bar_max
 
-    cash_spent = expenditures.values.flatten.map { |x| x[:fund_pledge] }.inject(:+) || 0
+    cash_spent = sum_fund_pledges expenditures.values.flatten
     { limit: [default_cash_ceiling, cash_spent].max,
       expenditures: expenditures }
   end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -30,8 +30,6 @@ class DashboardsController < ApplicationController
     # We call these by interpolation in the view; these comments are to let i18n-health know we're using them
     # i18n-tasks-use t('dashboard.budget_bar.pledged_item')
     # i18n-tasks-use t('dashboard.budget_bar.sent_item')
-    # i18n-tasks-use t('dashboard.budget_bar.pledged_report')
-    # i18n-tasks-use t('dashboard.budget_bar.sent_report')
     render partial: 'dashboards/budget_bar',
            locals: budget_bar_calculations(current_line)
   end

--- a/app/helpers/budget_bar_helper.rb
+++ b/app/helpers/budget_bar_helper.rb
@@ -20,7 +20,7 @@ module BudgetBarHelper
   end
 
   def sum_fund_pledges(pledges)
-    total = pledges.map{ |h| h[:fund_pledge] }.inject(:+) || 0
+    total = pledges.map{ |h| h[:fund_pledge] }.sum
     total
   end
 

--- a/app/helpers/budget_bar_helper.rb
+++ b/app/helpers/budget_bar_helper.rb
@@ -32,27 +32,37 @@ module BudgetBarHelper
 
   # we can call the builder directly for `remaining` but use the main function,
   # below, otherwise.
-  def budget_bar_statistic_builder(name, amount, count, limit)
-    formatted_amount = number_to_currency(amount,
+  def budget_bar_statistic_builder(options)
+    formatted_amount = number_to_currency(options[:amount],
                                           precision: 0,
                                           unit: '$',
                                           format: '%u%n')
 
     # if count is nil, don't mention the patients                               
-    if count.present?
-      patient_string = pluralize(count, t('common.patient').downcase) + ", "
+    if options[:count].present?
+      patient_string = pluralize(options[:count], t('common.patient').downcase)
+    end
+
+    if options[:show_aggregate_statistics]
+      # if displaying both, need a comma!
+      if patient_string.present?
+        patient_string += ", "
+      end
+
+      percent_string = "#{to_pct(options[:amount])}%"
     end
 
     # looks like: "$10 spent (4 patients, 10%)"
-    statistic = "#{formatted_amount} #{name} (#{patient_string}#{to_pct(amount)}%)"
+    statistic = "#{formatted_amount} #{options[:name]} (#{patient_string}#{percent_string})"
     statistic
   end
 
-  def budget_bar_statistic(name, expenditure, limit)
-    budget_bar_statistic_builder name,
-                                 sum_fund_pledges(expenditure),
-                                 expenditure.count,
-                                 limit
+  def budget_bar_statistic(name, expenditures, options)
+    budget_bar_statistic_builder name: name,
+                                 amount: sum_fund_pledges(expenditures),
+                                 count: expenditures.count,
+                                 limit: options[:limit],
+                                 show_aggregate_statistics: options[:show_aggregate_statistics]
   end
 
 

--- a/app/helpers/budget_bar_helper.rb
+++ b/app/helpers/budget_bar_helper.rb
@@ -32,37 +32,37 @@ module BudgetBarHelper
 
   # we can call the builder directly for `remaining` but use the main function,
   # below, otherwise.
-  def budget_bar_statistic_builder(options)
-    formatted_amount = number_to_currency(options[:amount],
+  def budget_bar_statistic_builder(name:, amount:, count: nil, limit:, show_aggregate_statistics: true)
+    formatted_amount = number_to_currency(amount,
                                           precision: 0,
                                           unit: '$',
                                           format: '%u%n')
 
     # if count is nil, don't mention the patients                               
-    if options[:count].present?
-      patient_string = pluralize(options[:count], t('common.patient').downcase)
+    if count.present?
+      patient_string = pluralize(count, t('common.patient').downcase)
     end
 
-    if options[:show_aggregate_statistics]
+    if show_aggregate_statistics
       # if displaying both, need a comma!
       if patient_string.present?
         patient_string += ", "
       end
 
-      percent_string = "#{to_pct(options[:amount])}%"
+      percent_string = "#{to_pct(amount)}%"
     end
 
     # looks like: "$10 spent (4 patients, 10%)"
-    statistic = "#{formatted_amount} #{options[:name]} (#{patient_string}#{percent_string})"
+    statistic = "#{formatted_amount} #{name} (#{patient_string}#{percent_string})"
     statistic
   end
 
-  def budget_bar_statistic(name, expenditures, options)
+  def budget_bar_statistic(name, expenditures, limit:, show_aggregate_statistics: true)
     budget_bar_statistic_builder name: name,
                                  amount: sum_fund_pledges(expenditures),
                                  count: expenditures.count,
-                                 limit: options[:limit],
-                                 show_aggregate_statistics: options[:show_aggregate_statistics]
+                                 limit: limit,
+                                 show_aggregate_statistics: show_aggregate_statistics
   end
 
 

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -20,6 +20,7 @@ class Config < ApplicationRecord
     days_to_keep_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year).",
     shared_reset: "Number of idle days until a patient is removed from the shared list. Defaults to 6 days, maximum 6 weeks.",
     hide_budget_bar: 'Enter "yes" to hide the budget bar display.',
+    aggregate_statistics: 'Enter "yes" to show aggregate statistics on the budget bar.'
   }.freeze
 
   enum config_key: {
@@ -40,6 +41,7 @@ class Config < ApplicationRecord
     days_to_keep_all_patients: 14,
     shared_reset: 15,
     hide_budget_bar: 16,
+    aggregate_statistics: 17,
   }
 
   # which fields are URLs (run special validation only on those)
@@ -90,6 +92,8 @@ class Config < ApplicationRecord
 
     hide_budget_bar:
       [:validate_singleton, :validate_yes_or_no],
+    aggregate_statistics:
+      [:validate_singleton, :validate_yes_or_no]
   }.freeze
 
   before_validation :clean_config_value
@@ -157,6 +161,10 @@ class Config < ApplicationRecord
 
   def self.hide_budget_bar?
     Config.find_or_create_by(config_key: 'hide_budget_bar').options.try(:last).to_s =~ /yes/i ? true : false
+  end
+
+  def self.show_aggregate_statistics?
+    Config.find_or_create_by(config_key: 'aggregate_statistics').options.try(:last).to_s =~ /yes/i ? true : false
   end
 
   private

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -16,13 +16,19 @@
 
 <div class="row" id='budget-report'>
   <% expenditures.each_pair do |type, patient_hashes| %>
-    <div class="col-sm-4">
-      <%= t("dashboard.budget_bar.#{type}_report",
-            amount: number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0,
-                                       precision: 0,
-                                       unit: '$',
-                                       format: '%u%n'),
-            count: expenditures[type].count) %>
+    <div class="col-sm-3">
+      <%= budget_bar_statistic(t("dashboard.budget_bar.#{type}"), expenditures[type], limit) %>
     </div>
   <% end %>
+
+  <div class="col-sm-3">
+    <%= budget_bar_statistic(t('dashboard.budget_bar.spent'), expenditures.values.flatten, limit) %>
+  </div>
+
+  <div class="col-sm-3">
+    <%= budget_bar_statistic_builder(t('dashboard.budget_bar.remaining'),
+                                     budget_bar_remaining(expenditures, limit),
+                                     nil,
+                                     limit) %>
+  </div>
 </div>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -26,15 +26,19 @@
 
   <% if Config.show_aggregate_statistics? %>
     <div class="col-sm-3">
-      <%= budget_bar_statistic(t('dashboard.budget_bar.spent'),
-                               expenditures.values.flatten,
-                               limit: limit) %>
+      <strong>
+        <%= budget_bar_statistic(t('dashboard.budget_bar.spent'),
+                                 expenditures.values.flatten,
+                                 limit: limit) %>
+      </strong>
     </div>
 
     <div class="col-sm-3">
-      <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
-                                       amount: budget_bar_remaining(expenditures, limit),
-                                       limit: limit) %>
+      <strong>
+        <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
+                                         amount: budget_bar_remaining(expenditures, limit),
+                                         limit: limit) %>
+      </strong>
     </div>
   <% end %>
 </div>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -17,20 +17,27 @@
 <div class="row" id='budget-report'>
   <% expenditures.each_pair do |type, patient_hashes| %>
     <div class="col-sm-3">
-      <%= budget_bar_statistic(t("dashboard.budget_bar.#{type}"), expenditures[type], limit) %>
+      <%= budget_bar_statistic(t("dashboard.budget_bar.#{type}"),
+                               expenditures[type],
+                               limit: limit,
+                               show_aggregate_statistics: Config.show_aggregate_statistics?) %>
     </div>
   <% end %>
 
   <% if Config.show_aggregate_statistics? %>
     <div class="col-sm-3">
-      <%= budget_bar_statistic(t('dashboard.budget_bar.spent'), expenditures.values.flatten, limit) %>
+      <%= budget_bar_statistic(t('dashboard.budget_bar.spent'),
+                               expenditures.values.flatten,
+                               limit: limit,
+                               show_aggregate_statistics: true) %>
     </div>
 
     <div class="col-sm-3">
-      <%= budget_bar_statistic_builder(t('dashboard.budget_bar.remaining'),
-                                      budget_bar_remaining(expenditures, limit),
-                                      nil,
-                                      limit) %>
+      <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
+                                       amount: budget_bar_remaining(expenditures, limit),
+                                       count: nil,
+                                       limit: limit,
+                                       show_aggregate_statistics: true) %>
     </div>
   <% end %>
 </div>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -28,16 +28,13 @@
     <div class="col-sm-3">
       <%= budget_bar_statistic(t('dashboard.budget_bar.spent'),
                                expenditures.values.flatten,
-                               limit: limit,
-                               show_aggregate_statistics: true) %>
+                               limit: limit) %>
     </div>
 
     <div class="col-sm-3">
       <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
                                        amount: budget_bar_remaining(expenditures, limit),
-                                       count: nil,
-                                       limit: limit,
-                                       show_aggregate_statistics: true) %>
+                                       limit: limit) %>
     </div>
   <% end %>
 </div>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -21,14 +21,16 @@
     </div>
   <% end %>
 
-  <div class="col-sm-3">
-    <%= budget_bar_statistic(t('dashboard.budget_bar.spent'), expenditures.values.flatten, limit) %>
-  </div>
+  <% if Config.show_aggregate_statistics? %>
+    <div class="col-sm-3">
+      <%= budget_bar_statistic(t('dashboard.budget_bar.spent'), expenditures.values.flatten, limit) %>
+    </div>
 
-  <div class="col-sm-3">
-    <%= budget_bar_statistic_builder(t('dashboard.budget_bar.remaining'),
-                                     budget_bar_remaining(expenditures, limit),
-                                     nil,
-                                     limit) %>
-  </div>
+    <div class="col-sm-3">
+      <%= budget_bar_statistic_builder(t('dashboard.budget_bar.remaining'),
+                                      budget_bar_remaining(expenditures, limit),
+                                      nil,
+                                      limit) %>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,12 +192,15 @@ en:
     activity_log:
       label: "%{current_line} Line Activity Log"
     budget_bar:
+      pledged: pledged
       pledged_item: "%{amount} pledged"
       pledged_report: "%{amount} pledged (%{count} patients)"
       pop_content_appt_date: appt on %{date}
       pop_content_no_appt_date: no appt date
+      remaining: remaining
+      sent: sent
       sent_item: "%{amount} sent"
-      sent_report: "%{amount} sent (%{count} patients)"
+      spent: spent
     helpers:
       voicemail_options:
         'no': Do not leave a voicemail

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -200,7 +200,6 @@ es:
       remaining: sobrante
       sent: enviado
       sent_item: "%{amount} enviado"
-      sent_report: "%{amount} enviado (%{count} pacientes)"
       spent: gastado
     helpers:
       voicemail_options:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -192,12 +192,16 @@ es:
     activity_log:
       label: Actividad de línea de llamadas %{current_line}
     budget_bar:
+      pledged: prometido
       pledged_item: "%{amount} prometido"
       pledged_report: "%{amount} prometido (%{count} pacientes)"
       pop_content_appt_date: cita en %{date}
       pop_content_no_appt_date: sin cita
+      remaining: sobrante
+      sent: enviado
       sent_item: "%{amount} enviado"
       sent_report: "%{amount} enviado (%{count} pacientes)"
+      spent: gastado
     helpers:
       voicemail_options:
         'no': No dejen mensajes de voz

--- a/test/helpers/budget_bar_helper_test.rb
+++ b/test/helpers/budget_bar_helper_test.rb
@@ -40,12 +40,36 @@ class BudgetBarHelperTest < ActionView::TestCase
     end
   end
 
-  describe 'budget bar remaining' do
-    before { @expenditures = Patient.pledged_status_summary(:DC) }
+  describe 'budget bar statistics' do
+    before do
+      @expenditures = {
+        :sent =>
+          [{fund_pledge: 10},
+           {fund_pledge: 20}],
+        :pledged =>
+          [{fund_pledge: 40}]
+      }
 
-    it 'should return an int' do
-      assert_equal 1000,
-                   budget_bar_remaining(@expenditures, 1000)
+      @limit = 1000
+    end
+
+    it 'should return an int & calculate remainder' do
+      assert_equal 930,
+                   budget_bar_remaining(@expenditures, @limit)
+    end
+
+    it 'should calculate statistics' do
+      assert_equal "$70 spent (3 patients, 7%)",
+          budget_bar_statistic('spent', @expenditures.values.flatten, 1000)
+    end
+
+    it 'should calculate remainder string' do
+      assert_equal "$930 remaining (93%)",
+          budget_bar_statistic_builder(
+            'remaining',
+            budget_bar_remaining(@expenditures, @limit),
+            nil,
+            @limit)
     end
   end
 end

--- a/test/helpers/budget_bar_helper_test.rb
+++ b/test/helpers/budget_bar_helper_test.rb
@@ -71,5 +71,22 @@ class BudgetBarHelperTest < ActionView::TestCase
             nil,
             @limit)
     end
+
+    it 'should properly sum fund pledges' do
+      # flattened should sum all
+      assert_equal 70, sum_fund_pledges(@expenditures.values.flatten)
+
+      # just one type should only sum that type
+      assert_equal 30, sum_fund_pledges(@expenditures[:sent])
+      assert_equal 40, sum_fund_pledges(@expenditures[:pledged])
+
+      # check nil case - should return 0
+      @expenditures[:sent] = []
+      assert_equal 0, sum_fund_pledges(@expenditures[:sent])
+      assert_equal 40, sum_fund_pledges(@expenditures.values.flatten)
+
+      @expenditures[:pledged] = []
+      assert_equal 0, sum_fund_pledges(@expenditures.values.flatten)
+    end
   end
 end

--- a/test/helpers/budget_bar_helper_test.rb
+++ b/test/helpers/budget_bar_helper_test.rb
@@ -70,9 +70,7 @@ class BudgetBarHelperTest < ActionView::TestCase
           budget_bar_statistic_builder(
             name: 'remaining',
             amount: budget_bar_remaining(@expenditures, @limit),
-            count: nil,
-            limit: @limit,
-            show_aggregate_statistics: true)
+            limit: @limit)
     end
 
     it 'should properly sum fund pledges' do

--- a/test/helpers/budget_bar_helper_test.rb
+++ b/test/helpers/budget_bar_helper_test.rb
@@ -60,16 +60,19 @@ class BudgetBarHelperTest < ActionView::TestCase
 
     it 'should calculate statistics' do
       assert_equal "$70 spent (3 patients, 7%)",
-          budget_bar_statistic('spent', @expenditures.values.flatten, 1000)
+          budget_bar_statistic('spent', @expenditures.values.flatten,
+                               limit: 1000,
+                               show_aggregate_statistics: true)
     end
 
     it 'should calculate remainder string' do
       assert_equal "$930 remaining (93%)",
           budget_bar_statistic_builder(
-            'remaining',
-            budget_bar_remaining(@expenditures, @limit),
-            nil,
-            @limit)
+            name: 'remaining',
+            amount: budget_bar_remaining(@expenditures, @limit),
+            count: nil,
+            limit: @limit,
+            show_aggregate_statistics: true)
     end
 
     it 'should properly sum fund pledges' do

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -112,8 +112,8 @@ class DataEntryTest < ApplicationSystemTestCase
       visit root_path
 
       within :css, '#budget_bar' do
-        assert has_text? "$100 sent (1 patient, 10%)"
-        assert has_text? "$0 pledged (0 patients, 0%)"
+        assert has_text? "$100 sent (1 patient)"
+        assert has_text? "$0 pledged (0 patients)"
         refute has_text? "Susie Everyteen - appt on "
       end
     end
@@ -165,8 +165,8 @@ class DataEntryTest < ApplicationSystemTestCase
       visit root_path
 
       within :css, '#budget_bar' do
-        assert has_text? "$99 sent (1 patient, 10%)"
-        assert has_text? "$0 pledged (0 patients, 0%)"
+        assert has_text? "$99 sent (1 patient)"
+        assert has_text? "$0 pledged (0 patients)"
         refute has_text? "$0 sent"
       end
     end

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -112,8 +112,8 @@ class DataEntryTest < ApplicationSystemTestCase
       visit root_path
 
       within :css, '#budget_bar' do
-        assert has_text? "$100 sent (1 patient)"
-        assert has_text? "$0 pledged (0 patients)"
+        assert has_text? "$100 sent (1 patient, 10%)"
+        assert has_text? "$0 pledged (0 patients, 0%)"
         refute has_text? "Susie Everyteen - appt on "
       end
     end
@@ -165,8 +165,8 @@ class DataEntryTest < ApplicationSystemTestCase
       visit root_path
 
       within :css, '#budget_bar' do
-        assert has_text? "$99 sent (1 patient)"
-        assert has_text? "$0 pledged (0 patients)"
+        assert has_text? "$99 sent (1 patient, 10%)"
+        assert has_text? "$0 pledged (0 patients, 0%)"
         refute has_text? "$0 sent"
       end
     end

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -112,7 +112,7 @@ class DataEntryTest < ApplicationSystemTestCase
       visit root_path
 
       within :css, '#budget_bar' do
-        assert has_text? "$100 sent (1 patients)"
+        assert has_text? "$100 sent (1 patient)"
         assert has_text? "$0 pledged (0 patients)"
         refute has_text? "Susie Everyteen - appt on "
       end
@@ -165,7 +165,7 @@ class DataEntryTest < ApplicationSystemTestCase
       visit root_path
 
       within :css, '#budget_bar' do
-        assert has_text? "$99 sent (1 patients)"
+        assert has_text? "$99 sent (1 patient)"
         assert has_text? "$0 pledged (0 patients)"
         refute has_text? "$0 sent"
       end

--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -213,7 +213,28 @@ class UpdatingConfigsTest < ApplicationSystemTestCase
           assert has_content? 'Budget for'
         end
       end
-
     end
+
+    describe 'updating a config - aggregate statistics' do
+      it 'should toggle aggregate statistics on budget bar' do
+        fill_in 'config_options_aggregate_statistics', with: 'yes'
+        click_button 'Update options for Aggregate statistics'
+        visit authenticated_root_path
+        within :css, "#overview" do
+          assert has_content? "$0 spent (0 patients, 0%)"
+          assert has_content? "$1,000 remaining (100%)"
+        end
+
+        visit configs_path
+        fill_in 'config_options_aggregate_statistics', with: 'no'
+        click_button 'Update options for Aggregate statistics'
+        visit authenticated_root_path
+        within :css, "#overview" do
+          refute has_content? "spent"
+          refute has_content? "remaining"
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* adds statistics to budget bar (spent, remaining, percentages)
* refactors code to make adding more aggregate stats easier (and prevent code duplicate!)

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2658 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
