### PR TITLE
Do not sign in on password reset

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -236,7 +236,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  config.sign_in_after_reset_password = false
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Similar to https://github.com/DARIAEngineering/dcaf_case_management/pull/2708 which signed out the user after a password _change_, this changes to not sign user in after password _reset_.

This pull request makes the following changes:

 Flips devise's config.sign_in_after_reset_password option to false. Displays a message set by devise (changeable [here](https://github.com/DARIAEngineering/dcaf_case_management/blob/96277ff58f9e54395288bcb1548c565ae164b8ca/config/locales/devise.en.yml#L38)): "Your password has been changed successfully."

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
