### PR TITLE
Remove health-checking after staging deploy

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -20,3 +20,4 @@ jobs:
           heroku_email: "xmunoz+heroku@opentechstrategies.com"
           healthcheck: "https://sandbox.dariaservices.com/users/sign_in"
           rollbackonhealthcheckfailed: true
+          delay: 10

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -18,6 +18,3 @@ jobs:
           heroku_api_key: ${{secrets.XMUNOZ_HEROKU_API_KEY}}
           heroku_app_name: "daria-services-staging"
           heroku_email: "xmunoz+heroku@opentechstrategies.com"
-          healthcheck: "https://sandbox.dariaservices.com/users/sign_in"
-          rollbackonhealthcheckfailed: true
-          delay: 10


### PR DESCRIPTION
I think our healthcheck is probably failing because of some of those cloudflare firewall rules that I turned on :shrug: 