### PR TITLE
add currency to practical support in export

### DIFF
--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -3,6 +3,7 @@ require 'csv'
 # Methods pertaining to patient export
 module Exportable
   extend ActiveSupport::Concern
+  include ActionView::Helpers::NumberHelper
 
   CSV_EXPORT_FIELDS = {
     "BSON ID" => :id,
@@ -185,7 +186,14 @@ module Exportable
   end
 
   def all_practical_supports
-    practical_supports.map { |ps| "#{ps.source} - #{ps.support_type} - #{ps.confirmed? ? 'Confirmed' : 'Unconfirmed'}" }.join('; ')
+    shaped_supports = practical_supports.map do |ps|
+      src = ps.source
+      typ = ps.support_type
+      confirmed = ps.confirmed? ? 'Confirmed' : 'Unconfirmed'
+      amt = ps.amount.present? ? number_to_currency(ps.amount) : '$0'
+      "#{src} - #{typ} - #{confirmed} - #{amt}"
+    end
+    shaped_supports.join('; ')
   end
 
   PATIENT_RELATIONS = [:line, :clinic, :fulfillment, :external_pledges, :calls, :practical_supports, :notes]

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -3,9 +3,117 @@ require_relative '../patient_test'
 
 class PatientTest::Exportable < PatientTest
   describe 'export concern methods' do
-    before { @patient = create :patient }
+    before do
+      @patient = create :patient
+      @archived = create :archived_patient
+    end
 
-    describe "exportable pledges sum" do
+    describe 'get_line' do
+      it 'should return the line name' do
+        assert_equal @patient.line.name, @patient.get_line
+      end
+    end
+
+    describe 'fulfilled' do
+      it 'should return fulfillment status' do
+        refute @patient.fulfilled
+        @patient.build_fulfillment(fulfilled: false).save
+        refute @patient.fulfilled
+        @patient.fulfillment.update fulfilled: true
+        assert @patient.fulfilled
+      end
+    end
+
+    describe 'archived?' do
+      it 'should return false if patient' do
+        refute @patient.archived?
+      end
+
+      it 'should return true if archived' do
+        assert @archived.archived?
+      end
+    end
+
+    describe 'household size tests' do
+      # get_household_size_children
+      # get_household_size_adults
+      it 'should return prefer not to answer with -1' do
+        @patient.update household_size_children: -1, household_size_adults: -1
+        assert_equal 'Prefer not to answer', @patient.get_household_size_children
+        assert_equal 'Prefer not to answer', @patient.get_household_size_adults
+      end
+
+      it 'should return number otherwise' do
+        @patient.update household_size_children: 4, household_size_adults: 3
+        assert_equal 4, @patient.get_household_size_children
+        assert_equal 3, @patient.get_household_size_adults
+      end
+
+      it 'should null out for archived patients' do
+        archived = create :archived_patient
+        assert_nil archived.get_household_size_children
+        assert_nil archived.get_household_size_adults
+      end
+    end
+
+    describe 'procedure_date' do
+      raise
+    end
+
+    describe 'gestation_at_procedure' do
+      raise
+    end
+
+    describe 'fund_payout' do
+      raise
+    end
+
+    describe 'check_number' do
+      raise
+    end
+
+    describe 'date_of_check' do
+      raise
+    end
+
+    describe 'first_call_timestamp' do
+      raise
+    end
+
+    describe 'last_call_timestamp' do
+      raise
+    end
+
+    describe 'call_count' do
+      raise
+    end
+
+    describe 'reached_patient_call_count' do
+      raise
+    end
+
+    describe 'export_clinic_name' do
+      raise
+    end
+
+
+    describe 'preferred language tests' do
+      it 'should return the right language' do
+        ['', nil].each do |language|
+          @patient.update language: language
+          assert_equal @patient.preferred_language, 'English'
+        end
+
+        @patient.update language: 'Spanish'
+        assert_equal @patient.preferred_language, 'Spanish'
+      end
+    end
+
+    describe 'external_pledge_count' do
+
+    end
+
+    describe "external_pledge_sum" do
       it "returns 0 if no pledges" do
         assert_equal @patient.external_pledge_sum, 0
       end
@@ -16,6 +124,16 @@ class PatientTest::Exportable < PatientTest
         assert_equal @patient.external_pledge_sum, 300
       end
     end
+
+    describe 'all_external_pledges' do
+      raise
+    end
+
+    describe 'all_practical_supports' do
+      raise
+    end
+
+
 
     describe 'age range tests' do
       it 'should return the right age for numbers' do
@@ -59,35 +177,13 @@ class PatientTest::Exportable < PatientTest
       end
     end
 
-    describe 'preferred language tests' do
-      it 'should return the right language' do
-        ['', nil].each do |language|
-          @patient.update language: language
-          assert_equal @patient.preferred_language, 'English'
-        end
-
-        @patient.update language: 'Spanish'
-        assert_equal @patient.preferred_language, 'Spanish'
-      end
-    end
-
-    describe 'household size tests' do
-      it 'should return prefer not to answer with -1' do
-        @patient.update household_size_children: -1, household_size_adults: -1
-        assert_equal 'Prefer not to answer', @patient.get_household_size_children
-        assert_equal 'Prefer not to answer', @patient.get_household_size_adults
+    describe 'get_field_value_for_serialization' do
+      it 'should clean and handle regular values' do
+        raise
       end
 
-      it 'should return number otherwise' do
-        @patient.update household_size_children: 4, household_size_adults: 3
-        assert_equal 4, @patient.get_household_size_children
-        assert_equal 3, @patient.get_household_size_adults
-      end
-
-      it 'should null out for archived patients' do
-        archived = create :archived_patient
-        assert_nil archived.get_household_size_children
-        assert_nil archived.get_household_size_adults
+      it 'should clean and join arrays' do
+        raise
       end
     end
   end

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -103,11 +103,14 @@ class PatientTest::Exportable < PatientTest
 
     describe 'call related' do
       before do
+        first = @patient.calls.create attributes_for(:call, status: :reached_patient)
+        @patient.calls.create attributes_for(:call, created_at: 3.days.ago, status: :left_voicemail)
+        last = @patient.calls.create attributes_for(:call, status: :left_voicemail)
         @first_call = 5.days.ago
         @last_call = 1.days.ago
-        @patient.calls.create attributes_for(:call, created_at: @first_call, status: :reached_patient)
-        @patient.calls.create attributes_for(:call, created_at: 3.days.ago, status: :left_voicemail)
-        @patient.calls.create attributes_for(:call, created_at: @last_call, status: :left_voicemail)
+        first.update created_at: @first_call
+        last.update created_at: @last_call
+
       end
 
       describe 'first_call_timestamp' do

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -103,14 +103,9 @@ class PatientTest::Exportable < PatientTest
 
     describe 'call related' do
       before do
-        first = @patient.calls.create attributes_for(:call, status: :reached_patient)
+        @patient.calls.create attributes_for(:call, created_at: 5.days.ago, status: :reached_patient)
         @patient.calls.create attributes_for(:call, created_at: 3.days.ago, status: :left_voicemail)
-        last = @patient.calls.create attributes_for(:call, status: :left_voicemail)
-        @first_call = 5.days.ago
-        @last_call = 1.days.ago
-        first.update created_at: @first_call
-        last.update created_at: @last_call
-
+        @patient.calls.create attributes_for(:call, created_at: 1.days.ago, status: :left_voicemail)
       end
 
       describe 'first_call_timestamp' do
@@ -120,7 +115,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should return datetime of first call' do
-          assert_equal @first_call, @patient.first_call_timestamp
+          assert_equal 5.days.ago.to_date, @patient.first_call_timestamp.to_date
         end
       end
   
@@ -131,7 +126,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should return datetime of last call' do
-          assert_equal @first_call, @patient.first_call_timestamp
+          assert_equal 1.days.ago.to_date, @patient.last_call_timestamp.to_date
         end
       end  
 

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -275,7 +275,7 @@ class PatientTest::Exportable < PatientTest
 
   describe 'class methods' do
     describe 'csv_header' do
-      it 'should something' do
+      it 'should generate correctly' do
         assert_equal ::Patient::CSV_EXPORT_FIELDS.keys.join(',') + "\n", Patient.csv_header.to_a[0]
       end
     end

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -49,13 +49,13 @@ class PatientTest::Exportable < PatientTest
     describe 'fulfillments related' do
       before do
         @fulfilled_patient = create :patient
-        create :fulfillment patient: @fulfilled_patient,
-                            fulfilled: true,
-                            procedure_date: 2.days.ago,
-                            gestation_at_procedure: 50,
-                            fund_payout: 30,
-                            check_number: 'A10',
-                            date_of_check: 3.days.ago
+        create :fulfillment, patient: @fulfilled_patient,
+                             fulfilled: true,
+                             procedure_date: 2.days.ago,
+                             gestation_at_procedure: 50,
+                             fund_payout: 30,
+                             check_number: 'A10',
+                             date_of_check: 3.days.ago
       end
 
       describe 'fulfilled' do
@@ -64,10 +64,9 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should return fulfillment status' do
-          @patient.build_fulfillment(fulfilled: false).save
-          assert_nil @patient.fulfilled
-          @patient.fulfillment.update fulfilled: true
-          assert @patient.fulfilled
+          assert @fulfilled_patient.fulfilled
+          @fulfilled_patient.fulfillment.update fulfilled: false
+          refute @fulfilled_patient.fulfilled
         end
       end
 
@@ -77,8 +76,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should show procedure_date when fulfillment is set' do
-          create :fulfillment patient: patient, procedure_date: 2.days.ago
-          assert_equal 2.days.ago.to_date, @patient.procedure_date
+          assert_equal 2.days.ago.to_date, @fulfilled_patient.procedure_date
         end
       end
 
@@ -88,8 +86,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should show gestation_at_procedure when fulfillment is set' do
-          create :fulfillment patient: patient, gestation_at_procedure: 50
-          assert_equal 50, @patient.gestation_at_procedure
+          assert_equal 50, @fulfilled_patient.gestation_at_procedure
         end
       end
 
@@ -99,8 +96,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should show fund_payout when fulfillment is set' do
-          create :fulfillment patient: patient, fund_payout: 50
-          assert_equal 50, @patient.fund_payout
+          assert_equal 50, @fulfilled_patient.fund_payout
         end
       end
 
@@ -110,8 +106,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should show fund_payout when fulfillment is set' do
-          create :fulfillment patient: patient, check_number: 'A20'
-          assert_equal 'A20', @patient.check_number
+          assert_equal 'A20', @fulfilled_patient.check_number
         end
       end
 
@@ -121,8 +116,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         it 'should show date_of_check when fulfillment is set' do
-          create :fulfillment patient: patient, date_of_check: 2.days.ago
-          assert_equal 2.days.ago.to_date, @patient.date_of_check
+          assert_equal 3.days.ago.to_date, @fulfilled_patient.date_of_check
         end
       end
     end
@@ -134,7 +128,6 @@ class PatientTest::Exportable < PatientTest
         create :call, patient: @patient, created_at: @first_call, status: :reached_patient
         create :call, patient: @patient, created_at: 3.days.ago, status: :left_message
         create :call, patient: @patient, created_at: @last_call, status: :left_message
-
       end
 
       describe 'first_call_timestamp' do
@@ -142,6 +135,7 @@ class PatientTest::Exportable < PatientTest
           @patient.calls.destroy_all
           assert_nil @patient.first_call_timestamp
         end
+
         it 'should return datetime of first call' do
           assert_equal @first_call, @patient.first_call_timestamp
         end
@@ -152,16 +146,15 @@ class PatientTest::Exportable < PatientTest
           @patient.calls.destroy_all
           assert_nil @patient.last_call_timestamp
         end
+
         it 'should return datetime of last call' do
           assert_equal @first_call, @patient.first_call_timestamp
-
         end
       end  
 
       describe 'call_count' do
         it 'should return count of calls' do
           raise
-
         end
       end
   
@@ -198,7 +191,14 @@ class PatientTest::Exportable < PatientTest
     
     describe 'external pledge related' do
       describe 'external_pledge_count' do
-        raise
+        it 'should return 0 if no pledges' do
+
+          raise
+        end
+
+        it 'should return count of pledges when they exist' do
+          raise
+        end
       end
 
       describe "external_pledge_sum" do
@@ -214,11 +214,24 @@ class PatientTest::Exportable < PatientTest
       end
 
       describe 'all_external_pledges' do
+        it 'should return nil if no external pledges' do
+          raise
+        end
+
+        it 'should return a joined list of practical supports' do
+          raise
+        end
+      end
+    end
+
+    describe 'all_practical_supports' do
+      it 'should return nil if no practical supports' do
         raise
       end
 
-    describe 'all_practical_supports' do
-      raise
+      it 'should return a joined list of practical supports' do
+        raise
+      end
     end
 
     describe 'age range tests' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adjust export to include practical support money. Default to $0 if not set.

This pull request makes the following changes:
* Add money for practical support entries in CSV export

no view changes, but here's how it shows up in a fresh seed:
```
Counselor - Advice - Unconfirmed - $0; Neighbor - Car rides - Unconfirmed - $0; Donation - Hotel - Unconfirmed - $100.00
```

It relates to the following issue #s: 
* Fixes https://github.com/DARIAEngineering/dcaf_case_management/issues/2747

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
