### PR TITLE
Allow multiple emails in email_for_pledges

### DIFF
--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -49,8 +49,9 @@ class ClinicsController < ApplicationController
 
   def clinic_params
     clinic_params = [:name, :street_address, :city, :state, :zip,
-                     :phone, :fax, :active, :email_for_pledges,
-                     :accepts_naf, :accepts_medicaid, :gestational_limit]
+                     :phone, :fax, :active, :accepts_naf, :accepts_medicaid,
+                     :gestational_limit, :email_for_pledges
+                    ]
     cost_params = (5..30).map { |i| "costs_#{i}wks".to_sym }
 
     params.require(:clinic).permit(

--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -49,9 +49,7 @@ class ClinicsController < ApplicationController
 
   def clinic_params
     clinic_params = [:name, :street_address, :city, :state, :zip,
-                     :phone, :fax, :active, :accepts_naf, :accepts_medicaid,
-                     :gestational_limit, :email_for_pledges
-                    ]
+                     :accepts_naf, :accepts_medicaid, :gestational_limit]
     cost_params = (5..30).map { |i| "costs_#{i}wks".to_sym }
 
     params.require(:clinic).permit(

--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -49,6 +49,7 @@ class ClinicsController < ApplicationController
 
   def clinic_params
     clinic_params = [:name, :street_address, :city, :state, :zip,
+                     :phone, :fax, :active, :email_for_pledges,
                      :accepts_naf, :accepts_medicaid, :gestational_limit]
     cost_params = (5..30).map { |i| "costs_#{i}wks".to_sym }
 

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -34,8 +34,9 @@ class Clinic < ApplicationRecord
 
   # Validations
   validates :name, :street_address, :city, :state, :zip, presence: true
-  validates :name, :street_address, :city, :state, :zip, :phone, :fax, :email_for_pledges,
+  validates :name, :street_address, :city, :state, :zip, :phone, :fax,
             length: { maximum: 150 }
+  validates :email_for_pledges, length: { maximum: 500 }
   validates_uniqueness_to_tenant :name
 
   # Methods

--- a/app/views/clinics/_clinic_form.html.erb
+++ b/app/views/clinics/_clinic_form.html.erb
@@ -12,7 +12,7 @@
       <%= f.text_field :fax,
                        autocomplete: 'off',
                        pattern: "[0-9]{10}|[0-9]{3}\.[0-9]{3}\.[0-9]{4}|[0-9]{3}[-][0-9]{3}[-][0-9]{4}" %>
-      <%= f.email_field :email_for_pledges,
+      <%= f.text_field :email_for_pledges,
                        autocomplete: 'off',
                        help: t('clinics.form.email_help') %>
       <%= f.check_box :accepts_naf,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
       active_help: Are we actively working with this clinic?
       add_clinic: Add clinic
       costs_weeks: Costs at %{week} weeks
-      email_help: Email this clinic uses to receive pledges. If fax preferred, leave this field blank.
+      email_help: Email(s) this clinic uses to receive pledges. If fax preferred, leave this field blank.
       save_changes: Save changes
       zip_help: To exclude this clinic from Clinic Finder searches, give it the ZIP code 99999.
     index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -152,7 +152,7 @@ es:
       active_help: "¿Estamos trabajando activamente con esta clínica?"
       add_clinic: Añadir clinica
       costs_weeks: Costos en %{week} semanas
-      email_help: Email que esta clínica usa para recibir promesas. Si prefiere fax, deje este campo en blanco.
+      email_help: Email(s) que esta clínica usa para recibir promesas. Si prefiere fax, deje este campo en blanco.
       save_changes: Guardar cambios
       zip_help: Para excluir esta clínica de las búsquedas de Clinic Finder, dale el código postal 99999.
     index:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This loosens the email_for_pledges field to allow arbitrary text, to let people punch in multiple emails.

We're giving up email formatting in the frontend in exchange for not doing a lot of complicated multi-element form parsing, which is a pain in the behind. But I think arbitrary text is probably fine here.

This pull request makes the following changes:
* Allow arbitrary text input (max length 500) for Clinic#email_for_pledges
* gentle adjustments around that (i18n)

The change here is that this sorta thing is now allowed, and we aren't doing any enforcement on it besides length. I think that's probably fine, since we aren't actively emailing people out of this system and so it's not Required to be Right.

![image](https://user-images.githubusercontent.com/3866868/209369566-ce1f3ed8-104f-4a9a-9ded-957a34b7456f.png)

It relates to the following issue #s: 
* Fixes #2660

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
