### PR TITLE
Option to hide default options

### DIFF
--- a/app/helpers/external_pledges_helper.rb
+++ b/app/helpers/external_pledges_helper.rb
@@ -16,11 +16,13 @@ module ExternalPledgesHelper
       [ t('external_pledge.sources.clinic_discount'), 'Clinic discount'],
       [ t('external_pledge.sources.other_funds'), 'Other funds (see notes)']
     ]
+
+    funds = external_funds
     unless Config.hide_standard_dropdown?
-      external_funds.push(*standard_options)
+      funds.push(*standard_options)
     end
 
-    external_funds.uniq
+    funds.uniq
   end
 
   def available_pledge_source_options_for(patient)

--- a/app/helpers/external_pledges_helper.rb
+++ b/app/helpers/external_pledges_helper.rb
@@ -18,10 +18,7 @@ module ExternalPledgesHelper
     ]
 
     funds = external_funds
-    unless Config.hide_standard_dropdown?
-      funds.push(*standard_options)
-    end
-
+    funds.push(*standard_options) unless Config.hide_standard_dropdown?
     funds.uniq
   end
 

--- a/app/helpers/external_pledges_helper.rb
+++ b/app/helpers/external_pledges_helper.rb
@@ -16,8 +16,11 @@ module ExternalPledgesHelper
       [ t('external_pledge.sources.clinic_discount'), 'Clinic discount'],
       [ t('external_pledge.sources.other_funds'), 'Other funds (see notes)']
     ]
-    external_funds.push(*standard_options)
-                  .uniq
+    unless Config.hide_standard_dropdown?
+      external_funds.push(*standard_options)
+    end
+
+    external_funds.uniq
   end
 
   def available_pledge_source_options_for(patient)

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -26,6 +26,8 @@ module PatientsHelper
   # TODO how to i18n the Config?
   def language_options(current_value = nil)
     standard_options = [ [t('patient.helper.language.English'),nil] ]
+    # NOTE: don't check hide_standard_dropdown here because we always want
+    # English to be available.
     full_set = standard_options + Config.find_or_create_by(config_key: 'language').options
 
     options_plus_current(full_set, current_value)
@@ -37,7 +39,11 @@ module PatientsHelper
         [t('dashboard.helpers.voicemail_options.no'), 'no'],
         [t('dashboard.helpers.voicemail_options.yes'), 'yes'],
     ]
-    full_set = standard_options + Config.find_or_create_by(config_key: 'voicemail').options
+    full_set = Config.find_or_create_by(config_key: 'voicemail').options
+
+    unless Config.hide_standard_dropdown?
+      full_set.push(*standard_options)
+    end
 
     options_plus_current(full_set, current_value)
   end
@@ -63,7 +69,11 @@ module PatientsHelper
       [ t('patient.helper.referred_by.youth'),                        'Youth outreach' ],
       [ t('common.prefer_not_to_answer'),                             'Prefer not to answer']
     ]
-    full_set = standard_options + Config.find_or_create_by(config_key: 'referred_by').options
+    full_set = Config.find_or_create_by(config_key: 'referred_by').options
+
+    unless Config.hide_standard_dropdown?
+      full_set.push(*standard_options)
+    end
 
     options_plus_current(full_set, current_value)
   end
@@ -87,7 +97,11 @@ module PatientsHelper
       [ t('common.prefer_not_to_answer'), 'Prefer not to answer'],
       [ t('patient.helper.insurance.other'), 'Other (add to notes)' ],
     ]
-    full_set = [nil] + Config.find_or_create_by(config_key: 'insurance').options + standard_options
+    full_set = [nil] + Config.find_or_create_by(config_key: 'insurance').options
+    
+    unless Config.hide_standard_dropdown?
+      full_set.push(*standard_options)
+    end
 
     options_plus_current(full_set, current_value)
   end

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -26,7 +26,7 @@ module PatientsHelper
   # TODO how to i18n the Config?
   def language_options(current_value = nil)
     standard_options = [ [t('patient.helper.language.English'),nil] ]
-    # NOTE: don't check hide_standard_dropdown here because we always want
+    # NOTE: don't check hide_standard_dropdown? here because we always want
     # English to be available.
     full_set = standard_options + Config.find_or_create_by(config_key: 'language').options
 
@@ -41,9 +41,8 @@ module PatientsHelper
     ]
     full_set = Config.find_or_create_by(config_key: 'voicemail').options
 
-    unless Config.hide_standard_dropdown?
-      full_set.push(*standard_options)
-    end
+    # voicemail also exempt from hide_standard_dropdown? config
+    full_set.push(*standard_options)
 
     options_plus_current(full_set, current_value)
   end
@@ -70,10 +69,7 @@ module PatientsHelper
       [ t('common.prefer_not_to_answer'),                             'Prefer not to answer']
     ]
     full_set = Config.find_or_create_by(config_key: 'referred_by').options
-
-    unless Config.hide_standard_dropdown?
-      full_set.push(*standard_options)
-    end
+    full_set.push(*standard_options) unless Config.hide_standard_dropdown?
 
     options_plus_current(full_set, current_value)
   end
@@ -98,10 +94,7 @@ module PatientsHelper
       [ t('patient.helper.insurance.other'), 'Other (add to notes)' ],
     ]
     full_set = [nil] + Config.find_or_create_by(config_key: 'insurance').options
-    
-    unless Config.hide_standard_dropdown?
-      full_set.push(*standard_options)
-    end
+    full_set.push(*standard_options) unless Config.hide_standard_dropdown?
 
     options_plus_current(full_set, current_value)
   end

--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -3,29 +3,41 @@ module PracticalSupportsHelper
   include PatientsHelper
 
   def practical_support_options(current_value = nil)
-    options = [
+    standard_options = [
       nil,
       [ t('patient.helper.practical_support.travel_to_region'), 'Travel to the region' ],
       [ t('patient.helper.practical_support.travel_inside_region'), 'Travel inside the region' ],
       [ t('patient.helper.practical_support.lodging'), 'Lodging' ],
       [ t('patient.helper.practical_support.companion'), 'Companion' ],
-    ] + Config.find_or_create_by(config_key: 'practical_support').options +
-      [
-        [ t('patient.helper.practical_support.other'), 'Other (see notes)' ]
-      ]
+    ]
+
+    options =
+      Config.find_or_create_by(config_key: 'practical_support').options +
+        [
+          [ t('patient.helper.practical_support.other'), 'Other (see notes)' ]
+        ]
+
+    unless Config.hide_standard_dropdown?
+      options.push(*standard_options)
+    end
 
     options_plus_current(options, current_value)
   end
 
   def practical_support_source_options(current_value = nil)
     options = [nil, ActsAsTenant.current_tenant.full_name] +
-      Config.find_or_create_by(config_key: 'external_pledge_source').options +
-      [
-        [ t('common.patient'), 'Patient' ],
-        [ t('common.clinic'), 'Clinic' ],
-        [ t('patient.helper.practical_support.other'), 'Other (see notes)' ],
-        [ t('patient.helper.practical_support.not_sure_yet'), 'Not sure yet (see notes)' ]
-      ]
+      Config.find_or_create_by(config_key: 'external_pledge_source').options
+
+    standard_options = [
+      [ t('common.patient'), 'Patient' ],
+      [ t('common.clinic'), 'Clinic' ],
+      [ t('patient.helper.practical_support.other'), 'Other (see notes)' ],
+      [ t('patient.helper.practical_support.not_sure_yet'), 'Not sure yet (see notes)' ]
+    ]
+
+    unless Config.hide_standard_dropdown?
+      options.push(*standard_options)
+    end
 
     options_plus_current(options, current_value)
   end

--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -17,9 +17,7 @@ module PracticalSupportsHelper
           [ t('patient.helper.practical_support.other'), 'Other (see notes)' ]
         ]
 
-    unless Config.hide_standard_dropdown?
-      options.push(*standard_options)
-    end
+    options.push(*standard_options) unless Config.hide_standard_dropdown?
 
     options_plus_current(options, current_value)
   end
@@ -35,9 +33,7 @@ module PracticalSupportsHelper
       [ t('patient.helper.practical_support.not_sure_yet'), 'Not sure yet (see notes)' ]
     ]
 
-    unless Config.hide_standard_dropdown?
-      options.push(*standard_options)
-    end
+    options.push(*standard_options) unless Config.hide_standard_dropdown?
 
     options_plus_current(options, current_value)
   end

--- a/test/helpers/external_pledges_helper_test.rb
+++ b/test/helpers/external_pledges_helper_test.rb
@@ -36,6 +36,10 @@ class ExternalPledgesHelperTest < ActionView::TestCase
   end
 
   describe 'creating a config object if one does not exist yet' do
+    before do
+      Config.hide_standard_dropdown?
+    end
+
     it 'should do that, with a properly set key' do
       assert_difference 'Config.count', 1 do
         @options = external_pledge_source_options

--- a/test/helpers/external_pledges_helper_test.rb
+++ b/test/helpers/external_pledges_helper_test.rb
@@ -44,7 +44,7 @@ class ExternalPledgesHelperTest < ActionView::TestCase
 
   describe 'creating a config object if one does not exist yet' do
     before do
-      Config.hide_standard_dropdown?
+      create_hide_defaults_config should_hide: false
     end
 
     it 'should do that, with a properly set key' do
@@ -54,7 +54,7 @@ class ExternalPledgesHelperTest < ActionView::TestCase
 
       expected_external_pledges_array = [["Clinic discount", "Clinic discount"],
                                          ["Other funds (see notes)","Other funds (see notes)"]]
-      assert_same_elements @options, expected_external_pledges_array
+      assert_same_elements expected_external_pledges_array, @options
 
       assert Config.find_by(config_key: 'external_pledge_source')
     end

--- a/test/helpers/external_pledges_helper_test.rb
+++ b/test/helpers/external_pledges_helper_test.rb
@@ -33,6 +33,13 @@ class ExternalPledgesHelperTest < ActionView::TestCase
       assert_includes available_pledge_source_options_for(@patient),
                       'Cat Town Abortion Fund (CTAF)'
     end
+
+    it 'should not include defaults if configured' do
+      create_hide_defaults_config
+      assert_same_elements ['Metallica Abortion Fund',
+                            'Texas Amalgamated Abortion Services (TAAS)',
+                            'Cat Town Abortion Fund (CTAF)'], external_pledge_source_options
+    end
   end
 
   describe 'creating a config object if one does not exist yet' do

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -58,7 +58,7 @@ class PatientsHelperTest < ActionView::TestCase
 
     describe 'without a config' do
       before do
-        Config.hide_standard_dropdown?
+        create_hide_defaults_config should_hide: false
       end
       
       it 'should create a config and return proper options' do
@@ -71,7 +71,7 @@ class PatientsHelperTest < ActionView::TestCase
                                    [ 'Don\'t know', 'Don\'t know' ],
                                    [ 'Prefer not to answer', 'Prefer not to answer'],
                                    [ 'Other (add to notes)', 'Other (add to notes)'] ]
-        assert_same_elements @options, expected_insurance_array
+        assert_same_elements expected_insurance_array, @options
         assert Config.find_by(config_key: 'insurance')
       end
     end
@@ -202,12 +202,6 @@ class PatientsHelperTest < ActionView::TestCase
         ]
       assert_same_elements expected_vm_options_array,
                            voicemail_options('ID as coworker')
-    end
-
-    it 'should not include defaults if configured' do
-      create_hide_defaults_config
-
-      assert_same_elements ['Use Codename', 'Only During Business Hours', 'Text Message Only'], voicemail_options
     end
   end
 

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -52,6 +52,10 @@ class PatientsHelperTest < ActionView::TestCase
     end
 
     describe 'without a config' do
+      before do
+        Config.hide_standard_dropdown?
+      end
+      
       it 'should create a config and return proper options' do
         assert_difference 'Config.count', 1 do
           @options = insurance_options

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -49,6 +49,11 @@ class PatientsHelperTest < ActionView::TestCase
         assert_same_elements expected_insurance_options_array,
                              insurance_options('Friendship')
       end
+
+      it 'should not include defaults if configured' do
+        create_hide_defaults_config
+        assert_same_elements [nil, 'DC Medicaid', 'Other state Medicaid'], insurance_options
+      end
     end
 
     describe 'without a config' do
@@ -198,6 +203,12 @@ class PatientsHelperTest < ActionView::TestCase
       assert_same_elements expected_vm_options_array,
                            voicemail_options('ID as coworker')
     end
+
+    it 'should not include defaults if configured' do
+      create_hide_defaults_config
+
+      assert_same_elements ['Use Codename', 'Only During Business Hours', 'Text Message Only'], voicemail_options
+    end
   end
 
   describe 'language_options' do
@@ -260,6 +271,12 @@ class PatientsHelperTest < ActionView::TestCase
       expected_referrals = expected_referrals_base + ['Social Worker']
 
       assert_same_elements expected_referrals, referred_by_options('Social Worker')
+    end
+
+    it 'should not include defaults if configured' do
+      create_hide_defaults_config
+
+      assert_same_elements ['Metal band'], referred_by_options
     end
   end
 

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -21,6 +21,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
     end
 
     describe 'without a config' do
+      before do
+        Config.hide_standard_dropdown?
+      end
+
       it 'should create a config and return proper options' do
         assert_difference 'Config.count', 1 do
           @options = practical_support_options
@@ -76,6 +80,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
     end
 
     describe 'without a config' do
+      before do
+        Config.hide_standard_dropdown?
+      end
+      
       it 'should create a config and return options' do
         assert_difference 'Config.count', 1 do
           @options = practical_support_source_options

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -18,6 +18,14 @@ class PracticalSupportsHelperTest < ActionView::TestCase
         ]
         assert_same_elements expected, practical_support_options
       end
+
+      it 'should not include defaults if configured' do
+        create_hide_defaults_config
+
+        expected_custom_options = ['Metallica Tickets', 'Clothing',
+                                    ['Other (see notes)', 'Other (see notes)']]
+        assert_same_elements expected_custom_options, practical_support_options
+      end
     end
 
     describe 'without a config' do
@@ -76,6 +84,13 @@ class PracticalSupportsHelperTest < ActionView::TestCase
           ['Not sure yet (see notes)', 'Not sure yet (see notes)']
         ]
         assert_same_elements expected, practical_support_source_options
+      end
+
+      it 'should not include defaults if configured' do
+        create_hide_defaults_config
+        assert_same_elements [nil, 'Cat Fund', 'Metallica Abortion Fund',
+                              'Texas Amalgamated Abortion Services (TAAS)',
+                              'Cat Town Abortion Fund (CTAF)'], practical_support_source_options
       end
     end
 

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -30,7 +30,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
 
     describe 'without a config' do
       before do
-        Config.hide_standard_dropdown?
+        create_hide_defaults_config should_hide: false
       end
 
       it 'should create a config and return proper options' do
@@ -96,7 +96,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
 
     describe 'without a config' do
       before do
-        Config.hide_standard_dropdown?
+        create_hide_defaults_config should_hide: false
       end
       
       it 'should create a config and return options' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,9 +85,9 @@ class ActiveSupport::TestCase
                     config_value: { options: ['http://www.efax.com'] }
   end
 
-  def create_hide_defaults_config
+  def create_hide_defaults_config(should_hide: true)
     c = Config.find_or_create_by(config_key: 'hide_standard_dropdown_values')
-    c.config_value = { options: ['yes'] }
+    c.config_value = { options: [should_hide ? 'yes' : 'no']}
     c.save!
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,6 +85,12 @@ class ActiveSupport::TestCase
                     config_value: { options: ['http://www.efax.com'] }
   end
 
+  def create_hide_defaults_config
+    c = Config.find_or_create_by(config_key: 'hide_standard_dropdown_values')
+    c.config_value = { options: ['yes'] }
+    c.save!
+  end
+
   def with_versioning(user = nil)
     was_enabled = PaperTrail.enabled?
     was_enabled_for_request = PaperTrail.request.enabled?


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* adds a config to hide standard options for the requested fields
* adds tests

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2717 
* Bumps #Y

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
