### PR TITLE
add in-app reporting

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,5 @@
+class ReportsController < ApplicationController
+  before_action :confirm_admin_user
+
+  def index; end
+end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,2 +1,5 @@
 module ReportsHelper
+  def report_url
+    "https://datastudio.google.com/embed/reporting/#{ENV.fetch('DATASTUDIO_REPORT_URL', '')}"
+  end
 end

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -20,6 +20,7 @@
         <%= link_to t('navigation.admin_tools.config_management'), configs_path, class: 'dropdown-item' %>
       <% end %>
       <%= link_to t('navigation.admin_tools.accounting'), accountants_path, class: 'dropdown-item' %>
+      <%= link_to t('navigation.admin_tools.reports'), reports_path, class: 'dropdown-item' %>
       <%= link_to t('navigation.admin_tools.export'), patients_path(format: :csv), class: 'dropdown-item' %>
     </div>
   </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Reporting</h1>
+
+<div class="col">
+  <iframe width="100%" height="600" src="<%= report_url %>" frameborder="0" style="border:0" allowfullscreen></iframe>
+</div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Reporting</h1>
+<h1><%= t 'navigation.admin_tools.reports' %></h1>
 
 <div class="col">
   <iframe width="100%" height="600" src="<%= report_url %>" frameborder="0" style="border:0" allowfullscreen></iframe>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,6 +305,7 @@ en:
       config_management: Config Management
       export: Export anonymized CSV
       label: Admin
+      reports: Reporting Dashboard
       user_management: User Management
     cm_resources:
       label: CM Resources

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -305,6 +305,7 @@ es:
       config_management: Manejo de Configuración
       export: Exportación anónima de CSV
       label: Administración
+      reports: Panel de Informes
       user_management: Manejo de Usuarios
     cm_resources:
       label: Recursos del Administrador de Casos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
     resources :clinics, only: [:index, :create, :update, :new, :destroy, :edit]
     resources :configs, only: [:index, :create, :update]
     resources :events, only: [:index]
+    resources :reports, only: [:index]
   end
 
   # Auth routes

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+# Tests for reports controller
+class ReportsControllerTest < ActionDispatch::IntegrationTest
+  describe 'index' do
+    it 'should render if admin' do
+      sign_in create :user, role: :admin
+      get reports_path
+      assert_response :success
+    end
+
+    it 'should deny if not' do
+      sign_in create :user, role: :cm
+      get reports_path
+      assert_redirected_to root_url
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

add an in app reporting utility
will need to work thru the permissioning, but this sets this up to run off an env var. (Hopefully other stuff will be handle-able by datastudio)

This pull request makes the following changes:
* Adds a pre-fab data studio report

early stub of the report: 

<img width="1409" alt="image" src="https://user-images.githubusercontent.com/3866868/211219254-d516509c-a540-4a03-b0a3-060b52c9df67.png">

It relates to the following issue #s: 
* Bumps #634 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
