### PR TITLE
Add Multi Factor Authentication with SMS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,12 @@ gem 'rack-attack', '~> 6.6.0'
 # For pagination
 gem 'kaminari', '~> 1.2'
 
+# For multi-step forms
+gem 'wicked'
+
+# Twilio Verify
+gem 'twilio-ruby'
+
 # Specific useful stuff
 gem 'render_async', '~> 2.1' # load slow partials asynchronously
 gem 'prawn' # pledge pdf generation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,6 +398,10 @@ GEM
     timecop (0.9.6)
     timeout (0.3.1)
     ttfunk (1.7.0)
+    twilio-ruby (5.74.1)
+      faraday (>= 0.9, < 3.0)
+      jwt (>= 1.5, <= 2.6)
+      nokogiri (>= 1.6, < 2.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.7)
@@ -415,6 +419,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wicked (2.0.0)
+      railties (>= 3.0.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.6)
@@ -487,8 +493,10 @@ DEPENDENCIES
   state_geo_tools
   strong_password (~> 0.0.10)
   timecop
+  twilio-ruby
   tzinfo-data
   webdrivers
+  wicked
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/app/controllers/auth_factor_steps_controller.rb
+++ b/app/controllers/auth_factor_steps_controller.rb
@@ -35,7 +35,7 @@ class AuthFactorStepsController < ApplicationController
       @client.send_sms_verification_code(auth_factor_params[:phone])
       return render_wizard @auth_factor
     rescue StandardError => e
-      flash.now[:alert] = "There was a problem sending the verification code: #{e.message}"
+      flash.now[:alert] = t('multi_factor.sending_sms_code_failed', error: e.message)
     end
     render_wizard
   end
@@ -44,12 +44,12 @@ class AuthFactorStepsController < ApplicationController
     begin
       status = @client.check_sms_verification_code(@auth_factor.phone, auth_factor_params[:code])
     rescue StandardError => e
-      flash.now[:alert] = "There was a problem checking the verification code: #{e.message}"
+      flash.now[:alert] = t('multi_factor.checking_sms_code_failed', error: e.message)
       return render_wizard
     end
 
     unless status == 'approved'
-      flash.now[:alert] = 'invalid code'
+      flash.now[:alert] = t('multi_factor.code_invalid')
       return render_wizard
     end
 
@@ -65,6 +65,6 @@ class AuthFactorStepsController < ApplicationController
                            when :verification
                              [:code]
                            end
-    params.require(:auth_factor).permit(permitted_attributes).merge(form_step: step.to_sym)
+    params.require(:auth_factor).permit(permitted_attributes).merge(current_form_step: step.to_sym)
   end
 end

--- a/app/controllers/auth_factor_steps_controller.rb
+++ b/app/controllers/auth_factor_steps_controller.rb
@@ -1,5 +1,3 @@
-require_relative '../lib/api_clients/twilio_verify_client'
-
 # Controls steps for registering a new authentication factor.
 class AuthFactorStepsController < ApplicationController
   include Wicked::Wizard

--- a/app/controllers/auth_factor_steps_controller.rb
+++ b/app/controllers/auth_factor_steps_controller.rb
@@ -1,0 +1,72 @@
+require_relative '../lib/api_clients/twilio_verify_client'
+
+# Controls steps for registering a new authentication factor.
+class AuthFactorStepsController < ApplicationController
+  include Wicked::Wizard
+
+  steps(*AuthFactor.form_steps)
+
+  def show
+    @auth_factor = AuthFactor.find(session[:auth_factor_id])
+    render_wizard
+  end
+
+  def update
+    @auth_factor = AuthFactor.find(session[:auth_factor_id])
+    @client = TwilioVerifyClient.new
+    case step
+    when :registration
+      register
+    when :verification
+      verify
+    end
+  end
+
+  def finish_wizard_path
+    session[:auth_factor_id] = nil
+    edit_user_registration_path
+  end
+
+  private
+
+  def register
+    @auth_factor.assign_attributes(auth_factor_params)
+    return render_wizard unless @auth_factor.valid?
+
+    begin
+      @client.send_sms_verification_code(auth_factor_params[:phone])
+      return render_wizard @auth_factor
+    rescue StandardError => e
+      flash.now[:alert] = "There was a problem sending the verification code: #{e.message}"
+    end
+    render_wizard
+  end
+
+  def verify
+    begin
+      status = @client.check_sms_verification_code(@auth_factor.phone, auth_factor_params[:code])
+    rescue StandardError => e
+      flash.now[:alert] = "There was a problem checking the verification code: #{e.message}"
+      return render_wizard
+    end
+
+    unless status == 'approved'
+      flash.now[:alert] = 'invalid code'
+      return render_wizard
+    end
+
+    @auth_factor.enabled = true
+    @auth_factor.registration_complete = true
+    render_wizard @auth_factor
+  end
+
+  def auth_factor_params
+    permitted_attributes = case step
+                           when :registration
+                             [:phone, :name]
+                           when :verification
+                             [:code]
+                           end
+    params.require(:auth_factor).permit(permitted_attributes).merge(form_step: step.to_sym)
+  end
+end

--- a/app/controllers/auth_factors_controller.rb
+++ b/app/controllers/auth_factors_controller.rb
@@ -1,0 +1,21 @@
+class AuthFactorsController < ApplicationController
+  # Initializes an auth_factor then hands off to the AuthFactorStepsController
+  # which handles the multi-step registration process.
+  def new
+    auth_factor_id = session[:auth_factor_id]
+    unless auth_factor_id
+      @auth_factor = AuthFactor.new
+      @auth_factor.user = current_user
+      @auth_factor.channel = 'sms'
+      @auth_factor.save! validate: false
+      session[:auth_factor_id] = @auth_factor.id
+    end
+    redirect_to build_auth_factor_path(AuthFactor.form_steps.first)
+  end
+
+  def destroy
+    @auth_factor = AuthFactor.find params[:id]
+    @auth_factor.destroy
+    redirect_to edit_user_registration_path
+  end
+end

--- a/app/controllers/multi_factor_authentication_controller.rb
+++ b/app/controllers/multi_factor_authentication_controller.rb
@@ -1,0 +1,102 @@
+require_relative '../lib/api_clients/twilio_verify_client'
+
+# Controls steps for logging in a user with two factor authentication.
+class MultiFactorAuthenticationController < ApplicationController
+  include Wicked::Wizard
+
+  steps :factor_select, :verification
+
+  skip_before_action :authenticate_user!, :confirm_user_not_disabled!
+
+  def show
+    case step
+    when :factor_select
+      user = User.find_by(id: session.dig(:mfa, :user_id))
+      return redirect_to new_user_session_path, error: 'Authentication error' unless user
+
+      @auth_factors = user.auth_factors.select(&:enabled?)
+    when :verification
+      @auth_factor = AuthFactor.find(session[:auth_factor_id])
+    end
+    render_wizard
+  end
+
+  def update
+    @client = TwilioVerifyClient.new
+    case step
+    when :factor_select
+      send_verification_code
+    when :verification
+      verify_code
+    end
+  end
+
+  private
+
+  def send_verification_code
+    # Needs the list of auth factors to populate the dropdown in the
+    # case of an error where we have to re-render factor select.
+    user = User.find(session[:mfa][:user_id])
+    @auth_factors = user.auth_factors.select(&:enabled?)
+
+    auth_factor_id = mfa_params[:auth_factor_id]
+    auth_factor = AuthFactor.find(auth_factor_id)
+
+    # Populate session with the selected auth factor id so we know
+    # which factor to verify in the next step.
+    session[:auth_factor_id] = auth_factor_id
+
+    begin
+      @client.send_sms_verification_code(auth_factor.phone)
+
+      # Not really skipping a step. This just ensures we go to the next step when
+      # we call render_wizard below instead of staying at the current step.
+      skip_step
+    rescue StandardError => e
+      flash.now[:alert] = "There was a problem sending the verification code: #{e.message}"
+    end
+    render_wizard
+  end
+
+  def verify_code
+    @auth_factor = AuthFactor.find(session[:auth_factor_id])
+    begin
+      status = @client.check_sms_verification_code(@auth_factor.phone, mfa_params[:code])
+    rescue StandardError => e
+      flash.now[:alert] = "There was a problem checking the verification code: #{e.message}"
+      return render_wizard
+    end
+
+    unless status == 'approved'
+      flash.now[:alert] = 'invalid code'
+      return render_wizard
+    end
+
+    sign_in_user
+  end
+
+  def mfa_params
+    permitted_attributes = case step
+                           when :factor_select
+                             [:auth_factor_id]
+                           when :verification
+                             [:code]
+                           end
+    params.permit(permitted_attributes)
+  end
+
+  def sign_in_user
+    user = User.find(session[:mfa][:user_id])
+
+    sign_in(:user, user)
+
+    user.remember_me! if session[:mfa][:remember_me]
+
+    flash[:notice] = 'Login with MFA successful!'
+    session.delete(:auth_factor_id)
+    session.delete(:mfa)
+
+    redirect = stored_location_for(user) || root_url
+    redirect_to redirect
+  end
+end

--- a/app/controllers/multi_factor_authentication_controller.rb
+++ b/app/controllers/multi_factor_authentication_controller.rb
@@ -1,5 +1,3 @@
-require_relative '../lib/api_clients/twilio_verify_client'
-
 # Controls steps for logging in a user with two factor authentication.
 class MultiFactorAuthenticationController < ApplicationController
   include Wicked::Wizard

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  def new
+    session.delete(:mfa)
+    super
+  end
+
+  def create
+    self.resource = warden.authenticate!(auth_options)
+
+    if multi_factor_enabled?
+      # preserve the stored location
+      stored_location = stored_location_for(resource)
+
+      # log out the user (this will also clear stored location)
+      warden.logout
+
+      # restore the stored location
+      store_location_for(resource, stored_location)
+
+      session[:mfa] = { user_id: resource.id, remember_me: params[:user][:remember_me] == '1' }
+
+      redirect_to multi_factor_authentication_path(:factor_select)
+    else
+      # continue without mfa
+      set_flash_message!(:notice, :signed_in)
+      sign_in(resource_name, resource)
+      yield resource if block_given?
+      respond_with resource, location: after_sign_in_path_for(resource)
+    end
+  end
+
+  private
+
+  def multi_factor_enabled?
+    current_user.auth_factors.any?(&:enabled?)
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -19,7 +19,7 @@ class Users::SessionsController < Devise::SessionsController
       # restore the stored location
       store_location_for(resource, stored_location)
 
-      session[:mfa] = { user_id: resource.id, remember_me: params[:user][:remember_me] == '1' }
+      session[:mfa] = { user_id: resource.id }
 
       redirect_to multi_factor_authentication_path(:factor_select)
     else

--- a/app/lib/api_clients/twilio_verify_client.rb
+++ b/app/lib/api_clients/twilio_verify_client.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'twilio-ruby'
+
+# Help: https://www.twilio.com/docs/verify/quickstarts/totp
+class TwilioVerifyClient
+  TWILIO_ACCOUNT_SID = ENV['TWILIO_ACCOUNT_SID']
+  TWILIO_AUTH_TOKEN = ENV['TWILIO_AUTH_TOKEN']
+  TWILIO_SMS_SERVICE = ENV['TWILIO_SMS_SERVICE']
+
+  def initialize
+    @client = Twilio::REST::Client.new(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+  end
+
+  def send_sms_verification_code(phone_number)
+    verification = @client.verify
+                          .v2
+                          .services(TWILIO_SMS_SERVICE)
+                          .verifications
+                          .create(to: "+1#{phone_number}", channel: 'sms')
+
+    verification.status
+  end
+
+  def check_sms_verification_code(phone_number, code)
+    verification_check = @client.verify
+                                .v2
+                                .services(TWILIO_SMS_SERVICE)
+                                .verification_checks
+                                .create(to: "+1#{phone_number}", code: code)
+
+    verification_check.status
+  end
+end

--- a/app/lib/twilio_verify_client.rb
+++ b/app/lib/twilio_verify_client.rb
@@ -5,6 +5,7 @@ require 'twilio-ruby'
 
 # Help: https://www.twilio.com/docs/verify/quickstarts/totp
 class TwilioVerifyClient
+  # For development these values can be found in the Twilio Console at https://console.twilio.com.
   TWILIO_ACCOUNT_SID = ENV['TWILIO_ACCOUNT_SID']
   TWILIO_AUTH_TOKEN = ENV['TWILIO_AUTH_TOKEN']
   TWILIO_SMS_SERVICE = ENV['TWILIO_SMS_SERVICE']

--- a/app/models/auth_factor.rb
+++ b/app/models/auth_factor.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# An authentication factor used for two factor authentication.
+class AuthFactor < ApplicationRecord
+  include PaperTrailable
+
+  cattr_accessor :form_steps do
+    [:registration, :verification, :confirmation]
+  end
+  attr_accessor :form_step
+
+  before_validation :clean_fields
+
+  belongs_to :user
+
+  CHANNELS = [
+    SMS = 'sms'
+  ].freeze
+
+  CHANNELS.each do |channel|
+    scope channel, -> { where(channel: channel) }
+  end
+
+  validates :channel, presence: true, inclusion: { in: CHANNELS }
+
+  with_options if: -> { required_for_step?(:registration) } do
+    validates :name, presence: true, uniqueness: { scope: :user_id }, length: { maximum: 30 }
+    validates :phone, presence: true, format: /\A\d{10}\z/, length: { is: 10 }
+  end
+
+  private
+
+  def clean_fields
+    phone&.gsub!(/\D/, '')
+    name&.strip!
+  end
+
+  def required_for_step?(step)
+    # All fields are required if no form step is present
+    return true if form_step.nil?
+
+    # All fields from previous steps are required if the
+    # step parameter appears before or we are on the current step
+    return true if form_steps.index(step) <= form_steps.index(form_step)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User < ApplicationRecord
 
   # Relationships
   has_many :call_list_entries
+  has_many :auth_factors, dependent: :destroy
   belongs_to :line, optional: true
 
   # Validations

--- a/app/views/auth_factor_steps/confirmation.html.erb
+++ b/app/views/auth_factor_steps/confirmation.html.erb
@@ -1,0 +1,5 @@
+<div class='authform'>
+  <h3>New SMS Authentication Factor Registered: <%= @auth_factor.name %></h3>
+  <p>New authentication factor successfully registered!</p>
+  <%= button_to('Next', next_wizard_path, method: :get, class: 'btn btn-primary') %>
+</div>

--- a/app/views/auth_factor_steps/confirmation.html.erb
+++ b/app/views/auth_factor_steps/confirmation.html.erb
@@ -1,5 +1,5 @@
 <div class='authform'>
-  <h3>New SMS Authentication Factor Registered: <%= @auth_factor.name %></h3>
-  <p>New authentication factor successfully registered!</p>
-  <%= button_to('Next', next_wizard_path, method: :get, class: 'btn btn-primary') %>
+  <h3><%= t 'multi_factor.confirmation.heading', name: @auth_factor.name %></h3>
+  <p><%= t 'multi_factor.confirmation.message' %></p>
+  <%= button_to t('multi_factor.next'), next_wizard_path, method: :get, class: 'btn btn-primary' %>
 </div>

--- a/app/views/auth_factor_steps/registration.html.erb
+++ b/app/views/auth_factor_steps/registration.html.erb
@@ -1,0 +1,9 @@
+<div class='authform'>
+  <h3>Register SMS Authentication Factor</h3>
+  <p>Enter a name for this authentication factor and your phone number to register.</p>
+  <%= bootstrap_form_with model: @auth_factor, url: wizard_path do |f| %>
+    <%= f.text_field :name, label: "Nickname", placeholder: "e.g. 'my cell phone'" %>
+    <%= f.text_field :phone, label: "Phone" %>
+    <%= f.submit "Next", class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/app/views/auth_factor_steps/registration.html.erb
+++ b/app/views/auth_factor_steps/registration.html.erb
@@ -1,9 +1,12 @@
 <div class='authform'>
-  <h3>Register SMS Authentication Factor</h3>
-  <p>Enter a name for this authentication factor and your phone number to register.</p>
+  <h3><%= t 'multi_factor.registration.heading' %></h3>
+  <p><%= t 'multi_factor.registration.message' %></p>
   <%= bootstrap_form_with model: @auth_factor, url: wizard_path do |f| %>
-    <%= f.text_field :name, label: "Nickname", placeholder: "e.g. 'my cell phone'" %>
-    <%= f.text_field :phone, label: "Phone" %>
-    <%= f.submit "Next", class: 'btn btn-primary' %>
+    <%= f.text_field :name,
+                     label: t('multi_factor.registration.name_label'),
+                     placeholder: t('multi_factor.registration.phone_placeholder')
+    %>
+    <%= f.text_field :phone, label: t('multi_factor.registration.phone_label') %>
+    <%= f.submit t('multi_factor.next'), class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/app/views/auth_factor_steps/verification.html.erb
+++ b/app/views/auth_factor_steps/verification.html.erb
@@ -1,12 +1,12 @@
 <div class='authform'>
-  <h3>Verify New SMS Authentication Factor: <%= @auth_factor.name %></h3>
-  <p>You should receive a verification code at the phone number entered in the previous step. Enter the code here to complete registration.</p>
+  <h3><%= t 'multi_factor.verification.heading', name: @auth_factor.name %></h3>
+  <p><%= t 'multi_factor.verification.message' %></p>
   <%= bootstrap_form_with model: @auth_factor, url: wizard_path do |f| %>
     <%= f.text_field :code,
-                     label: "Verification Code",
+                     label: t('multi_factor.verification.code_label'),
                      autocomplete: 'off',
                      size: 6,
                      maxlength: 6 %>
-    <%= f.submit "Next", class: 'btn btn-primary' %>
+    <%= f.submit t('multi_factor.next'), class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/app/views/auth_factor_steps/verification.html.erb
+++ b/app/views/auth_factor_steps/verification.html.erb
@@ -1,0 +1,12 @@
+<div class='authform'>
+  <h3>Verify New SMS Authentication Factor: <%= @auth_factor.name %></h3>
+  <p>You should receive a verification code at the phone number entered in the previous step. Enter the code here to complete registration.</p>
+  <%= bootstrap_form_with model: @auth_factor, url: wizard_path do |f| %>
+    <%= f.text_field :code,
+                     label: "Verification Code",
+                     autocomplete: 'off',
+                     size: 6,
+                     maxlength: 6 %>
+    <%= f.submit "Next", class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/app/views/devise/registrations/_auth_factors_list.html.erb
+++ b/app/views/devise/registrations/_auth_factors_list.html.erb
@@ -1,0 +1,42 @@
+<div class="card">
+  <div class="card-header">
+    Two Factor Authentication
+  </div>
+  <div class="card-body">
+    <% if current_user.auth_factors.none? {|f| f.enabled? } %>
+      <%= button_to('Enable Two Factor Authentication', new_auth_factor_path, method: :get, class: 'btn btn-primary') %>
+    <% else %>
+      <%= button_to('Add New Authentication Factor', new_auth_factor_path, method: :get, class: 'btn btn-primary') %>
+      <table class="table border-side">
+        <thead>
+          <tr>
+            <th><!-- spacer --></th>
+            <th><%= 'Name' %></th>
+            <th><%= 'Channel' %></th>
+            <th><%= 'Status' %></th>
+            <th><!-- delete factor btn --></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% if current_user.auth_factors.present? %>
+            <% current_user.auth_factors.each do |factor| %>
+              <% if factor.registration_complete? %>
+                <tr id='factor-<%= factor.name %>'>
+                  <td><!-- spacer --></td>
+                  <td><%= factor.name %></td>
+                  <td><%= factor.channel %></td>
+                  <td><%= factor.enabled ? 'Enabled' : 'Disabled' %>
+                  <td><%= button_to("Delete",
+                                    auth_factor_path(factor),
+                                    method: :delete,
+                                    class: 'btn btn-warning') %>
+                  </td>
+                </tr>
+              <% end %>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/registrations/_auth_factors_list.html.erb
+++ b/app/views/devise/registrations/_auth_factors_list.html.erb
@@ -1,19 +1,25 @@
 <div class="card">
   <div class="card-header">
-    Two Factor Authentication
+    <%= t 'multi_factor.factor_list.heading' %>
   </div>
   <div class="card-body">
     <% if current_user.auth_factors.none? {|f| f.enabled? } %>
-      <%= button_to('Enable Two Factor Authentication', new_auth_factor_path, method: :get, class: 'btn btn-primary') %>
+      <%= button_to t('multi_factor.factor_list.enable_button'),
+                    new_auth_factor_path,
+                    method: :get,
+                    class: 'btn btn-primary' %>
     <% else %>
-      <%= button_to('Add New Authentication Factor', new_auth_factor_path, method: :get, class: 'btn btn-primary') %>
+      <%= button_to t('multi_factor.factor_list.add_button'),
+                    new_auth_factor_path,
+                    method: :get,
+                    class: 'btn btn-primary' %>
       <table class="table border-side">
         <thead>
           <tr>
             <th><!-- spacer --></th>
-            <th><%= 'Name' %></th>
-            <th><%= 'Channel' %></th>
-            <th><%= 'Status' %></th>
+            <th><%= t 'multi_factor.factor_list.name' %></th>
+            <th><%= t 'multi_factor.factor_list.channel' %></th>
+            <th><%= t 'multi_factor.factor_list.status' %></th>
             <th><!-- delete factor btn --></th>
           </tr>
         </thead>
@@ -25,11 +31,13 @@
                   <td><!-- spacer --></td>
                   <td><%= factor.name %></td>
                   <td><%= factor.channel %></td>
-                  <td><%= factor.enabled ? 'Enabled' : 'Disabled' %>
-                  <td><%= button_to("Delete",
+                  <td><%= factor.enabled ?
+                    t('multi_factor.factor_list.enabled') :
+                    t('multi_factor.factor_list.disabled') %>
+                  <td><%= button_to t('multi_factor.factor_list.delete_button'),
                                     auth_factor_path(factor),
                                     method: :delete,
-                                    class: 'btn btn-warning') %>
+                                    class: 'btn btn-warning' %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -22,5 +22,8 @@
     <%= f.submit t('user.profile_edit.update_info_button'), class: 'btn btn-primary' %>
   <% end %>
   <br>
+  <br />
+  <%= render 'devise/registrations/auth_factors_list' %>
+  <br />
   <%= link_to t('common.back'), :back %>
 </div>

--- a/app/views/multi_factor_authentication/factor_select.html.erb
+++ b/app/views/multi_factor_authentication/factor_select.html.erb
@@ -1,10 +1,10 @@
 <div class="card">
-  <div class="card-header">Select Authentication Factor</div>
+  <div class="card-header"><%= t 'multi_factor.factor_select.heading' %></div>
   <div class="card-body">
     <%= bootstrap_form_with url: wizard_path, method: :put do |f| %>
       <div class="actions">
         <%= f.select :auth_factor_id, @auth_factors.collect { |af| [ af.name, af.id ] } %>
-        <%= f.submit 'Next', class: 'btn btn-primary mt-2' %>
+        <%= f.submit t('multi_factor.next'), class: 'btn btn-primary mt-2' %>
       </div>
     <% end %>
   </div>

--- a/app/views/multi_factor_authentication/factor_select.html.erb
+++ b/app/views/multi_factor_authentication/factor_select.html.erb
@@ -1,0 +1,11 @@
+<div class="card">
+  <div class="card-header">Select Authentication Factor</div>
+  <div class="card-body">
+    <%= bootstrap_form_with url: wizard_path, method: :put do |f| %>
+      <div class="actions">
+        <%= f.select :auth_factor_id, @auth_factors.collect { |af| [ af.name, af.id ] } %>
+        <%= f.submit 'Next', class: 'btn btn-primary mt-2' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/multi_factor_authentication/verification.html.erb
+++ b/app/views/multi_factor_authentication/verification.html.erb
@@ -1,0 +1,12 @@
+<div class='authform'>
+  <h3>Verify SMS Authentication Factor: <%= @auth_factor.name %></h3>
+  <p>You should receive a verification code at the phone number entered in the previous step. Enter the code here to complete registration.</p>
+  <%= bootstrap_form_with url: wizard_path, method: :put do |f| %>
+    <%= f.text_field :code,
+                     label: "Verification Code",
+                     autocomplete: 'off',
+                     size: 6,
+                     maxlength: 6 %>
+    <%= f.submit "Authenticate", class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/app/views/multi_factor_authentication/verification.html.erb
+++ b/app/views/multi_factor_authentication/verification.html.erb
@@ -1,12 +1,12 @@
 <div class='authform'>
-  <h3>Verify SMS Authentication Factor: <%= @auth_factor.name %></h3>
-  <p>You should receive a verification code at the phone number entered in the previous step. Enter the code here to complete registration.</p>
+  <h3><%= t 'multi_factor.verification.heading', name: @auth_factor.name %></h3>
+  <p><%= t 'multi_factor.verification.message' %></p>
   <%= bootstrap_form_with url: wizard_path, method: :put do |f| %>
     <%= f.text_field :code,
-                     label: "Verification Code",
+                     label: t('multi_factor.verification.code_label'),
                      autocomplete: 'off',
                      size: 6,
                      maxlength: 6 %>
-    <%= f.submit "Authenticate", class: 'btn btn-primary' %>
+    <%= f.submit t('multi_factor.authenticate'), class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,6 +298,39 @@ en:
       start: Get started
       welcome_to_daria: Welcome to DARIA (%{fund} edition)!
       what_line: What line are you working on?
+  multi_factor:
+    authenticate: Authenticate
+    authentication_error: Authentication error
+    checking_sms_code_failed: There was a problem checking the verification code - %{error}
+    code_invalid: invalid code
+    confirmation:
+      heading: 'New SMS Authentication Factor Registered: %{name}'
+      message: New authentication factor successfully registered!
+    factor_list:
+      add_button: Add New Authentication Factor
+      channel: Channel
+      delete_button: Delete
+      disabled: Disabled
+      enable_button: Enable Multi Factor Authentication
+      enabled: Enabled
+      heading: Multi Factor Authentication
+      name: Name
+      status: Status
+    factor_select:
+      heading: Select Authentication Factor
+    login_successful: Login with MFA successful!
+    next: Next
+    registration:
+      heading: Register SMS Authentication Factor
+      message: Enter a name for this authentication factor and your phone number to register.
+      name_label: Nickname
+      phone_label: Phone
+      phone_placeholder: e.g. 'my cell phone'
+    sending_sms_code_failed: There was a problem sending the verification code - %{error}
+    verification:
+      code_label: Verification Code
+      heading: 'Verify SMS Authentication Factor: %{name}'
+      message: You should receive a verification code at the phone number entered in the previous step. Enter the code here to complete registration.
   navigation:
     admin_tools:
       accounting: Accounting

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -298,6 +298,39 @@ es:
       start: Empezar
       welcome_to_daria: "¡Bienvenido a DARIA (edición de %{fund})!"
       what_line: "¿En cuál línea estás trabajando?"
+  multi_factor:
+    authenticate: Authenticate
+    authentication_error: Authentication error
+    checking_sms_code_failed: There was a problem checking the verification code - %{error}
+    code_invalid: invalid code
+    confirmation:
+      heading: 'New SMS Authentication Factor Registered: %{name}'
+      message: New authentication factor successfully registered!
+    factor_list:
+      add_button: Add New Authentication Factor
+      channel: Channel
+      delete_button: Delete
+      disabled: Disabled
+      enable_button: Enable Multi Factor Authentication
+      enabled: Enabled
+      heading: Multi Factor Authentication
+      name: Name
+      status: Status
+    factor_select:
+      heading: Select Authentication Factor
+    login_successful: Login with MFA successful!
+    next: Next
+    registration:
+      heading: Register SMS Authentication Factor
+      message: Enter a name for this authentication factor and your phone number to register.
+      name_label: Nickname
+      phone_label: Phone
+      phone_placeholder: e.g. 'my cell phone'
+    sending_sms_code_failed: There was a problem sending the verification code - %{error}
+    verification:
+      code_label: Verification Code
+      heading: 'Verify SMS Authentication Factor: %{name}'
+      message: You should receive a verification code at the phone number entered in the previous step. Enter the code here to complete registration.
   navigation:
     admin_tools:
       accounting: Contabilidad

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,9 @@ Rails.application.routes.draw do
     resources :clinics, only: [:index, :create, :update, :new, :destroy, :edit]
     resources :configs, only: [:index, :create, :update]
     resources :events, only: [:index]
+
+    resources :auth_factors, only: [:new, :destroy]
+    resources :build_auth_factor, only: [:show, :update], controller: 'auth_factor_steps'
   end
 
   # Auth routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { :omniauth_callbacks => "users/omniauth_callbacks" },
-                     skip: [:registrations]
+  devise_for :users,
+             controllers: { omniauth_callbacks: 'users/omniauth_callbacks', sessions: 'users/sessions' },
+             skip: [:registrations]
   authenticate :user do
     root to: 'dashboards#index', as: :authenticated_root
     get 'dashboard', to: 'dashboards#index', as: 'dashboard'
@@ -61,6 +62,8 @@ Rails.application.routes.draw do
     resources :auth_factors, only: [:new, :destroy]
     resources :build_auth_factor, only: [:show, :update], controller: 'auth_factor_steps'
   end
+
+  resources :multi_factor_authentication, only: [:show, :update]
 
   # Auth routes
   root :to => redirect('/users/sign_in')

--- a/db/migrate/20230113192110_create_auth_factors.rb
+++ b/db/migrate/20230113192110_create_auth_factors.rb
@@ -1,0 +1,17 @@
+class CreateAuthFactors < ActiveRecord::Migration[7.0]
+  def change
+    create_table :auth_factors do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+      t.string :channel
+      t.boolean :enabled, default: false
+      t.boolean :registration_complete, default: false
+      t.string :external_id
+      t.string :phone
+      t.string :email
+
+      t.timestamps
+    end
+    add_index :auth_factors, %i[name user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_13_192110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -63,6 +63,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
     t.index ["line_legacy"], name: "index_archived_patients_on_line_legacy"
     t.index ["pledge_generated_by_id"], name: "index_archived_patients_on_pledge_generated_by_id"
     t.index ["pledge_sent_by_id"], name: "index_archived_patients_on_pledge_sent_by_id"
+  end
+
+  create_table "auth_factors", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name"
+    t.string "channel"
+    t.boolean "enabled", default: false
+    t.boolean "registration_complete", default: false
+    t.string "external_id"
+    t.string "phone"
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "user_id"], name: "index_auth_factors_on_name_and_user_id", unique: true
+    t.index ["user_id"], name: "index_auth_factors_on_user_id"
   end
 
   create_table "call_list_entries", force: :cascade do |t|
@@ -391,6 +406,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
   add_foreign_key "archived_patients", "lines"
   add_foreign_key "archived_patients", "users", column: "pledge_generated_by_id"
   add_foreign_key "archived_patients", "users", column: "pledge_sent_by_id"
+  add_foreign_key "auth_factors", "users"
   add_foreign_key "call_list_entries", "funds"
   add_foreign_key "call_list_entries", "lines"
   add_foreign_key "call_list_entries", "patients"

--- a/test/controllers/auth_factors_controller_test.rb
+++ b/test/controllers/auth_factors_controller_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+# Tests for the auth factors controller
+class AuthFactorsControllerTest < ActionDispatch::IntegrationTest
+  before do
+    @user = create :user, role: :admin
+    sign_in @user
+  end
+
+  describe 'new' do
+    it 'should render' do
+      get new_auth_factor_path
+
+      assert_redirected_to build_auth_factor_path(AuthFactor.form_steps.first)
+    end
+
+    it 'should create unregistered auth factor' do
+      assert_difference('AuthFactor.count', 1) do
+        get new_auth_factor_path
+      end
+
+      assert session.key?(:auth_factor_id)
+
+      new_auth_factor = AuthFactor.find(session[:auth_factor_id])
+      assert_not new_auth_factor.registration_complete
+      assert_not new_auth_factor.enabled
+    end
+  end
+
+  describe 'destroy' do
+    before do
+      @user.auth_factors.create attributes_for(:auth_factor, :registration_complete)
+      @auth_factor = @user.auth_factors.first
+    end
+
+    it 'should destroy an auth factor record' do
+      assert_difference('AuthFactor.count', -1) do
+        delete auth_factor_path(@auth_factor)
+      end
+
+      assert_redirected_to edit_user_registration_path
+    end
+  end
+end

--- a/test/factories/auth_factor.rb
+++ b/test/factories/auth_factor.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  sequence :name do |n|
+    "my phone #{n}"
+  end
+
+  factory :auth_factor do
+    association :user
+    channel { 'sms' }
+
+    trait :registration_complete do
+      name { generate :name }
+      phone { '555-555-5555' }
+      registration_complete { true }
+      enabled { true }
+    end
+
+    trait :not_enabled do
+      name { generate :name }
+      registration_complete { false }
+      enabled { false }
+    end
+  end
+end

--- a/test/models/auth_factor_test.rb
+++ b/test/models/auth_factor_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class AuthFactorTest < ActiveSupport::TestCase
+  before do
+    @user = create :user
+    with_versioning(@user) do
+      @user.auth_factors.create attributes_for(:auth_factor, :registration_complete)
+      @auth_factor = @user.auth_factors.first
+    end
+  end
+
+  describe 'validations' do
+    it 'should build' do
+      assert @auth_factor.valid?
+    end
+  end
+
+  describe 'relationships' do
+    it 'should be linkable to a user' do
+      assert_equal @auth_factor.created_by, @user
+    end
+  end
+end

--- a/test/system/auth_factor_registration_test.rb
+++ b/test/system/auth_factor_registration_test.rb
@@ -21,59 +21,59 @@ class AuthFactorRegistrationTest < ApplicationSystemTestCase
     it 'should go to verification step when completed successfully' do
       @twilio_verify_mock.expect(:send_sms_verification_code, 'success', [PHONE])
 
-      fill_in 'Nickname', with: NICKNAME
-      fill_in 'Phone', with: PHONE
+      fill_in t('multi_factor.registration.name_label'), with: NICKNAME
+      fill_in t('multi_factor.registration.phone_label'), with: PHONE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Next'
+        click_button t('multi_factor.next')
       end
 
-      assert_text 'Verify New SMS Authentication Factor'
+      assert_text 'Verify SMS Authentication Factor'
     end
 
     it 'should not proceed if name empty' do
-      fill_in 'Nickname', with: ''
-      fill_in 'Phone', with: PHONE
+      fill_in t('multi_factor.registration.name_label'), with: ''
+      fill_in t('multi_factor.registration.phone_label'), with: PHONE
 
-      click_button 'Next'
+      click_button t('multi_factor.next')
 
       assert_text "can't be blank"
-      assert_text 'Register SMS Authentication Factor'
+      assert_text t('multi_factor.registration.heading')
     end
 
     it 'should not proceed if phone empty' do
-      fill_in 'Nickname', with: NICKNAME
-      fill_in 'Phone', with: ''
+      fill_in t('multi_factor.registration.name_label'), with: NICKNAME
+      fill_in t('multi_factor.registration.phone_label'), with: ''
 
-      click_button 'Next'
+      click_button t('multi_factor.next')
 
       assert_text "can't be blank"
-      assert_text 'Register SMS Authentication Factor'
+      assert_text t('multi_factor.registration.heading')
     end
 
     it 'should not proceed if phone format invalid' do
-      fill_in 'Nickname', with: NICKNAME
-      fill_in 'Phone', with: '123'
+      fill_in t('multi_factor.registration.name_label'), with: NICKNAME
+      fill_in t('multi_factor.registration.phone_label'), with: '123'
 
-      click_button 'Next'
+      click_button t('multi_factor.next')
 
       assert_text 'is invalid'
-      assert_text 'Register SMS Authentication Factor'
+      assert_text t('multi_factor.registration.heading')
     end
 
     it 'should not proceed if sending SMS fails' do
       raises_exception = -> { raise StandardError }
       @twilio_verify_mock.expect(:send_sms_verification_code, raises_exception)
 
-      fill_in 'Nickname', with: NICKNAME
-      fill_in 'Phone', with: PHONE
+      fill_in t('multi_factor.registration.name_label'), with: NICKNAME
+      fill_in t('multi_factor.registration.phone_label'), with: PHONE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Next'
+        click_button t('multi_factor.next')
       end
 
       assert_text 'There was a problem sending the verification code'
-      assert_text 'Register SMS Authentication Factor'
+      assert_text t('multi_factor.registration.heading')
     end
   end
 
@@ -85,40 +85,40 @@ class AuthFactorRegistrationTest < ApplicationSystemTestCase
     it 'should go to confirmation step when completed successfully' do
       @twilio_verify_mock.expect(:check_sms_verification_code, 'approved', [PHONE, CORRECT_CODE])
 
-      fill_in 'Verification Code', with: CORRECT_CODE
+      fill_in t('multi_factor.verification.code_label'), with: CORRECT_CODE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Next'
+        click_button t('multi_factor.next')
       end
 
-      assert_text 'New authentication factor successfully registered!'
+      assert_text t('multi_factor.confirmation.message')
     end
 
     it 'should not proceed if verification code is invalid' do
       @twilio_verify_mock.expect(:check_sms_verification_code, 'pending', [PHONE, INCORRECT_CODE])
 
-      fill_in 'Verification Code', with: INCORRECT_CODE
+      fill_in t('multi_factor.verification.code_label'), with: INCORRECT_CODE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Next'
+        click_button t('multi_factor.next')
       end
 
-      assert_text 'invalid code'
-      assert_text 'Verify New SMS Authentication Factor'
+      assert_text t('multi_factor.code_invalid')
+      assert_text 'Verify SMS Authentication Factor'
     end
 
     it 'should not proceed if call to check code raises exception' do
       raises_exception = -> { raise StandardError }
       @twilio_verify_mock.expect(:check_sms_verification_code, raises_exception)
 
-      fill_in 'Verification Code', with: INCORRECT_CODE
+      fill_in t('multi_factor.verification.code_label'), with: INCORRECT_CODE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Next'
+        click_button t('multi_factor.next')
       end
 
       assert_text 'There was a problem checking the verification code'
-      assert_text 'Verify New SMS Authentication Factor'
+      assert_text 'Verify SMS Authentication Factor'
     end
   end
 
@@ -128,7 +128,7 @@ class AuthFactorRegistrationTest < ApplicationSystemTestCase
     end
 
     it 'should navigate to user profile on clicking Next button' do
-      click_button 'Next'
+      click_button t('multi_factor.next')
       assert_text 'User panel'
     end
   end
@@ -141,14 +141,14 @@ class AuthFactorRegistrationTest < ApplicationSystemTestCase
     it 'should show newly registered auth factor in profile' do
       visit edit_user_registration_path
       assert_text NICKNAME
-      assert_text 'Enabled'
+      assert_text t('multi_factor.factor_list.enabled')
     end
 
     # Ensures we're not still seeing data from the previous registration, e.g. if the auth_factor id
     # isn't getting cleared from the session after completing the registration.
     it 'should allow starting a new registration' do
-      click_button 'Add New Authentication Factor'
-      assert_text 'Register SMS Authentication Factor'
+      click_button t('multi_factor.factor_list.add_button')
+      assert_text t('multi_factor.registration.heading')
       assert_no_text NICKNAME
       assert_no_text PHONE
     end
@@ -156,11 +156,9 @@ class AuthFactorRegistrationTest < ApplicationSystemTestCase
 
   private
 
-  def submit_with_stubbed_twilio_client; end
-
   def complete_up_to_registration_step
     visit edit_user_registration_path
-    click_button 'Enable Two Factor Authentication'
+      click_button t('multi_factor.factor_list.enable_button')
   end
 
   def complete_up_to_verification_step
@@ -168,11 +166,11 @@ class AuthFactorRegistrationTest < ApplicationSystemTestCase
 
     @twilio_verify_mock.expect(:send_sms_verification_code, 'success', [PHONE])
 
-    fill_in 'Nickname', with: 'my new factor'
-    fill_in 'Phone', with: PHONE
+    fill_in t('multi_factor.registration.name_label'), with: 'my new factor'
+    fill_in t('multi_factor.registration.phone_label'), with: PHONE
 
     TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-      click_button 'Next'
+      click_button t('multi_factor.next')
     end
   end
 
@@ -182,13 +180,13 @@ class AuthFactorRegistrationTest < ApplicationSystemTestCase
     @twilio_verify_mock.expect(:check_sms_verification_code, 'approved', [PHONE, CORRECT_CODE])
 
     TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-      fill_in 'Verification Code', with: CORRECT_CODE
-      click_button 'Next'
+      fill_in t('multi_factor.verification.code_label'), with: CORRECT_CODE
+      click_button t('multi_factor.next')
     end
   end
 
   def complete_wizard
     complete_up_to_confirmation_step
-    click_button 'Next'
+    click_button t('multi_factor.next')
   end
 end

--- a/test/system/auth_factor_registration_test.rb
+++ b/test/system/auth_factor_registration_test.rb
@@ -1,0 +1,194 @@
+require 'application_system_test_case'
+
+class AuthFactorRegistrationTest < ApplicationSystemTestCase
+  NICKNAME = 'my new factor'
+  PHONE = '5555555555'
+  CORRECT_CODE = '123456'
+  INCORRECT_CODE = '000000'
+
+  before do
+    @twilio_verify_mock = Minitest::Mock.new
+
+    create :line
+    log_in_as create(:user)
+  end
+
+  describe 'registration step' do
+    before do
+      complete_up_to_registration_step
+    end
+
+    it 'should go to verification step when completed successfully' do
+      @twilio_verify_mock.expect(:send_sms_verification_code, 'success', [PHONE])
+
+      fill_in 'Nickname', with: NICKNAME
+      fill_in 'Phone', with: PHONE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Next'
+      end
+
+      assert_text 'Verify New SMS Authentication Factor'
+    end
+
+    it 'should not proceed if name empty' do
+      fill_in 'Nickname', with: ''
+      fill_in 'Phone', with: PHONE
+
+      click_button 'Next'
+
+      assert_text "can't be blank"
+      assert_text 'Register SMS Authentication Factor'
+    end
+
+    it 'should not proceed if phone empty' do
+      fill_in 'Nickname', with: NICKNAME
+      fill_in 'Phone', with: ''
+
+      click_button 'Next'
+
+      assert_text "can't be blank"
+      assert_text 'Register SMS Authentication Factor'
+    end
+
+    it 'should not proceed if phone format invalid' do
+      fill_in 'Nickname', with: NICKNAME
+      fill_in 'Phone', with: '123'
+
+      click_button 'Next'
+
+      assert_text 'is invalid'
+      assert_text 'Register SMS Authentication Factor'
+    end
+
+    it 'should not proceed if sending SMS fails' do
+      raises_exception = -> { raise StandardError }
+      @twilio_verify_mock.expect(:send_sms_verification_code, raises_exception)
+
+      fill_in 'Nickname', with: NICKNAME
+      fill_in 'Phone', with: PHONE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Next'
+      end
+
+      assert_text 'There was a problem sending the verification code'
+      assert_text 'Register SMS Authentication Factor'
+    end
+  end
+
+  describe 'verification step' do
+    before do
+      complete_up_to_verification_step
+    end
+
+    it 'should go to confirmation step when completed successfully' do
+      @twilio_verify_mock.expect(:check_sms_verification_code, 'approved', [PHONE, CORRECT_CODE])
+
+      fill_in 'Verification Code', with: CORRECT_CODE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Next'
+      end
+
+      assert_text 'New authentication factor successfully registered!'
+    end
+
+    it 'should not proceed if verification code is invalid' do
+      @twilio_verify_mock.expect(:check_sms_verification_code, 'pending', [PHONE, INCORRECT_CODE])
+
+      fill_in 'Verification Code', with: INCORRECT_CODE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Next'
+      end
+
+      assert_text 'invalid code'
+      assert_text 'Verify New SMS Authentication Factor'
+    end
+
+    it 'should not proceed if call to check code raises exception' do
+      raises_exception = -> { raise StandardError }
+      @twilio_verify_mock.expect(:check_sms_verification_code, raises_exception)
+
+      fill_in 'Verification Code', with: INCORRECT_CODE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Next'
+      end
+
+      assert_text 'There was a problem checking the verification code'
+      assert_text 'Verify New SMS Authentication Factor'
+    end
+  end
+
+  describe 'confirmation step' do
+    before do
+      complete_up_to_confirmation_step
+    end
+
+    it 'should navigate to user profile on clicking Next button' do
+      click_button 'Next'
+      assert_text 'User panel'
+    end
+  end
+
+  describe 'after completing the wizard' do
+    before do
+      complete_wizard
+    end
+
+    it 'should show newly registered auth factor in profile' do
+      visit edit_user_registration_path
+      assert_text NICKNAME
+      assert_text 'Enabled'
+    end
+
+    # Ensures we're not still seeing data from the previous registration, e.g. if the auth_factor id
+    # isn't getting cleared from the session after completing the registration.
+    it 'should allow starting a new registration' do
+      click_button 'Add New Authentication Factor'
+      assert_text 'Register SMS Authentication Factor'
+      assert_no_text NICKNAME
+      assert_no_text PHONE
+    end
+  end
+
+  private
+
+  def submit_with_stubbed_twilio_client; end
+
+  def complete_up_to_registration_step
+    visit edit_user_registration_path
+    click_button 'Enable Two Factor Authentication'
+  end
+
+  def complete_up_to_verification_step
+    complete_up_to_registration_step
+
+    @twilio_verify_mock.expect(:send_sms_verification_code, 'success', [PHONE])
+
+    fill_in 'Nickname', with: 'my new factor'
+    fill_in 'Phone', with: PHONE
+
+    TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+      click_button 'Next'
+    end
+  end
+
+  def complete_up_to_confirmation_step
+    complete_up_to_verification_step
+
+    @twilio_verify_mock.expect(:check_sms_verification_code, 'approved', [PHONE, CORRECT_CODE])
+
+    TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+      fill_in 'Verification Code', with: CORRECT_CODE
+      click_button 'Next'
+    end
+  end
+
+  def complete_wizard
+    complete_up_to_confirmation_step
+    click_button 'Next'
+  end
+end

--- a/test/system/mfa_login_test.rb
+++ b/test/system/mfa_login_test.rb
@@ -1,0 +1,128 @@
+require 'application_system_test_case'
+
+class MfaLoginTest < ApplicationSystemTestCase
+  PHONE = '5555555555'
+  CORRECT_CODE = '123456'
+  INCORRECT_CODE = '000000'
+
+  before do
+    @twilio_verify_mock = Minitest::Mock.new
+
+    create :line
+    @user = create :user
+  end
+
+  describe 'login' do
+    it 'should successfully login user with no enabled auth factors' do
+      @user.auth_factors.create attributes_for(:auth_factor, :not_enabled)
+      log_in_as @user
+      assert_text 'Build your call list'
+    end
+
+    it 'should redirect user with an enabled auth factor MFA login' do
+      @user.auth_factors.create attributes_for(:auth_factor, :registration_complete)
+      log_in_as @user
+
+      assert_text 'Select Authentication Factor'
+    end
+  end
+
+  describe 'factor_select step' do
+    before do
+      @auth_factor_enabled = @user.auth_factors.create attributes_for(:auth_factor, :registration_complete)
+      @auth_factor_disabled = @user.auth_factors.create attributes_for(:auth_factor, :not_enabled)
+      log_in_as @user
+    end
+
+    it 'should include enabled auth factors as options' do
+      assert_text @auth_factor_enabled.name
+      assert_no_text @auth_factor_disabled.name
+    end
+
+    it 'should go to verification step when completed successfully' do
+      @twilio_verify_mock.expect(:send_sms_verification_code, 'success', [PHONE])
+
+      select @auth_factor_enabled.name, from: 'Auth factor'
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Next'
+      end
+
+      assert_text 'Verify SMS Authentication Factor'
+    end
+
+    it 'should not proceed if sending SMS fails' do
+      raises_exception = -> { raise StandardError }
+      @twilio_verify_mock.expect(:send_sms_verification_code, raises_exception)
+
+      select @auth_factor_enabled.name, from: 'Auth factor'
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Next'
+      end
+
+      assert_text 'There was a problem sending the verification code'
+      assert_text 'Select Authentication Factor'
+    end
+  end
+
+  describe 'verification step' do
+    before do
+      complete_up_to_verification_step
+    end
+
+    it 'should log user in when code is correct' do
+      @twilio_verify_mock.expect(:check_sms_verification_code, 'approved', [PHONE, CORRECT_CODE])
+
+      fill_in 'Verification Code', with: CORRECT_CODE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Authenticate'
+      end
+
+      assert_text 'Login with MFA successful'
+    end
+
+    it 'should not proceed if verification code is invalid' do
+      @twilio_verify_mock.expect(:check_sms_verification_code, 'pending', [PHONE, INCORRECT_CODE])
+
+      fill_in 'Verification Code', with: INCORRECT_CODE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Authenticate'
+      end
+
+      assert_text 'invalid code'
+      assert_text 'Verify SMS Authentication Factor'
+    end
+
+    it 'should not proceed if call to check code raises exception' do
+      raises_exception = -> { raise StandardError }
+      @twilio_verify_mock.expect(:check_sms_verification_code, raises_exception)
+
+      fill_in 'Verification Code', with: INCORRECT_CODE
+
+      TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+        click_button 'Authenticate'
+      end
+
+      assert_text 'There was a problem checking the verification code'
+      assert_text 'Verify SMS Authentication Factor'
+    end
+  end
+
+  private
+
+  def complete_up_to_verification_step
+    auth_factor = @user.auth_factors.create attributes_for(:auth_factor, :registration_complete)
+    log_in_as @user
+
+    @twilio_verify_mock.expect(:send_sms_verification_code, 'success', [PHONE])
+
+    select auth_factor.name, from: 'Auth factor'
+
+    TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
+      click_button 'Next'
+    end
+  end
+end

--- a/test/system/mfa_login_test.rb
+++ b/test/system/mfa_login_test.rb
@@ -16,14 +16,14 @@ class MfaLoginTest < ApplicationSystemTestCase
     it 'should successfully login user with no enabled auth factors' do
       @user.auth_factors.create attributes_for(:auth_factor, :not_enabled)
       log_in_as @user
-      assert_text 'Build your call list'
+      assert_text t('dashboard.search.header')
     end
 
     it 'should redirect user with an enabled auth factor MFA login' do
       @user.auth_factors.create attributes_for(:auth_factor, :registration_complete)
       log_in_as @user
 
-      assert_text 'Select Authentication Factor'
+      assert_text t('multi_factor.factor_select.heading')
     end
   end
 
@@ -45,7 +45,7 @@ class MfaLoginTest < ApplicationSystemTestCase
       select @auth_factor_enabled.name, from: 'Auth factor'
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Next'
+        click_button t('multi_factor.next')
       end
 
       assert_text 'Verify SMS Authentication Factor'
@@ -58,11 +58,11 @@ class MfaLoginTest < ApplicationSystemTestCase
       select @auth_factor_enabled.name, from: 'Auth factor'
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Next'
+        click_button t('multi_factor.next')
       end
 
       assert_text 'There was a problem sending the verification code'
-      assert_text 'Select Authentication Factor'
+      assert_text t('multi_factor.factor_select.heading')
     end
   end
 
@@ -74,25 +74,25 @@ class MfaLoginTest < ApplicationSystemTestCase
     it 'should log user in when code is correct' do
       @twilio_verify_mock.expect(:check_sms_verification_code, 'approved', [PHONE, CORRECT_CODE])
 
-      fill_in 'Verification Code', with: CORRECT_CODE
+      fill_in t('multi_factor.verification.code_label'), with: CORRECT_CODE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Authenticate'
+        click_button t('multi_factor.authenticate')
       end
 
-      assert_text 'Login with MFA successful'
+      assert_text t('multi_factor.login_successful')
     end
 
     it 'should not proceed if verification code is invalid' do
       @twilio_verify_mock.expect(:check_sms_verification_code, 'pending', [PHONE, INCORRECT_CODE])
 
-      fill_in 'Verification Code', with: INCORRECT_CODE
+      fill_in t('multi_factor.verification.code_label'), with: INCORRECT_CODE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Authenticate'
+        click_button t('multi_factor.authenticate')
       end
 
-      assert_text 'invalid code'
+      assert_text t('multi_factor.code_invalid')
       assert_text 'Verify SMS Authentication Factor'
     end
 
@@ -100,10 +100,10 @@ class MfaLoginTest < ApplicationSystemTestCase
       raises_exception = -> { raise StandardError }
       @twilio_verify_mock.expect(:check_sms_verification_code, raises_exception)
 
-      fill_in 'Verification Code', with: INCORRECT_CODE
+      fill_in t('multi_factor.verification.code_label'), with: INCORRECT_CODE
 
       TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-        click_button 'Authenticate'
+        click_button t('multi_factor.authenticate')
       end
 
       assert_text 'There was a problem checking the verification code'
@@ -122,7 +122,7 @@ class MfaLoginTest < ApplicationSystemTestCase
     select auth_factor.name, from: 'Auth factor'
 
     TwilioVerifyClient.stub(:new, @twilio_verify_mock) do
-      click_button 'Next'
+      click_button t('multi_factor.next')
     end
   end
 end

--- a/test/system/update_user_info_test.rb
+++ b/test/system/update_user_info_test.rb
@@ -35,7 +35,7 @@ class UpdateUserInfoTest < ApplicationSystemTestCase
     end
   end
 
-  describe 'Two Factor Authentication' do
+  describe 'Multi Factor Authentication' do
     before do
       @user.auth_factors.create attributes_for(:auth_factor, :not_enabled)
       @disabled_factor = @user.auth_factors.first
@@ -46,13 +46,13 @@ class UpdateUserInfoTest < ApplicationSystemTestCase
         visit edit_user_registration_path
       end
 
-      it 'should display Enable Two Factor Authentication' do
-        assert_text 'Enable Two Factor Authentication'
+      it 'should display Enable Multi Factor Authentication' do
+        assert_text t('multi_factor.factor_list.enable_button')
       end
 
       it 'should go to registration when Enable 2FA pressed' do
-        click_button 'Enable Two Factor Authentication'
-        assert_text 'Register SMS Authentication Factor'
+        click_button t('multi_factor.factor_list.enable_button')
+        assert_text t('multi_factor.registration.heading')
       end
     end
 
@@ -64,7 +64,7 @@ class UpdateUserInfoTest < ApplicationSystemTestCase
       end
 
       it 'should display Add New Authentication Factor' do
-        assert_text 'Add New Authentication Factor'
+        assert_text t('multi_factor.factor_list.add_button')
       end
 
       it 'should display enabled factors' do
@@ -73,7 +73,7 @@ class UpdateUserInfoTest < ApplicationSystemTestCase
       end
 
       it 'should delete factor when delete button pressed' do
-        click_button 'Delete'
+        click_button t('multi_factor.factor_list.delete_button')
         assert_no_text @enabled_factor.name
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds multi factor authentication with SMS using the Twilio Verify API.

## Overview

This pull request makes the following changes:
* Adds a registration form to register SMS as a 2nd factor.
* Adds a Multi Factor Authentication settings card to the User Profile that links to the registration form and lists registered factors.
* Adds a Multi Factor Authentication step to login for users with it enabled.

More detailed outline [in the issue](https://github.com/DARIAEngineering/dcaf_case_management/issues/2003#issuecomment-1379662445). That comment describes a flow including additional channel types beyond SMS. This PR is basically the same but with SMS only.

It relates to the following issue #s: 
* https://github.com/DARIAEngineering/dcaf_case_management/issues/2003

## Notes

### Resources
* [Wicked gem docs](https://github.com/zombocom/wicked): used for multi-step forms for registration and login.
* [Twilio Verify SMS quickstart](https://www.twilio.com/docs/verify/quickstarts/ruby-rails)
* [Rails Wizards](https://jonsully.net/blog/rails-wizards-part-five/): goes into depth on multiple ways to implement multi-step forms. This PR uses the "Database Persistence / In-Session Routing" strategy described here.
* [MFA with Devise](https://www.honeybadger.io/blog/multi-factor-2fa-authentication-rails-webauthn-devise/): gives an example MFA setup with Devise. I used this guide's strategy for overriding the devise sessions controller for MFA login.

### Next Steps
* Cleanup incomplete AuthFactor records: since the multi-step registration forms build up a record over multiple steps, leaving the site halfway through will result in an incomplete record hanging around in the database. It would be good to have a regularly scheduled rake task to clean these up.
* Set up full Twilio Verify account. I developed with the trial account. We'll need to look at what settings need to change to make sure this works in production.

## For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
