### PR TITLE
Issue 2761: Update Patient Phone Match Error

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -164,7 +164,7 @@ class Patient < ApplicationRecord
       if volunteers_line == patients_line
         errors.add(:this_phone_number_is_already_taken, "on this line.")
       else
-        errors.add(:this_phone_number_is_already_taken, "on the #{patients_line} line. If you need the patient's line changed, please contact the CM directors.")
+        errors.add(:this_phone_number_is_already_taken, "on the #{patients_line.name} line. If you need the patient's line changed, please contact the CM directors.")
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR addresses issue #2761 by updating the patient model to return the line name instead of the line object in the phone match error. 

This pull request makes the following changes:
* return line name instead of line object

It relates to the following issue #s: 
* Fixes #2761 


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
