### PR TITLE
county field dropdown

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -117,6 +117,14 @@ module PatientsHelper
     ]
   end
 
+  def county_options(current_value = nil)
+    county_options = Config.find_or_create_by(config_key: 'county').options
+
+    return [] if county_options.blank?
+
+    options_plus_current([nil] + county_options, current_value)
+  end
+
   def household_size_options
     (0..10).map { |i| i }
            .unshift([t('common.prefer_not_to_answer'), -1])
@@ -146,6 +154,8 @@ module PatientsHelper
 
     active_clinics | inactive_clinics
   end
+
+  
 
   def disable_continue?(patient)
     patient.pledge_info_present? ? 'disabled="disabled"' : ''

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -155,8 +155,6 @@ module PatientsHelper
     active_clinics | inactive_clinics
   end
 
-  
-
   def disable_continue?(patient)
     patient.pledge_info_present? ? 'disabled="disabled"' : ''
   end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -21,7 +21,7 @@ class Config < ApplicationRecord
     shared_reset: "Number of idle days until a patient is removed from the shared list. Defaults to 6 days, maximum 6 weeks.",
     hide_budget_bar: 'Enter "yes" to hide the budget bar display.',
     aggregate_statistics: 'Enter "yes" to show aggregate statistics on the budget bar.',
-    hide_standard_dropdown_values: 'Enter "yes" to hide standard dropdown values. Only custom options (specified on this page) will be used.'
+    hide_standard_dropdown_values: 'Enter "yes" to hide standard dropdown values. Only custom options (specified on this page) will be used.',
   }.freeze
 
   enum config_key: {
@@ -44,6 +44,7 @@ class Config < ApplicationRecord
     hide_budget_bar: 16,
     aggregate_statistics: 17,
     hide_standard_dropdown_values: 18,
+    county: 19,
   }
 
   # which fields are URLs (run special validation only on those)
@@ -52,7 +53,8 @@ class Config < ApplicationRecord
   CLEAN_PRE_VALIDATION = {
     start_of_week: [:fix_capitalization],
     hide_practical_support: [:fix_capitalization],
-    language: [:fix_capitalization]
+    language: [:fix_capitalization],
+    county: [:fix_capitalization]
   }.freeze
 
   VALIDATIONS = {
@@ -67,6 +69,8 @@ class Config < ApplicationRecord
     referred_by:
       [:validate_length],
     voicemail:
+      [:validate_length],
+    county:
       [:validate_length],
 
     start_of_week:

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -40,7 +40,13 @@
           </div>
         </div>
 
-        <%= f.text_field :county, autocomplete: 'off' %>
+        <% if county_options.present? %>
+          <%= f.select :county, options_for_select(county_options(patient.county),
+                                        patient.county), autocomplete: 'off' %>
+        <% else %>
+          <%= f.text_field :county, autocomplete: 'off' %>
+        <% end %>
+
         <%= f.text_field :zipcode, autocomplete: 'off',
                           pattern: '\d{5}(-?\d{4})?'%>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,9 +48,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
     t.datetime "pledge_generated_at", precision: nil
     t.datetime "pledge_sent_at", precision: nil
     t.boolean "textable"
-    t.bigint "clinic_id"
-    t.bigint "pledge_generated_by_id"
-    t.bigint "pledge_sent_by_id"
+    t.integer "clinic_id"
+    t.integer "pledge_generated_by_id"
+    t.integer "pledge_sent_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
@@ -66,8 +66,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
   end
 
   create_table "call_list_entries", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "patient_id", null: false
+    t.integer "user_id", null: false
+    t.integer "patient_id", null: false
     t.string "line_legacy"
     t.integer "order_key", null: false
     t.datetime "created_at", null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
   create_table "calls", force: :cascade do |t|
     t.integer "status", null: false
     t.string "can_call_type", null: false
-    t.bigint "can_call_id", null: false
+    t.integer "can_call_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
@@ -172,7 +172,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
     t.integer "amount"
     t.boolean "active"
     t.string "can_pledge_type", null: false
-    t.bigint "can_pledge_id", null: false
+    t.integer "can_pledge_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
@@ -189,7 +189,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
     t.date "date_of_check"
     t.boolean "audited"
     t.string "can_fulfill_type", null: false
-    t.bigint "can_fulfill_id", null: false
+    t.integer "can_fulfill_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
@@ -221,7 +221,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
 
   create_table "notes", force: :cascade do |t|
     t.string "full_text", null: false
-    t.bigint "patient_id"
+    t.integer "patient_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
@@ -279,10 +279,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
     t.datetime "pledge_generated_at", precision: nil
     t.datetime "pledge_sent_at", precision: nil
     t.boolean "textable"
-    t.bigint "clinic_id"
-    t.bigint "pledge_generated_by_id"
-    t.bigint "pledge_sent_by_id"
-    t.bigint "last_edited_by_id"
+    t.integer "clinic_id"
+    t.integer "pledge_generated_by_id"
+    t.integer "pledge_sent_by_id"
+    t.integer "last_edited_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
@@ -327,7 +327,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_161204) do
     t.boolean "confirmed"
     t.string "source", null: false
     t.string "can_support_type"
-    t.bigint "can_support_id"
+    t.integer "can_support_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fund_id"

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -286,4 +286,28 @@ class PatientsHelperTest < ActionView::TestCase
       assert_equal expected, line_options
     end
   end
+
+  describe 'county_options' do
+    describe 'with a config' do
+      before { create_county_config }
+
+      it 'should include custom counties as well as current' do
+        expected_counties = [nil, 'Arlington', 'Fairfax', 'Montgomery',
+                              "Prince George's"]
+        assert_same_elements expected_counties,
+                            county_options("Prince George's")
+      end
+    end
+
+    describe 'without a config' do
+      it 'should create a config and return empty' do
+        assert_difference 'Config.count', 1 do
+          @options = county_options
+        end
+  
+        assert_empty @options
+        assert Config.find_by(config_key: 'county')
+      end
+    end
+  end
 end

--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -236,5 +236,36 @@ class UpdatingConfigsTest < ApplicationSystemTestCase
       end
     end
 
+    describe 'updating a config - county' do
+      it 'should display dropdown if counties specified and retain previous' do
+        @patient.county = 'Bird'
+        @patient.save!
+
+        fill_in 'config_options_county', with: 'Dog, Cat, Turtle'
+        click_button 'Update options for County'
+        
+        visit edit_patient_path @patient
+
+        within :css, "#patient_information_form" do
+          assert has_select? with_options: %w[Dog Cat Turtle Bird],
+                             selected: 'Bird'
+        end
+      end
+
+      it 'should keep current value when config removed' do
+        @patient.county = 'Bear'
+        @patient.save!
+
+        # no config, so we should get a text box
+        fill_in 'config_options_county', with: ''
+        click_button 'Update options for County'
+        
+        visit edit_patient_path @patient
+
+        within :css, "#patient_information_form" do
+          assert has_field? type: 'text', with: 'Bear'
+        end
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,12 @@ class ActiveSupport::TestCase
                     config_value: { options: insurance_options }
   end
 
+  def create_county_config
+    county_options = ['Arlington', 'Fairfax', 'Montgomery']
+      create :config, config_key: 'county',
+                      config_value: { options: county_options }
+  end
+  
   def create_practical_support_config
     practical_support_options = ['Metallica Tickets', 'Clothing']
     create :config, config_key: 'practical_support',


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* adds a config for county field
* if config is defined, display a dropdown
* otherwise, display text field (existing behavior)

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2771 


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
