### PR TITLE
Remove remote: true from patient delete form

### DIFF
--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -61,8 +61,7 @@
                       patient_path(patient),
                       class: 'btn btn-danger',
                       method: :delete,
-                      data: { confirm: t('patient.dashboard.confirm_del', name: patient.name) },
-                      remote: true %>
+                      data: { confirm: t('patient.dashboard.confirm_del', name: patient.name) } %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

"Remote: true" in the delete-patient-link in the patient dashboard was causing a problem with the redirects when the user confirmed they wanted to delete a patient. Removed it, and ta-da bug seems to be squashed?

This pull request makes the following changes:
* Removes "remote: true" option from the delete patient link.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1979 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
