### PR TITLE
Issue 2804: Config for timezone display

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -86,8 +86,8 @@ class Patient < ApplicationRecord
   # Methods
   def self.pledged_status_summary(line)
     plucked_attrs = [:fund_pledge, :pledge_sent, :id, :name, :appointment_date, :fund_pledged_at]
-    start_of_period = Config.start_day.downcase.to_s == "monthly" ? Time.zone.today.beginning_of_month.in_time_zone
-                                                                  : Time.zone.today.beginning_of_week(Config.start_day).in_time_zone
+    start_of_period = Config.start_day.downcase.to_s == "monthly" ? Time.zone.today.beginning_of_month.in_time_zone(Config.time_zone)
+                                                                  : Time.zone.today.beginning_of_week(Config.start_day).in_time_zone(Config.time_zone)
     # Get patients who have been pledged this week, as a simplified hash
     base = Patient.where(line: line,
                          resolved_without_fund: [false, nil])

--- a/config/initializers/time_with_zone.rb
+++ b/config/initializers/time_with_zone.rb
@@ -2,12 +2,12 @@
 module ActiveSupport
   class TimeWithZone
     def display_date
-      tz = Config.time_zone || Rails.application.time_zone
+      tz = Config.time_zone || Rails.application.config.time_zone
       in_time_zone(tz).strftime("%m/%d/%Y")
     end
 
     def display_time
-      tz = Config.time_zone || Rails.application.time_zone
+      tz = Config.time_zone || Rails.application.config.time_zone
       in_time_zone(tz).strftime("%-l:%M %P")
     end
   end

--- a/config/initializers/time_with_zone.rb
+++ b/config/initializers/time_with_zone.rb
@@ -1,0 +1,14 @@
+# Extends ActiveSupport::TimeWithZone class with convenience methods
+module ActiveSupport
+  class TimeWithZone
+    def display_date
+      tz = Config.time_zone || Rails.application.time_zone
+      in_time_zone(tz).strftime("%m/%d/%Y")
+    end
+
+    def display_time
+      tz = Config.time_zone || Rails.application.time_zone
+      in_time_zone(tz).strftime("%-l:%M %P")
+    end
+  end
+end

--- a/test/initializers/time_with_zone_test.rb
+++ b/test/initializers/time_with_zone_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class TimeWithZoneTest < ActiveSupport::TestCase
+  # The system time of the Rails app is set to ET
+
+  describe "display_date" do
+    it "converts a time_with_zone stored in system time to the configured time zone and displays" do
+      config = Config.create(config_key: :time_zone, config_value: { options: ['Eastern'] })
+      time = Time.zone.local(2023, 2, 10, 1, 30, 45)
+      
+      assert_equal "02/10/2023", time.display_date
+
+      config.update(config_value: { options: ['Central'] })
+      assert_equal "02/10/2023", time.display_date
+
+      config.update(config_value: { options: ['Mountain'] })
+      assert_equal "02/09/2023", time.display_date
+
+      config.update(config_value: { options: ['Pacific'] })
+      assert_equal "02/09/2023", time.display_date
+    end
+  end
+
+  describe "display_time" do
+    it "converts a time_with_zone stored in system time to the configured time zone and displays" do
+      config = Config.create(config_key: :time_zone, config_value: { options: ['Eastern'] })
+      time = Time.zone.local(2023, 2, 10, 1, 30, 45)
+      
+      assert_equal "1:30 am", time.display_time
+
+      config.update(config_value: { options: ['Central'] })
+      assert_equal "12:30 am", time.display_time
+
+      config.update(config_value: { options: ['Mountain'] })
+      assert_equal "11:30 pm", time.display_time
+
+      config.update(config_value: { options: ['Pacific'] })
+      assert_equal "10:30 pm", time.display_time
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Added the ability for users to configure the time zone for their fund. I chose to use shorter strings than those required by ActiveSupport to limit typo errors and then do some simple mapping on the backend.

Extended the `ActiveSupport::TimeWithZone` class (similar to how we extend `Date` and `Time`). We couldn't add to the existing extension methods b/c `Date` and `Time` are not time zone aware. They're still used if we have instances of those classes but most of our dates (like `created_at`) are actually `TimeWithZone`.

Used the new config to make `Patient.pledged_status_summary` time zone aware.

This pull request makes the following changes:
* Add `config_key` for time zone and add cleaners and validations for this new config
* Add `display_date` and `display_time` for `ActiveSupport::TimeWithZone` to take care of correctly displaying the date/time in the fund's configured time zone.
* Added `titleize_capitalization` but let me know if that's too much, I can remove since we use `capitalize` everywhere else. I could just take care of titleizing in the getter.
* Updated `Patient.pledged_status_summary` to use the config timezone as the param to `in_time_zone`

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2804

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
