### PR TITLE
Update Gemfile.lock for ruby 3.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,7 +491,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 3.2.0p0
+   ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.5
+   2.4.6


### PR DESCRIPTION
Follow-up needed after #2836 was merged.