### PR TITLE
Upgrade to papertrail 14 (safe, the breaking changes are to yaml)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'bootstrap_form', '~> 4.5.0'
 
 # Our database is postgres
 gem 'pg', '~> 1.2'
-gem 'paper_trail', '~> 13.0'
+gem 'paper_trail', '~> 14.0'
 gem 'activerecord-session_store'
 
 # Our authentication library is devise, with oauth2 for google signin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,9 +256,9 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    paper_trail (13.0.0)
-      activerecord (>= 5.2)
-      request_store (~> 1.1)
+    paper_trail (14.0.0)
+      activerecord (>= 6.0)
+      request_store (~> 1.4)
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
@@ -460,7 +460,7 @@ DEPENDENCIES
   nokogiri (>= 1.13.4)
   omniauth-google-oauth2 (~> 1.1.1)
   omniauth-rails_csrf_protection (~> 1.0)
-  paper_trail (~> 13.0)
+  paper_trail (~> 14.0)
   pdf-inspector
   pg (~> 1.2)
   prawn


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

#2760 is a little snarled up, so doing this on its own.

The breaking changes from https://github.com/paper-trail-gem/paper_trail/blob/master/CHANGELOG.md:

```
https://github.com/paper-trail-gem/paper_trail/pull/1399 - Same change re: YAML.safe_load as in 13.0.0, but this time for Rails 6.0 and 6.1.
        This change only affects users whose versions table has object or object_changes columns of type text, and who use the YAML serializer. People who use the JSON serializer, or those with json(b) columns, are unaffected.
        Please see [doc/pt_13_yaml_safe_load.md](https://github.com/paper-trail-gem/paper_trail/blob/master/doc/pt_13_yaml_safe_load.md) for details.
    https://github.com/paper-trail-gem/paper_trail/pull/1406 - Certain [Metadata](https://github.com/paper-trail-gem/paper_trail#4c-storing-metadata) keys are now forbidden, like id, and item_type. These keys are reserved by PT.
        This change is unlikely to affect anyone. It is not expected that anyone uses these metadata keys. Most people probably don't use PT metadata at all.
```

so, looks okay to me. (sorry for my slowness here.)

This pull request makes the following changes:
* papertrail to v14

no views
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
