### PR TITLE
Issue 2586: encrypt note content

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,6 +1,7 @@
 # A case manager's log of their interactions with a patient.
 class Note < ApplicationRecord
   acts_as_tenant :fund
+  encrypts :full_text
 
   # Concerns
   include PaperTrailable

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,11 @@ module DARIA
 
     # Custom exceptions pages
     config.exceptions_app = self.routes
+
+    # temporary, can be removed in separate release once data migration for encrypted data is complete
+    config.active_record.encryption.support_unencrypted_data = true
+    # the first key in the list is the active key to perform encryptions, the rest of the list is decryption keys (to support key rotation)
+    config.active_record.encryption.primary_key = [ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "default_primary_key")]
+    config.active_record.encryption.key_derivation_salt = ENV.fetch("ACTIVE_RECORD_KEY_DERIVATION_SALT", "default_salt")
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -70,4 +70,6 @@ Rails.application.configure do
 
   # Set mailer default url to localhost in tests.
   config.action_mailer.default_url_options = { :host => 'localhost' }
+  #  all the encryptable attributes will be encrypted according to the encryption settings defined in the model
+  config.active_record.encryption.encrypt_fixtures = true
 end

--- a/lib/tasks/encrypt_notes.rake
+++ b/lib/tasks/encrypt_notes.rake
@@ -1,0 +1,8 @@
+namespace :note do
+  desc "update notes to be encrypted with ActiveRecord encryption"
+  task encrypt_full_text: :environment do
+    Note.all.find_each do |note|
+      note.encrypt
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR uses ActiveRecord encryption to encrypt note full_text at rest.

This pull request makes the following changes:
* configure app to support ActiveRecord encryption
* encrypt note full_text
* add rake task to run post-deploy to encrypt all existing notes

It relates to the following issue #s: 
* Fixes #2586

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
