### PR TITLE
Practical support: add support_date field

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -97,6 +97,7 @@ class PatientsController < ApplicationController
   def edit
     # i18n-tasks-use t('activerecord.attributes.practical_support.confirmed')
     # i18n-tasks-use t('activerecord.attributes.practical_support.source')
+    # i18n-tasks-use t('activerecord.attributes.practical_support.support_date')
     # i18n-tasks-use t('activerecord.attributes.practical_support.support_type')
     # i18n-tasks-use t('activerecord.attributes.external_pledge.active')
     # i18n-tasks-use t('activerecord.attributes.external_pledge.amount')

--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -40,7 +40,7 @@ class PracticalSupportsController < ApplicationController
 
   def practical_support_params
     params.require(:practical_support)
-          .permit(:confirmed, :source, :support_type, :amount)
+          .permit(:confirmed, :source, :support_type, :amount, :support_date)
   end
 
   def find_patient

--- a/app/javascript/styles/buttons.scss
+++ b/app/javascript/styles/buttons.scss
@@ -105,3 +105,8 @@
 .btn[data-orientation='cancel'] {
   color: $red;
 }
+
+// Styling for the remove button for practical supports
+.practical-support-remove {
+  margin-top: -3.25rem;
+}

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -10,8 +10,7 @@ class PracticalSupport < ApplicationRecord
 
   # Validations
   validates :source, :support_type, presence: true, length: { maximum: 150 }
-  validates :support_type, uniqueness: { scope: :can_support }
-  validates :amount, 
-              allow_nil: true,
-              numericality: { greater_than_or_equal_to: 0 }
+  validates :amount,
+            allow_nil: true,
+            numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -10,20 +10,24 @@
         </span>
       </div>
 
-      <div class="col-5">
+      <div class="col-4">
         <%= f.select :source,
                      options_for_select(practical_support_source_options(practical_support.source),
                                         practical_support.source),
                      hide_label: true %>
       </div>
 
-      <div class="col-4">
+      <div class="col-3">
         <%= f.number_field :amount,
                            value: number_to_currency(f.object.amount.to_f, unit: '', delimiter: ''),
                            hide_label: true,
                            autocomplete: 'off',
                            prepend: '$',
                            step: '0.01' %>
+      </div>
+
+      <div class="col-2">
+        <%= f.date_field :support_date, autocomplete: 'off', hide_label: true %>
       </div>
 
       <div class="col-2">

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -1,7 +1,7 @@
 <div class="row info-form practical-support-item" id="practical-support-item-<%= practical_support.id %>">
   <%= bootstrap_form_with model: practical_support,
                          url: patient_practical_support_path(patient, practical_support),
-                         html: { class: 'edit_practical_support col-10' },
+                         html: { class: 'edit_practical_support col-12' },
                          local: false do |f| %>
     <div class="row">
       <div class="col-3">
@@ -10,14 +10,14 @@
         </span>
       </div>
 
-      <div class="col-4">
+      <div class="col-5">
         <%= f.select :source,
                      options_for_select(practical_support_source_options(practical_support.source),
                                         practical_support.source),
                      hide_label: true %>
       </div>
 
-      <div class="col-3">
+      <div class="col-4">
         <%= f.number_field :amount,
                            value: number_to_currency(f.object.amount.to_f, unit: '', delimiter: ''),
                            hide_label: true,
@@ -26,25 +26,25 @@
                            step: '0.01' %>
       </div>
 
-      <div class="col-2">
+      <div class="col-3">
         <%= f.date_field :support_date, autocomplete: 'off', hide_label: true %>
       </div>
 
-      <div class="col-2">
+      <div class="col-5">
         <%= f.form_group :confirmed do %>
           <%= f.check_box :confirmed,
                           id: "practical_support_confirmed_#{practical_support.id}" %>
         <% end %>
       </div>
-    </div>
-  <% end %>
 
-  <div class="col">
-    <%= button_to t('patient.practical_support.remove'),
+      <div class="col-4">
+      <%= button_to t('patient.practical_support.remove'),
                   patient_practical_support_path(patient, practical_support),
                   remote: true,
                   method: :delete,
                   data: { confirm: t('patient.practical_support.delete_confirm') },
-                  class: "btn btn-danger" %>
-  </div>
+                  class: "btn btn-danger float-right" %>
+                  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -36,6 +36,7 @@
                           id: "practical_support_confirmed_#{practical_support.id}" %>
         <% end %>
       </div>
+  <% end %>
 
       <div class="col-4">
       <%= button_to t('patient.practical_support.remove'),
@@ -46,5 +47,4 @@
                   class: "btn btn-danger float-right" %>
                   </div>
     </div>
-  <% end %>
 </div>

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -36,15 +36,14 @@
                           id: "practical_support_confirmed_#{practical_support.id}" %>
         <% end %>
       </div>
-  <% end %>
-
-      <div class="col-4">
-      <%= button_to t('patient.practical_support.remove'),
-                  patient_practical_support_path(patient, practical_support),
-                  remote: true,
-                  method: :delete,
-                  data: { confirm: t('patient.practical_support.delete_confirm') },
-                  class: "btn btn-danger float-right" %>
-                  </div>
     </div>
+  <% end %>
+  <div class="col-12">
+      <%= button_to t('patient.practical_support.remove'),
+                patient_practical_support_path(patient, practical_support),
+                remote: true,
+                method: :delete,
+                data: { confirm: t('patient.practical_support.delete_confirm') },
+                class: "btn btn-danger float-right practical-support-remove" %>
+  </div>
 </div>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -1,20 +1,20 @@
 <% if patient.practical_supports.present? %>
-<div class="row practical-support-headers">
-  <div class="col-10">
-    <div class="row">
-      <h5 class="col-3"><%= t 'patient.practical_support.support_needed' %></h5>
-      <h5 class="col-4"><%= t 'patient.practical_support.point_of_contact' %></h5>
-      <h5 class="col-3">Amount</h5>
-      <h5 class="col-2"><%= t 'patient.practical_support.support_date' %></h5>
+  <div class="row practical-support-headers">
+    <div class="col-12">
+      <div class="row">
+        <h5 class="col-3"><%= t 'patient.practical_support.support_needed' %></h5>
+        <h5 class="col-5"><%= t 'patient.practical_support.point_of_contact' %></h5>
+        <h5 class="col-4">Amount</h5>
+      </div>
     </div>
+    <div class="col"><!-- Where button would go --></div>
   </div>
-  <div class="col"><!-- Where button would go --></div>
-</div>
-
-<% patient.practical_supports.each do |entry| %>
   <hr/>
-  <%= render 'practical_supports/edit',
-             patient: patient,
-             practical_support: entry %>
+
+  <% patient.practical_supports.each do |entry| %>
+    <%= render 'practical_supports/edit',
+              patient: patient,
+              practical_support: entry %>
+    <hr/>
   <% end %>
 <% end %>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -3,8 +3,9 @@
   <div class="col-10">
     <div class="row">
       <h5 class="col-3"><%= t 'patient.practical_support.support_needed' %></h5>
-      <h5 class="col-5"><%= t 'patient.practical_support.point_of_contact' %></h5>
-      <h5 class="col-4">Amount</h5>
+      <h5 class="col-4"><%= t 'patient.practical_support.point_of_contact' %></h5>
+      <h5 class="col-3">Amount</h5>
+      <h5 class="col-2"><%= t 'patient.practical_support.support_date' %></h5>
     </div>
   </div>
   <div class="col"><!-- Where button would go --></div>

--- a/app/views/practical_supports/_new.html.erb
+++ b/app/views/practical_supports/_new.html.erb
@@ -6,6 +6,7 @@
   <%= f.select :support_type, practical_support_options %>
   <%= f.select :source, practical_support_source_options %>
   <%= f.number_field :amount, autocomplete: 'off', prepend: '$', step: '0.01' %>
+  <%= f.date_field :support_date, autocomplete: 'off' %>
   <%= f.check_box :confirmed %>
   <br />
   <%= f.submit t('patient.practical_support.create'), class: 'btn btn-primary', id: 'create-practical-support' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
       practical_support:
         confirmed: Confirmed
         source: Source
+        support_date: Support date
         support_type: Support type
       user:
         current_password: Current password
@@ -576,6 +577,7 @@ en:
       new: 'Record new practical support info:'
       point_of_contact: Point of contact
       remove: Remove
+      support_date: Support date
       support_needed: Support needed
       title: Practical support
     shared:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,7 +577,6 @@ en:
       new: 'Record new practical support info:'
       point_of_contact: Point of contact
       remove: Remove
-      support_date: Support date
       support_needed: Support needed
       title: Practical support
     shared:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -577,7 +577,6 @@ es:
       new: 'Grabar nueva información de soporte práctico:'
       point_of_contact: Punto de contacto
       remove: Elimina
-      support_date: Día de el apoyo
       support_needed: Soporte Necesarios
       title: Apoyo practico
     shared:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -102,6 +102,7 @@ es:
       practical_support:
         confirmed: Confirmado
         source: Fuente
+        support_date: Día de el apoyo
         support_type: Tipo de apoyo
       user:
         current_password: Contraseña actual
@@ -576,6 +577,7 @@ es:
       new: 'Grabar nueva información de soporte práctico:'
       point_of_contact: Punto de contacto
       remove: Elimina
+      support_date: Día de el apoyo
       support_needed: Soporte Necesarios
       title: Apoyo practico
     shared:

--- a/db/migrate/20230327181226_add_support_date_to_practical_support.rb
+++ b/db/migrate/20230327181226_add_support_date_to_practical_support.rb
@@ -1,0 +1,5 @@
+class AddSupportDateToPracticalSupport < ActiveRecord::Migration[7.0]
+  def change
+    add_column :practical_supports, :support_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_13_192110) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_27_181226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -347,6 +347,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_13_192110) do
     t.datetime "updated_at", null: false
     t.bigint "fund_id"
     t.decimal "amount", precision: 8, scale: 2
+    t.date "support_date"
     t.index ["can_support_type", "can_support_id"], name: "index_practical_supports_on_can_support_type_and_can_support_id"
     t.index ["fund_id"], name: "index_practical_supports_on_fund_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -172,7 +172,7 @@ fund2 = Fund.create! name: 'CatFund',
       end
 
       if i % 3 == 0
-        patient.practical_supports.create! support_type: 'Car rides', source: 'Neighbor'
+        patient.practical_supports.create! support_type: 'Car rides', source: 'Neighbor', support_date: 3.days.from_now
       end
 
       if i % 5 == 0

--- a/test/controllers/practical_supports_controller_test.rb
+++ b/test/controllers/practical_supports_controller_test.rb
@@ -25,8 +25,9 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should respond bad_request if the support record does not save' do
-      # submitting a duplicate support
-      post patient_practical_supports_path(@patient), params: { practical_support: @support }, xhr: true
+      # submitting a support with an invalid source
+      invalid_support = attributes_for :practical_support, source: Faker::Lorem.characters(number: 151)
+      post patient_practical_supports_path(@patient), params: { practical_support: invalid_support }, xhr: true
       assert response.body.include? 'failed to save'
     end
 

--- a/test/controllers/practical_supports_controller_test.rb
+++ b/test/controllers/practical_supports_controller_test.rb
@@ -48,7 +48,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
                                          source: 'Transit',
                                          amount: 10
       @support = @patient.practical_supports.first
-      @support_edits = { support_type: 'Lodging' }
+      @support_edits = { support_type: 'Lodging', support_date: 3.days.from_now.to_date }
       patch patient_practical_support_path(@patient, @support),
             params: { practical_support: @support_edits },
             xhr: true
@@ -61,6 +61,10 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
 
     it 'should update the support_type field' do
       assert_equal @support.support_type, 'Lodging'
+    end
+
+    it 'should update the support_date field' do
+      assert_equal @support.support_date, 3.days.from_now.to_date
     end
 
     [:source, :support_type].each do |field|
@@ -79,6 +83,14 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
 
     it 'should allow blank amount' do
       @support_edits[:amount] = nil
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: @support_edits },
+            xhr: true
+      assert response.body.include? 'saved'
+    end
+
+    it 'should allow blank support_date' do
+      @support_edits[:support_date] = nil
       patch patient_practical_support_path(@patient, @support),
             params: { practical_support: @support_edits },
             xhr: true

--- a/test/factories/practical_support.rb
+++ b/test/factories/practical_support.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
       "Support #{n}"
     end
     confirmed { false }
+    support_date { 2.days.from_now }
   end
 end

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -8,7 +8,8 @@ class PracticalSupportTest < ActiveSupport::TestCase
                                        source: 'Metallica Abortion Fund'
     @patient.practical_supports.create support_type: 'Swag',
                                        source: 'YOLO AF',
-                                       confirmed: true
+                                       confirmed: true,
+                                       support_date: 2.days.from_now
     @patient.practical_supports.create support_type: 'Companion',
                                        source: 'Cat',
                                        amount: 32

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -33,16 +33,5 @@ class PracticalSupportTest < ActiveSupport::TestCase
         refute @psupport1.valid?
       end
     end
-
-    it 'should enforce uniqueness of support_type' do
-      fields = attributes_for :practical_support, support_type: 'hello'
-      support1 = @patient.practical_supports.create fields
-      assert support1.valid?
-
-      support2 = @patient.practical_supports.new fields
-      refute support2.valid?
-      assert_equal ['has already been taken'],
-                   support2.errors.messages[:support_type]
-    end
   end
 end


### PR DESCRIPTION
Complex abortions can be a multi-day process, and patients may need rides etc on multiple days. We should adjust our practical support flow to allow this case.

This pull request makes the following changes:
* Remove support type uniqueness constraint
* Add support_date to practical support model
* Update practical support UI to allow editing support_date

<img width="875" alt="image" src="https://user-images.githubusercontent.com/9774690/228042514-ea702ceb-b412-4b09-ba7f-814e8a624993.png">

It relates to the following issue #s: 
* Fixes #2882 

Open questions
* I didn't add any validations for support_date. I didn't think it made sense to require presence b/c there will be a whole bunch of existing records without a date. Let me know if you want any validation checking that the date is in the future or something like that.
* Let me know if you prefer something different for the UI changes.
* I'm not great at Spanish, I think my translation makes sense but probably good to have someone fluent make sure it's correct.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
