### PR TITLE
Issue 413: Encrypt sensitive data in the event table

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,6 +5,9 @@ class Event < ApplicationRecord
   # Relations
   belongs_to :line
 
+  encrypts :cm_name
+  encrypts :patient_name
+
   # Enums
   enum event_type: {
     reached_patient: 0,

--- a/lib/tasks/encrypt_event_columns.rake
+++ b/lib/tasks/encrypt_event_columns.rake
@@ -1,0 +1,8 @@
+namespace :event do
+  desc "update events to be encrypted with ActiveRecord encryption"
+  task encrypt_sensitive_columns: :environment do
+    Event.all.find_each do |event|
+      event.encrypt
+    end
+  end
+end

--- a/lib/tasks/encrypt_notes.rake
+++ b/lib/tasks/encrypt_notes.rake
@@ -1,8 +1,0 @@
-namespace :note do
-  desc "update notes to be encrypted with ActiveRecord encryption"
-  task encrypt_full_text: :environment do
-    Note.all.find_each do |note|
-      note.encrypt
-    end
-  end
-end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR encrypts sensitive event data at-rest.

This pull request makes the following changes:
* Encrypts sensitive event columns
* Adds post-deploy rake task to encrypt existing event data
    * run `rails event:encrypt_sensitive_columns` after you deploy this branch
    * if you run a select query on the events table in production, you should see both `cm_name` and `patient_name` are encrypted
* Removes note encryption task that has already been run in production (this is just some clean up)

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Bumps #413 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
