### PR TITLE
Issue 413: Encrypt sensitive data in the clinics table

### DIFF
--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -9,6 +9,15 @@ class Clinic < ApplicationRecord
   # e.g. so a fund can have an 'OTHER CLINIC' catchall.
   EXCLUDED_ZIP = '99999'
 
+  encrypts :name
+  encrypts :street_address
+  encrypts :city
+  encrypts :state
+  encrypts :zip
+  encrypts :phone
+  encrypts :fax
+  encrypts :email_for_pledges
+
   # Scopes
   # Is gestational_limit either nil or above x?
   scope :gestational_limit_above, ->(gestation) {

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -9,7 +9,7 @@ class Clinic < ApplicationRecord
   # e.g. so a fund can have an 'OTHER CLINIC' catchall.
   EXCLUDED_ZIP = '99999'
 
-  encrypts :name
+  encrypts :name, deterministic: true
   encrypts :street_address
   encrypts :city
   encrypts :state

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,5 +66,6 @@ module DARIA
     # the first key in the list is the active key to perform encryptions, the rest of the list is decryption keys (to support key rotation)
     config.active_record.encryption.primary_key = [ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "default_primary_key")]
     config.active_record.encryption.key_derivation_salt = ENV.fetch("ACTIVE_RECORD_KEY_DERIVATION_SALT", "default_salt")
+    config.active_record.encryption.deterministic_key = [ENV.fetch("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY", "default_deterministic_key")]
   end
 end

--- a/lib/tasks/encrypt_clinic_columns.rake
+++ b/lib/tasks/encrypt_clinic_columns.rake
@@ -1,0 +1,8 @@
+namespace :clinic do
+  desc "update clinics to be encrypted with ActiveRecord encryption"
+  task encrypt_sensitive_columns: :environment do
+    Clinic.all.find_each do |clinic|
+      clinic.encrypt
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR encrypts sensitive clinic data at-rest.

This pull request makes the following changes:
* Configures deterministic encryption to support cases where that's required (like when we want to have uniqueness validation)
    * You'll want to set an env var in production for `ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY` prior to running the post-deploy rake task
* Encrypts sensitive clinic columns
* Adds post-deploy rake task to encrypt existing clinic data
    * run `rails clinic:encrypt_sensitive_columns` after you deploy this branch
    * if you run a select query on the clinics table in production, you should see both a bunch of the columns are encrypted

It relates to the following issue #s: 
* Bumps #413 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
