### PR TITLE
Add Practical Support Mode!

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -36,6 +36,13 @@ class PatientsController < ApplicationController
     end
   end
 
+  def complete
+    @patient = Patient.find params[:patient_id]
+    respond_to do |format|
+      format.js
+    end
+  end
+
   # download a filled out pledge form based on patient record
   def download
     if params[:case_manager_name].blank?
@@ -189,7 +196,7 @@ class PatientsController < ApplicationController
                              :fund_payout, :check_number, :date_of_check, :audited]
   ].freeze
 
-  OTHER_PARAMS = [:shared_flag, :initial_call_date, :pledge_sent].freeze
+  OTHER_PARAMS = [:shared_flag, :initial_call_date, :pledge_sent, :marked_complete].freeze
 
   def patient_params
     permitted_params = [].concat(

--- a/app/helpers/pledges_helper.rb
+++ b/app/helpers/pledges_helper.rb
@@ -16,6 +16,22 @@ module PledgesHelper
     end
   end
 
+  def mark_complete_button
+    content_tag :span, class: 'btn btn-primary btn-lg submit-btn btn-block',
+                       aria: { hidden: true },
+                       id: 'submit-pledge-button' do
+      t('patient.menu.mark_complete')
+    end 
+  end
+
+  def mark_incomplete_button
+    content_tag :span, class: 'btn btn-warning btn-lg cancel-btn btn-block',
+                       aria: { hidden: true },
+                       id: 'submit-pledge-button' do
+      t('patient.menu.mark_incomplete')
+    end 
+  end
+
   def clinic_pledge_email(patient)
     email = patient.clinic&.email_for_pledges
     return unless email

--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -20,10 +20,13 @@ module Statusable
     dropoff: { key: I18n.t('patient.status.key.dropoff'),
                help_text: I18n.t('patient.status.help.dropoff')},
     resolved: { key: I18n.t('patient.status.key.resolved', fund: ActsAsTenant.current_tenant&.name),
-                help_text: I18n.t('patient.status.help.resolved')}
+                help_text: I18n.t('patient.status.help.resolved')},
+    completed: { key: I18n.t('patient.status.key.completed'),
+                 help_text: I18n.t('patient.status.help.completed') },
   }.freeze
 
   def status
+    return STATUSES[:completed][:key] if practical_support_completed?
     return STATUSES[:fulfilled][:key] if fulfillment.fulfilled?
     return STATUSES[:resolved][:key] if resolved_without_fund?
     return STATUSES[:pledge_unfulfilled][:key] if days_since_pledge_sent > 150
@@ -35,6 +38,10 @@ module Statusable
   end
 
   private
+
+  def practical_support_completed?
+    Config.practical_support_mode? && marked_complete?
+  end
 
   def contact_made?
     calls.each do |call|

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-sm-12">
-    <% unless Config.hide_budget_bar? %>
+    <% unless Config.hide_budget_bar? or Config.practical_support_mode? %>
       <%= render partial: 'dashboards/overview' %>
     <% end %>
     <%= render partial: 'dashboards/search_form' %>

--- a/app/views/patients/_complete.html.erb
+++ b/app/views/patients/_complete.html.erb
@@ -1,0 +1,55 @@
+<% if not patient.marked_complete %>
+  <div class="modal-header">
+    <h4 class="modal-title"><%= t('patient.complete.title') %></h4>
+  </div>
+
+  <div class="modal-body">
+    <div class="row">
+      <%= t('patient.complete.body') %>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <div class="col">
+      <button type="button" class="btn btn-outline-secondary js-btn-step float-left" style="color:red;" data-dismiss="modal"><%= t('common.no') %></button>
+    </div>
+    
+    <div class="col">
+      <%= bootstrap_form_with model: @patient,
+                              html: { id: 'submit-pledge-form' },
+                              local: false,
+                              method: 'patch',
+                              class: 'edit_patient' do |f| %>
+        <%= f.hidden_field :marked_complete, value: true %>
+        <%= f.submit t('common.yes'), class: "btn btn-success js-btn-step float-right", id: 'submit-pledge-submit'%>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <div class="modal-header">
+    <h4 class="modal-title"><%= t('patient.complete.cancel.title') %></h4>
+  </div>
+
+  <div class="modal-body">
+    <div class="row">
+      <p><%= t('patient.complete.cancel.confirm') %></p>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <div class="col">
+      <button type="button" class="btn btn-outline-secondary js-btn-step float-left" style="color:red;" data-dismiss="modal"><%= t('common.no') %></button>
+    </div>
+
+    <div class="col">
+      <%= bootstrap_form_with model: @patient,
+                              html: { id: 'cancel-pledge-form' },
+                              local: false,
+                              method: 'patch',
+                              class: 'edit_patient' do |f| %>
+        <%= f.hidden_field :marked_complete, value: false %>
+        <%= f.submit t('common.yes'), class: "btn btn-success js-btn-step float-right", id: 'cancel-pledge-submit'%>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -1,14 +1,14 @@
 <div id='menu-content' class="row mt-5">
   <div class="nav nav-pills flex-column abortion-left-menu" id='menu-list' role='tablist' aria-orientation="vertical">
     <%= render 'menu_item', link_for: 'patient_information', active: true %>
-    <%= render 'menu_item', link_for: 'abortion_information', active: false %>
+    <%= render 'menu_item', link_for: 'abortion_information', active: false unless Config.practical_support_mode? %>
     <%= render 'menu_item', link_for: 'practical_support', active: false unless Config.hide_practical_support? %>
     <%= render 'menu_item', link_for: 'notes', active: false %>
     <%= render 'menu_item', link_for: 'change_log', active: false %>
     <%= render 'menu_item', link_for: 'call_log', active: false %>
 
     <% if current_user.allowed_data_access? && patient.pledge_sent? %>
-      <%= render 'menu_item', link_for: 'pledge_fulfillment', active: false %>
+      <%= render 'menu_item', link_for: 'pledge_fulfillment', active: false unless Config.practical_support_mode? %>
     <% end %>
   </div>
 </div>

--- a/app/views/patients/_menu_pledge_button.html.erb
+++ b/app/views/patients/_menu_pledge_button.html.erb
@@ -1,13 +1,29 @@
-<% if not patient.pledge_sent? %>
-  <%= link_to submit_pledge_button,
-              submit_pledge_path(patient),
-              class: 'submit-pledge-button',
-              aria: { label: t('patient.menu.submit_pledge') },
-              remote: true %>
+<% if Config.practical_support_mode? %>
+  <% if not patient.marked_complete? %>
+    <%= link_to mark_complete_button,
+                mark_complete_path(patient),
+                class: 'submit-pledge-button', # reuse classes from submit pledge button
+                aria: { label: t('patient.menu.mark_complete') },
+                remote: true %>
+  <% else %>
+    <%= link_to mark_incomplete_button,
+                mark_complete_path(patient),
+                class: 'submit-pledge-button',
+                aria: { label: t('patient.menu.mark_incomplete') },
+                remote: true %>
+  <% end %>
 <% else %>
-  <%= link_to cancel_pledge_button,
-              submit_pledge_path(patient),
-              class: 'submit-pledge-button',
-              aria: { label: t('patient.menu.cancel_pledge') },
-              remote: true %>
+  <% if not patient.pledge_sent? %>
+    <%= link_to submit_pledge_button,
+                submit_pledge_path(patient),
+                class: 'submit-pledge-button',
+                aria: { label: t('patient.menu.submit_pledge') },
+                remote: true %>
+  <% else %>
+    <%= link_to cancel_pledge_button,
+                submit_pledge_path(patient),
+                class: 'submit-pledge-button',
+                aria: { label: t('patient.menu.cancel_pledge') },
+                remote: true %>
+  <% end %>
 <% end %>

--- a/app/views/patients/complete.js.erb
+++ b/app/views/patients/complete.js.erb
@@ -1,0 +1,17 @@
+$('.modal-content').html('')
+$('.modal').attr('id', 'pledge-modal')
+$('.modal-content').append(
+  '<%= escape_javascript(render partial: "patients/complete", locals: { patient: @patient, disable_next: disable_continue?(@patient) })%>'
+);
+
+$('.modal').modal('toggle');
+
+<% if (!@patient.marked_complete) %>
+
+  $('#pledge-modal').modalSteps();
+  
+<% else %>
+  $('#cancel-pledge-form').on('submit', function() {
+    $('.modal').modal('hide');
+  })
+<% end %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -14,9 +14,11 @@
       <%= render 'patients/patient_information', patient: @patient %>
     </div>
 
+    <% unless Config.practical_support_mode? %>
     <div id="abortion_information" class="abortion-info tab-pane">
       <%= render 'patients/abortion_information', patient: @patient, new_external_pledge: @external_pledge %>
     </div>
+    <% end %>
 
     <div id="change_log" class="change-log tab-pane">
       <%= render 'patients/change_log', patient: @patient %>
@@ -32,15 +34,15 @@
 
 
     <% unless Config.hide_practical_support? %>
-    <div id="practical_support" class="practical_support tab-pane">
-      <%= render 'patients/practical_support', patient: @patient, note: @note %>
-    </div>
-    <% end %>
+      <div id="practical_support" class="practical_support tab-pane">
+        <%= render 'patients/practical_support', patient: @patient, note: @note %>
+      </div>
 
-    <div id="pledge_fulfillment" class="pledge-fulfillment-info tab-pane">
-      <% if current_user.allowed_data_access? && @patient.pledge_sent? %>
-        <%= render 'patients/fulfillment', patient: @patient %>
-      <% end %>
-    </div>
+      <div id="pledge_fulfillment" class="pledge-fulfillment-info tab-pane">
+        <% if current_user.allowed_data_access? && @patient.pledge_sent? %>
+          <%= render 'patients/fulfillment', patient: @patient %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -29,7 +29,7 @@ $('#change_log').html(
 $('#patient_shared_flag').prop('checked', <%= @patient.shared_flag? %>);
 
 // if pledge is sent, re-rack fulfillment info
-<% if current_user.allowed_data_access? && @patient.pledge_sent? %>
+<% if current_user.allowed_data_access? && !Config.practical_support_mode && @patient.pledge_sent? %>
   // populate the fulfillment form if it's supposed to be there and not there already
   if ($('#pledge_fulfillment-menu-item').length == 0) {
     $('#pledge_fulfillment').empty()

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,6 +397,12 @@ en:
         change: Change (from -> to)
         modified_date: Modified Date
       title: Patient history
+    complete:
+      body: Is this patient completed?
+      cancel:
+        confirm: Are you sure you want to mark this patient incomplete?
+        title: Mark Incomplete
+      title: Confirm Completion
     dashboard:
       approx_gestation: 'Approx gestation at appt: %{weeks} weeks %{days} days'
       called_on: 'Called on: %{date}'
@@ -502,6 +508,8 @@ en:
       call_log: Call Log
       cancel_pledge: Cancel pledge
       change_log: Change Log
+      mark_complete: Mark Complete
+      mark_incomplete: Mark Incomplete
       notes: Notes
       patient_information: Patient Information
       pledge_fulfillment: Pledge Fulfillment
@@ -585,6 +593,7 @@ en:
       status: Status
     status:
       help:
+        completed: Patient has been marked completed for practical support.
         dropoff: Patient has not been heard from in 120+ days.
         fulfilled: Patient has been marked fulfilled.
         fundraising: The patient has an appointment date, and is working on raising funds.
@@ -595,6 +604,7 @@ en:
         pledge_unfulfilled: Patient had a pledge sent 150+ days ago but has not cashed it.
         resolved: Patient has decided to not involve the fund in their plans.
       key:
+        completed: Support Completed
         dropoff: Probable Dropoff
         fulfilled: Pledge Fulfilled
         fundraising: Fundraising

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -397,6 +397,12 @@ es:
         change: Cambiar (de -> a)
         modified_date: Fecha modificada
       title: Historia del paciente
+    complete:
+      body: "¿Este paciente está completo?"
+      cancel:
+        confirm: "¿Estás seguro de que deseas marcar a este paciente como incompleto?"
+        title: Marcar incompleto
+      title: Confirmar finalización
     dashboard:
       approx_gestation: 'Aprox la gestación en la cita: %{weeks} semanas %{days} días'
       called_on: 'Llamado en: %{date}'
@@ -502,6 +508,8 @@ es:
       call_log: Registro de Llamadas
       cancel_pledge: Cancelar Promesa
       change_log: Registro de Cambios
+      mark_complete: Marcar completo
+      mark_incomplete: Marcar incompleto
       notes: Notas
       patient_information: Información del Paciente
       pledge_fulfillment: Cumplimiento de la Promesa
@@ -585,6 +593,7 @@ es:
       status: Estatus
     status:
       help:
+        completed: El paciente ha sido marcado como completado para recibir apoyo práctico.
         dropoff: Paciente no ha sido escuchado en 120+ días.
         fulfilled: El paciente ha sido marcado cumplido.
         fundraising: El paciente tiene una cita y está trabajando para recaudar fondos.
@@ -595,6 +604,7 @@ es:
         pledge_unfulfilled: El paciente tenía una promesa enviada hace 150+ días, pero no la ha cobrado.
         resolved: El paciente ha decidido no involucrar al fondo en sus planes.
       key:
+        completed: Apoyo Completado
         dropoff: Probable Abandono
         fulfilled: Promesa Cumplida
         fundraising: Recaudación de fondos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
     end
 
     get 'patients/:patient_id/submit_pledge', to: 'patients#pledge', as: 'submit_pledge'
+    get 'patients/:patient_id/mark_complete', to: 'patients#complete', as: 'mark_complete'
 
     get 'data_entry', to: 'patients#data_entry', as: 'data_entry' # temporary
     post 'data_entry', to: 'patients#data_entry_create', as: 'data_entry_create' # temporary

--- a/db/migrate/20230712194816_add_marked_complete_to_patient.rb
+++ b/db/migrate/20230712194816_add_marked_complete_to_patient.rb
@@ -1,0 +1,5 @@
+class AddMarkedCompleteToPatient < ActiveRecord::Migration[7.0]
+  def change
+    add_column :patients, :marked_complete, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_27_181226) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_12_194816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -304,6 +304,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_181226) do
     t.bigint "line_id", null: false
     t.boolean "solidarity"
     t.string "solidarity_lead"
+    t.boolean "marked_complete"
     t.index ["clinic_id"], name: "index_patients_on_clinic_id"
     t.index ["fund_id"], name: "index_patients_on_fund_id"
     t.index ["identifier"], name: "index_patients_on_identifier"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Adds a config for practical support mode (#2876) and `marked_complete` field in the Patient model.
* Updates views when practical support mode is on; specifically, hides budget bar and fulfillment options, and changes language in table (#3017)
* Changes the `Submit Pledge` button to `Mark Complete`, and updates the confirmation modals:

<img width="602" alt="Screenshot 2023-08-25 at 13 32 46" src="https://github.com/DARIAEngineering/dcaf_case_management/assets/7085805/79518f4e-27b5-4605-8284-73e57156c798">

<img width="1123" alt="Screenshot 2023-08-25 at 13 42 06" src="https://github.com/DARIAEngineering/dcaf_case_management/assets/7085805/3b4a2860-f199-4c9d-a163-4354325d9865">

Currently, there is no valid for marking a patient complete, as there is for fulifilling a pledge; this could be changed.

DRAFT until tests are added.

It relates to the following issue #s: 
* Fixes #2876,  #3017, #2174, #2142

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
