### PR TITLE
Set up renovate batched dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:recommended"],
   "reviewers": ["xmunoz"],
   "packageRules": [
     {
@@ -40,12 +38,8 @@
     },
     {
       "groupName": "sentry",
-      "matchPackagePatterns": [
-        "^devise",
-        "^omniauth-"
-      ],
+      "matchPackagePatterns": ["^devise", "^omniauth-"],
       "matchUpdateTypes": ["patch", "minor"]
     }
-
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,50 @@
   "extends": [
     "config:base"
   ],
-  "reviewers": ["xmunoz"]
+  "reviewers": ["xmunoz"],
+  "packageRules": [
+    {
+      "groupName": "devDependencies (non-major)",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "groupName": "asset pipeline",
+      "matchPackagePatterns": [
+        "sprockets-rails",
+        "jsbundling-rails",
+        "cssbundling-rails",
+        "bootstrap_form"
+      ],
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "groupName": "database",
+      "matchPackagePatterns": [
+        "pg",
+        "paper_trail",
+        "activerecord-session_store"
+      ],
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "groupName": "devise and oauth",
+      "matchPackagePatterns": [
+        "devise",
+        "devise-security",
+        "omniauth-google-oauth2",
+        "omniauth-rails_csrf_protection"
+      ],
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "groupName": "sentry",
+      "matchPackagePatterns": [
+        "^devise",
+        "^omniauth-"
+      ],
+      "matchUpdateTypes": ["patch", "minor"]
+    }
+
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,53 +3,7 @@
   "reviewers": ["xmunoz"],
   "packageRules": [
     {
-      "groupName": "Dev and Test",
-      "matchDepTypes": [
-        "devDependencies",
-        "development",
-        "test"
-      ],
-      "matchUpdateTypes": ["patch", "minor"]
-    },
-    {
-      "groupName": "js-dependencies",
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": ["patch", "minor"]
-    },
-    {
-      "groupName": "asset pipeline",
-      "matchPackagePatterns": [
-        "sprockets-rails",
-        "jsbundling-rails",
-        "cssbundling-rails",
-        "bootstrap_form"
-      ],
-      "matchUpdateTypes": ["patch", "minor"]
-    },
-    {
-      "groupName": "database",
-      "matchPackagePatterns": [
-        "pg",
-        "paper_trail",
-        "activerecord-session_store"
-      ],
-      "matchUpdateTypes": ["patch", "minor"]
-    },
-    {
-      "groupName": "devise and oauth",
-      "matchPackagePatterns": [
-        "devise",
-        "devise-security",
-        "omniauth-google-oauth2",
-        "omniauth-rails_csrf_protection"
-      ],
-      "matchUpdateTypes": ["patch", "minor"]
-    },
-    {
-      "groupName": "sentry",
-      "matchPackagePatterns": ["^devise", "^omniauth-"],
+      "groupName": "all minor and patch",
       "matchUpdateTypes": ["patch", "minor"]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,19 @@
   "reviewers": ["xmunoz"],
   "packageRules": [
     {
-      "groupName": "devDependencies (non-major)",
-      "matchDepTypes": ["devDependencies"],
+      "groupName": "Dev and Test",
+      "matchDepTypes": [
+        "devDependencies",
+        "development",
+        "test"
+      ],
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "groupName": "js-dependencies",
+      "matchDepTypes": [
+        "dependencies"
+      ],
       "matchUpdateTypes": ["patch", "minor"]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
       "groupName": "all minor and patch",
       "matchUpdateTypes": ["patch", "minor"]
     }
+  ],
+  "schedule": [
+    "before 4am on Monday"
   ]
 }


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Tell renovate to group our changes together

This pull request makes the following changes:
* all minor and patch, together

**Testing**
You can validate the config via the [renovate-config-validator](https://docs.renovatebot.com/getting-started/installing-onboarding/#repository-re-configuration) script, but I don't know how to ask it to validate the batching 🤷🏼 

It relates to the following issue #s: 
* Fixes #3049 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
