### PR TITLE
Revert "Set up renovate batched dependencies"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,6 @@
 {
-  "extends": ["config:recommended"],
-  "reviewers": ["xmunoz"],
-  "packageRules": [
-    {
-      "groupName": "all minor and patch",
-      "matchUpdateTypes": ["patch", "minor"]
-    }
+  "extends": [
+    "config:base"
   ],
-  "schedule": [
-    "before 4am on Monday"
-  ]
+  "reviewers": ["xmunoz"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "extends": [
     "config:recommended"
   ],
+  "schedule": [
+    "before 4am on Monday"
+  ],
   "reviewers": ["xmunoz"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "reviewers": ["xmunoz"]
 }


### PR DESCRIPTION
Reverts DARIAEngineering/dcaf_case_management#3056

Unfortunately, renovate does not handle batched dependency updates well. See #3079. I think when it tries to rebase, all of the other dependency updates get lost. Revert this for now.