### PR TITLE
Move to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/githubDARIAEngineering/dcaf_case_management//administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "xmunoz"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "xmunoz"
+    labels:
+      - "dependencies"
+
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,8 @@ updates:
       interval: "weekly"
     groups:
       minor-patch:
-        patterns:
-          - "*"
+        exclude-patterns:
+          - "@acts_as_tenant*" # DARIAEngineering/dcaf_case_management#3078
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,6 @@ updates:
       interval: "weekly"
     groups:
       minor-patch:
-        patterns:
-          - "*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     labels:
       - "dependencies"
 
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,0 @@
-{
-  "extends": [
-    "config:recommended"
-  ],
-  "schedule": [
-    "before 4am on Monday"
-  ],
-  "reviewers": ["xmunoz"]
-}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We tried and failed to use renovate's bundled version bumps. It would still be very nice to have the grouped updates, and dependabot has long ago caught upto supporting our version of yarn, so swapping back gets us the grouped updates.

This pull request makes the following changes:
* Removes Renovate
* Adds dependabot
* Avoids the one-know-bad case we'll handle in #3078 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
