### PR TITLE
Fix dependabot excludes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      minor-patch:
+      ruby-minor-patch:
         exclude-patterns:
-          - "@acts_as_tenant*" # DARIAEngineering/dcaf_case_management#3078
+          - "acts_as_tenant" # DARIAEngineering/dcaf_case_management#3078
         update-types:
           - "minor"
           - "patch"
@@ -26,7 +26,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      minor-patch:
+      js-minor-patch:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I misformatted the exclude pattern in #3086. Also adds distinct names for the two groups.


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
