### PR TITLE
Upgrade papertrail to support newer versions of AR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'bootstrap_form', '~> 4.5.0'
 
 # Our database is postgres
 gem 'pg', '~> 1.2'
-gem 'paper_trail', '~> 15.0'
+gem 'paper_trail', '~> 15.1'
 gem 'activerecord-session_store'
 
 # Our authentication library is devise, with oauth2 for google signin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,7 +278,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    paper_trail (15.0.0)
+    paper_trail (15.1.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.23.0)
@@ -498,7 +498,7 @@ DEPENDENCIES
   nokogiri (>= 1.13.4)
   omniauth-google-oauth2 (~> 1.1.1)
   omniauth-rails_csrf_protection (~> 1.0)
-  paper_trail (~> 15.0)
+  paper_trail (~> 15.1)
   pdf-inspector
   pg (~> 1.2)
   prawn


### PR DESCRIPTION
Bumps papertrail one minor version to squash this message:
> PaperTrail 15.0.0 is not compatible with ActiveRecord 7.1.1. We allow PT
      contributors to install incompatible versions of ActiveRecord, and this
      warning can be silenced with an environment variable, but this is a bad
      idea for normal use. Please install a compatible version of ActiveRecord
      instead (>= 6.1, < 7.1). Please see the discussion in paper_trail/compatibility.rb
      for details.

We are currently on rails 7.1.1, which [should be supported](https://github.com/paper-trail-gem/paper_trail/blob/master/Appraisals) in this verison of papertrail.