### PR TITLE
added support date key under patient in ES and EN; removed underscore…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
         audited: Audited
         check_number: Check number
         city: City
-        clinic_id: Clinic_Id
+        clinic_id: Clinic ID
         completed_ultrasound: Completed ultrasound?
         confirmed: Confirmed
         county: County
@@ -96,6 +96,7 @@ en:
         special_circumstances: Special circumstances
         state: State
         support_type: Support type
+        support_date: Support date
         textable: Textable
         voicemail_preference: Voicemail preference
         zipcode: Zipcode

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,8 +95,8 @@ en:
         source: Source
         special_circumstances: Special circumstances
         state: State
-        support_type: Support type
         support_date: Support date
+        support_type: Support type
         textable: Textable
         voicemail_preference: Voicemail preference
         zipcode: Zipcode

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -96,6 +96,7 @@ es:
         special_circumstances: Circunstancias Especiales
         state: Estado
         support_type: Tipo de soporte
+        support_date: Fecha del soporte
         textable: Textable
         voicemail_preference: Preferencia de correo de voz
         zipcode: Código postal

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -95,8 +95,8 @@ es:
         source: Fuente
         special_circumstances: Circunstancias Especiales
         state: Estado
-        support_type: Tipo de soporte
         support_date: Fecha del soporte
+        support_type: Tipo de soporte
         textable: Textable
         voicemail_preference: Preferencia de correo de voz
         zipcode: Código postal


### PR DESCRIPTION
I have completed some work on Case Manager that's ready for review!

This pull request adds the 'support_date' key and string to the `en.yml` and `es.yml` files.
Previously, we encountered an error in which the application could not find a translation for 'support_date' when referenced from `en.activerecord.attributes.patient`. This caused the application to display a "translation missing" error message in places where `support_date` was referenced.

As a side note, the `support_date` key already exists in `en.activerecord.attributes.practical_support`; I'm not sure if the issue should actually be fixed somewhere else, but I will look into it.

Screenshots below refer to Patient 0, Maru line

Before:
<img width="571" alt="screenshot of patient history" src="https://github.com/DARIAEngineering/dcaf_case_management/assets/27842268/126421ff-eb74-49f6-b756-de148dac8db3">
After:
<img width="571" alt="screenshot of patient history" src="https://github.com/DARIAEngineering/dcaf_case_management/assets/27842268/2ae95371-5cd8-45f9-8b28-de87d04985ff">

I also removed the underscore from the string of the `clinic_id` key in `en.yml`, just a tiny fix.

It relates to the following issue #s: 
* Fixes #3134 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
