### PR TITLE
Default select the first line in a list

### DIFF
--- a/app/views/lines/new.html.erb
+++ b/app/views/lines/new.html.erb
@@ -4,8 +4,12 @@
 
     <%= bootstrap_form_with url: lines_path, local: true, class: 'line-select-form' do |f| %>
       <%= f.form_group :line_id, label: { text: t('lines.new.what_line') } do %>
-        <% @lines.each do |line| %>
-          <%= f.radio_button :line_id, line.id, label: line.name %>
+        <% @lines.each_with_index do |line, index| %>
+          <% if index == 0 %>
+            <%= f.radio_button :line_id, line.id, label: line.name, checked: true %>
+          <% else %>
+            <%= f.radio_button :line_id, line.id, label: line.name %>
+          <% end %>
         <% end %>
       <% end %>
       <%= f.submit t('lines.new.start'), class: 'btn-lg btn-primary' %>


### PR DESCRIPTION
This is not in an open issue, just something that slightly annoyed me as I was testing out a PR on my local development environment. On the first screen after login, you must select a line to work on.
<img width="765" alt="Screenshot 2024-02-20 at 10 22 56" src="https://github.com/DARIAEngineering/dcaf_case_management/assets/1065196/01aba7a8-bea0-4f4e-bbad-45f4ac29aca0">

If you click just outside the text box for the label, it doesn't select the radio button. If you then click "Get started" without properly selecting a radio button, you get an error.
<img width="765" alt="Screenshot 2024-02-20 at 10 24 26" src="https://github.com/DARIAEngineering/dcaf_case_management/assets/1065196/f1d2df63-ead1-4830-b093-ff05cf14cfea">

What this PR adds: Pre-select the first radio button in the lines list. It should prevent this unpleasant UX situation, which I found myself in because of working quickly.