### PR TITLE
Upgrade docker compose to v2

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -17,11 +17,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Bring up containers
         run: |
-          docker-compose build
-          docker-compose run --rm web rails db:create db:migrate db:seed
-          docker-compose up -d
+          docker compose build
+          docker compose run --rm web rails db:create db:migrate db:seed
+          docker compose up -d
           sleep 30
-          docker-compose logs -t
+          docker compose logs -t
           docker ps -a | (! grep Exited ) # Return a non-zero exit code if any of the containers are stopped
 
   build:

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,13 @@ run-tests:
 t: run-tests ## Runs the provided test(s)
 
 docker-run:
-	docker-compose up
+	docker compose up
 
 ds: docker-run ## Run the docker server
 
 docker-restart: ## stop and start the docker server
-	docker-compose down
-	docker-compose up
+	docker compose down
+	docker compose up
 
 ###: ## .
 ###Database-Commands: ## .
@@ -68,7 +68,7 @@ seed: ## Populate the dev database with fresh data
 	bundle exec rails db:seed
 
 docker-seed: ## Seed or reseed your docker instance
-	docker-compose run --rm web rails db:create db:migrate db:seed
+	docker compose run --rm web rails db:create db:migrate db:seed
 
 add-migration: ## Generate a rails migration
 	bundle exec rails g migration $(RUN_ARGS)
@@ -122,7 +122,7 @@ lint-setup-audits: ## Setup ruby auditors
 	gem install brakeman ruby_audit bundler-audit
 
 docker-build:
-	docker-compose build
+	docker compose build
 
 docker-install: docker-build docker-seed ## Setup the docker instance from scratch
 

--- a/docs/GOOGLE_SIGN_ON_SETUP.md
+++ b/docs/GOOGLE_SIGN_ON_SETUP.md
@@ -14,4 +14,4 @@ Once you've done this, Sign In with Google functionality should start working fo
 
 Note that unlike a lot of Google SSO builds, our Sign In With Google functionality doesn't automatically create an account; you'll need to have an account associated with that email address persisted in the database already.
 
-BUT WAIT! What about Docker?! Never fear, these environment variables will get passed through to the docker image if you are using docker-compose up. 
+BUT WAIT! What about Docker?! Never fear, these environment variables will get passed through to the docker image if you are using docker compose up. 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -19,9 +19,9 @@ For the rest of the setup, you have two options: Docker, or installing everythin
 
 We've dockerized this app, to manage the dependencies and save us some headache. If you've got [Docker installed already](https://docs.docker.com/engine/installation/), you can be up and running with three commands:
 
-* `docker-compose build # (this may say 'uses an image, skipping' a few times, that's OK)`
-* `docker-compose run --rm web rails db:drop db:create db:migrate db:seed # to populate the database`
-* `docker-compose up`
+* `docker compose build # (this may say 'uses an image, skipping' a few times, that's OK)`
+* `docker compose run --rm web rails db:drop db:create db:migrate db:seed # to populate the database`
+* `docker compose up`
 
 The last command will take a moment and should print a number of things. When it's ready
 to go, it should say something like:
@@ -33,7 +33,7 @@ take a minute or two for resources to compile and load, but it should eventually
 
 Any errors will show up in your terminal in the window you are running the `up` command in.
 
-If the server won't start, it may not have cleanly shut down. Run `rm tmp/pids/server.pid` to remove the leftover server process and run `docker-compose up` again.
+If the server won't start, it may not have cleanly shut down. Run `rm tmp/pids/server.pid` to remove the leftover server process and run `docker compose up` again.
 
 If you're using a Windows 10 machine to run docker, we strongly suggest downloading and using [Docker-Desktop](https://www.docker.com/products/docker-desktop).
 The Docker-Desktop experience on Windows 10 is mostly very smooth these days, but there are a couple common "gotchas" we've seen while developing this (and other) apps. One of our core maintainers keeps additional info on this [here](https://github.com/mdworken/MKD-Docker-Windows-Rails). If you run into issues that are not covered there, or if you have suggestions to improve the readability of the repo, please let us know! We're happy to help debug, and once we understand the issues you've seen, you'll have helped future users who may encounter the same issue.


### PR DESCRIPTION
v1 is now deprecated on the default github actions runners https://github.com/actions/runner-images/issues/9557

All subsequent PRs are likely to have failing CI until this is merged to main.

Also, update docs.

https://docs.docker.com/compose/migrate/