### PR TITLE
Add a Procedure Type to Patient

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -176,7 +176,7 @@ class PatientsController < ApplicationController
     :city, :state, :county, :zipcode, :other_contact, :other_phone,
     :other_contact_relationship, :employment_status, :income,
     :household_size_adults, :household_size_children, :insurance, :referred_by,
-    special_circumstances: []
+    :procedure_type, special_circumstances: []
   ].freeze
 
   ABORTION_INFORMATION_PARAMS = [

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -99,6 +99,16 @@ module PatientsHelper
     options_plus_current(full_set, current_value)
   end
 
+  def show_procedure_type?
+    !Config.find_or_create_by(config_key: 'procedure_type').options.empty?
+  end
+
+  def procedure_type_options(current_value = nil)
+    full_set = [nil] + Config.find_or_create_by(config_key: 'procedure_type').options
+
+    options_plus_current(full_set, current_value)
+  end
+
   def income_options
     [nil,
      [ t('patient.helper.income.under_10'), 'Under $9,999'],

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -99,14 +99,12 @@ module PatientsHelper
     options_plus_current(full_set, current_value)
   end
 
-  def show_procedure_type?
-    !Config.find_or_create_by(config_key: 'procedure_type').options.empty?
-  end
-
   def procedure_type_options(current_value = nil)
-    full_set = [nil] + Config.find_or_create_by(config_key: 'procedure_type').options
+    procedure_type_options = Config.find_or_create_by(config_key: 'procedure_type').options
 
-    options_plus_current(full_set, current_value)
+    return [] if procedure_type_options.blank?
+
+    options_plus_current([nil] + procedure_type_options, current_value)
   end
 
   def income_options

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -85,6 +85,7 @@ class ArchivedPatient < ApplicationRecord
       race_ethnicity: patient.race_ethnicity,
       employment_status: patient.employment_status,
       insurance: patient.insurance,
+      procedure_type: patient.procedure_type,
       income: patient.income,
       language: patient.language,
       voicemail_preference: patient.voicemail_preference,

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -22,6 +22,7 @@ module Exportable
     "Minors in Household" => :get_household_size_children,
     "Adults in Household" => :get_household_size_adults,
     "Insurance" => :insurance,
+    "Procedure Type" => :procedure_type,
     "Income" => :income,
     "Referred By" => :referred_by,
     "Referred to clinic by fund" => :referred_to_clinic,

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -46,7 +46,8 @@ class Config < ApplicationRecord
     aggregate_statistics: 17,
     hide_standard_dropdown_values: 18,
     county: 19,
-    time_zone: 20
+    time_zone: 20,
+    procedure_type: 21,
   }
 
   # which fields are URLs (run special validation only on those)
@@ -74,6 +75,8 @@ class Config < ApplicationRecord
     voicemail:
       [:validate_length],
     county:
+      [:validate_length],
+    procedure_type:
       [:validate_length],
 
     start_of_week:

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -5,8 +5,7 @@ class Config < ApplicationRecord
   # Concerns
   include PaperTrailable
 
-  # Define overrides for particular config fields.
-  # Useful if there is no `_options` method.
+  # Define overrides for particular config fields help text.
   HELP_TEXT_OVERRIDES = {
     resources_url: 'A link to a Google Drive folder with CM resources. ' \
                    'Ex: https://drive.google.com/drive/my-resource-dir',
@@ -22,8 +21,24 @@ class Config < ApplicationRecord
     hide_budget_bar: 'Enter "yes" to hide the budget bar display.',
     aggregate_statistics: 'Enter "yes" to show aggregate statistics on the budget bar.',
     hide_standard_dropdown_values: 'Enter "yes" to hide standard dropdown values. Only custom options (specified on this page) will be used.',
-    time_zone: "Time zone to use for displaying dates. Default is Eastern. Valid options are Eastern, Central, Mountain, Pacific, Alaska, Hawaii, Arizona, Indiana (East), or Puerto Rico."
+    time_zone: "Time zone to use for displaying dates. Default is Eastern. Valid options are Eastern, Central, Mountain, Pacific, Alaska, Hawaii, Arizona, Indiana (East), or Puerto Rico.",
+    procedure_type: "Any kind of distinction in procedure your fund would like to track. Field hides if no options " \
+                    "are added here. Please separate with commas.",
   }.freeze
+
+  # Whether a config should show a current options dropdown to the right
+  # Must have a `_options` method implemented
+  SHOW_CURRENT_OPTIONS = [
+    :county,
+    :external_pledge_source,
+    :insurance,
+    :language,
+    :pledge_limit_help_text,
+    :practical_support,
+    :procedure_type,
+    :referred_by,
+    :voicemail,
+  ]
 
   enum config_key: {
     insurance: 0,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -71,7 +71,7 @@ class Patient < ApplicationRecord
   validates :household_size_adults, :household_size_children, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: -1 }
   validates :name, :primary_phone, :other_contact, :other_phone, :other_contact_relationship,
             :voicemail_preference, :language, :pronouns, :city, :state, :county, :zipcode,
-            :race_ethnicity, :employment_status, :insurance, :income, :referred_by, :solidarity_lead,
+            :race_ethnicity, :employment_status, :insurance, :income, :referred_by, :solidarity_lead, :procedure_type,
             length: { maximum: 150 }
   validates_associated :fulfillment
 

--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -11,8 +11,7 @@
   </div>
 
   <div class="col" id="<%= config.config_key.to_s %>_options_list">
-    <% if Config::HELP_TEXT_OVERRIDES[config.config_key.to_sym] %>
-    <% else %>
+    <% if Config::SHOW_CURRENT_OPTIONS.include?(config.config_key.to_sym) %>
       <%= bootstrap_form_with model: config, inline: true, local: true do |f| %>
         <%= f.select :current, 
               public_send("#{config.config_key}_options").compact,

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -56,7 +56,7 @@
           <%= f.select :procedure_type,
             options_for_select(procedure_type_options(patient.procedure_type),
                                patient.procedure_type),
-            label: t('patient.information.procedure_type') %>
+            label: t('patient.abortion_information.clinic_section.procedure_type') %>
         <% end %>
       </div>
     </div>

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -52,6 +52,12 @@
               label_class: 'tooltip-header-input',
             },
             data: {'tooltip-text': solidarity_lead_help_text } %>
+        <% if show_procedure_type? %>
+          <%= f.select :procedure_type,
+            options_for_select(procedure_type_options(patient.procedure_type),
+                               patient.procedure_type),
+            label: t('patient.information.procedure_type') %>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -52,7 +52,7 @@
               label_class: 'tooltip-header-input',
             },
             data: {'tooltip-text': solidarity_lead_help_text } %>
-        <% if show_procedure_type? %>
+        <% if procedure_type_options.present? %>
           <%= f.select :procedure_type,
             options_for_select(procedure_type_options(patient.procedure_type),
                                patient.procedure_type),

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -118,7 +118,7 @@
   <% if procedure_type_options.present? %>
     <%= f.select :procedure_type,
       options_for_select(procedure_type_options),
-      label: t('patient.information.procedure_type') %>
+      label: t('patient.abortion_information.clinic_section.procedure_type') %>
   <% end %>
 
 

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -115,7 +115,7 @@
                label: t('patient.helper.referred_by.title'),
                autocomplete: 'off' %>
 
-  <% if show_procedure_type? %>
+  <% if procedure_type_options.present? %>
     <%= f.select :procedure_type,
       options_for_select(procedure_type_options),
       label: t('patient.information.procedure_type') %>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -115,6 +115,13 @@
                label: t('patient.helper.referred_by.title'),
                autocomplete: 'off' %>
 
+  <% if show_procedure_type? %>
+    <%= f.select :procedure_type,
+      options_for_select(procedure_type_options),
+      label: t('patient.information.procedure_type') %>
+  <% end %>
+
+
   <%= f.number_field :procedure_cost,
                      label: t('patient.pledge_fulfillment.form.procedure_cost') %>
   <%= f.number_field :patient_contribution,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
         primary_phone: Primary phone
         procedure_cost: Procedure cost
         procedure_date: Procedure date
+        procedure_type: Procedure type
         pronouns: Pronouns
         race_ethnicity: Race / Ethnicity
         referred_by: Referred by

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,6 +364,7 @@ en:
         medicaid_only_toggle: Enable only Medicaid clinics
         naf_only_toggle: Enable only NAF clinics
         not_currently_working_with_fund: "(Not currently working with %{fund}) - %{clinic_name}"
+        procedure_type: Procedure type
         referred_to_clinic: Referred to clinic
         resolved_without_fund: Resolved without assistance from %{fund}
         solidarity: Solidarity Pledge

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -364,6 +364,7 @@ es:
         medicaid_only_toggle: Enseñar solo las clínicas de Medicaid
         naf_only_toggle: Enseñar solo clínicas de la NAF
         not_currently_working_with_fund: "(Actualmente no trabaja con %{fund}) - %{clinic_name}"
+        procedure_type: Tipo de procedimiento
         referred_to_clinic: Referido a la clínica
         resolved_without_fund: Resuelto sin ayuda de %{fund}
         solidarity: Promesa solidaria

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -86,6 +86,7 @@ es:
         primary_phone: Número de teléfono principal
         procedure_cost: Costo del procedimiento
         procedure_date: Fecha de procedimiento
+        procedure_type: Tipo de procedimiento
         pronouns: Pronombres
         race_ethnicity: Raza / Etnicidad
         referred_by: Referido por

--- a/db/migrate/20240403225952_add_procedure_type_to_patient.rb
+++ b/db/migrate/20240403225952_add_procedure_type_to_patient.rb
@@ -1,0 +1,6 @@
+class AddProcedureTypeToPatient < ActiveRecord::Migration[7.1]
+  def change
+    add_column :patients, :procedure_type, :string
+    add_column :archived_patients, :procedure_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_27_181226) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_03_225952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_181226) do
     t.bigint "line_id", null: false
     t.boolean "solidarity"
     t.string "solidarity_lead"
+    t.string "procedure_type"
     t.index ["clinic_id"], name: "index_archived_patients_on_clinic_id"
     t.index ["fund_id"], name: "index_archived_patients_on_fund_id"
     t.index ["line_id"], name: "index_archived_patients_on_line_id"
@@ -304,6 +305,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_181226) do
     t.bigint "line_id", null: false
     t.boolean "solidarity"
     t.string "solidarity_lead"
+    t.string "procedure_type"
     t.index ["clinic_id"], name: "index_patients_on_clinic_id"
     t.index ["fund_id"], name: "index_patients_on_fund_id"
     t.index ["identifier"], name: "index_patients_on_identifier"

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -304,9 +304,33 @@ class PatientsHelperTest < ActionView::TestCase
         assert_difference 'Config.count', 1 do
           @options = county_options
         end
-  
+
         assert_empty @options
         assert Config.find_by(config_key: 'county')
+      end
+    end
+  end
+
+  describe 'procedure_type_options' do
+    describe 'with configured options' do
+      custom_procedure_types = ['medical', 'evisit', 'in person']
+      current_option = 'phone'
+      before { create_procedure_type_config(custom_procedure_types) }
+      it 'should include custom procedure types as well as current' do
+        expected_procedure_types = [nil, [custom_procedure_types], current_option].flatten
+
+        assert_same_elements expected_procedure_types,
+                            procedure_type_options(current_option)
+      end
+    end
+    describe 'without configured options' do
+      it 'should create a config and return empty' do
+        assert_difference 'Config.count', 1 do
+          @options = procedure_type_options
+        end
+
+        assert_empty @options
+        assert Config.find_by(config_key: 'procedure_type')
       end
     end
   end

--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -267,5 +267,36 @@ class UpdatingConfigsTest < ApplicationSystemTestCase
         end
       end
     end
+
+    describe 'updating a config - procedure_type' do
+      it 'should display dropdown if procedure types are specified' do
+        fill_in 'config_options_procedure_type', with: 'Dog, Cat, Turtle'
+        click_button 'Update options for Procedure type'
+
+        @patient.procedure_type = 'Dog'
+        @patient.save!
+
+        visit edit_patient_path @patient
+        click_link 'Abortion Information'
+
+        within :css, "#abortion-information-form-1" do
+          assert has_select? with_options: %w[Dog Cat Turtle],
+                             selected: 'Dog'
+        end
+      end
+
+      it 'should hide the dropdown when config removed' do
+        # no config, so we should get a text box
+        fill_in 'config_options_procedure_type', with: ''
+        click_button 'Update options for Procedure type'
+
+        visit edit_patient_path @patient
+        click_link 'Abortion Information'
+
+        within :css, "#abortion-information-form-1" do
+          refute has_content? 'Procedure type'
+        end
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,12 +48,17 @@ class ActiveSupport::TestCase
                     config_value: { options: insurance_options }
   end
 
+  def create_procedure_type_config(procedure_type_options)
+    create :config, config_key: 'procedure_type',
+                    config_value: { options: procedure_type_options }
+  end
+
   def create_county_config
     county_options = ['Arlington', 'Fairfax', 'Montgomery']
       create :config, config_key: 'county',
                       config_value: { options: county_options }
   end
-  
+
   def create_practical_support_config
     practical_support_options = ['Metallica Tickets', 'Clothing']
     create :config, config_key: 'practical_support',


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds a configurable, exportable, archivable field Procedure Type to Patient.

Also slightly tweaks the Config model so a field can have both help text _and_ a Current Options dropdown.

| Change | Screenshot |
|--|--|
| Config Option | ![Config page option](https://github.com/DARIAEngineering/dcaf_case_management/assets/6129479/38e6ab3d-b8d8-47db-9e22-7a1787f3e49b) | 
| Patient Abortion Information | ![Abortion Information - Clinic Section showing Procedure Type](https://github.com/DARIAEngineering/dcaf_case_management/assets/6129479/aceb7506-e925-4457-a9e2-656ca095e3d0) |
| Patient Abortion Information (not configured) | ![Abortion Information - Clinic Section hiding Procedure Type](https://github.com/DARIAEngineering/dcaf_case_management/assets/6129479/677d9157-998b-4b9d-a0e9-622832d5fa6e) |




It relates to the following issue #s: 
* Fixes #3174 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
