### PR TITLE
move i18n-js to general gems instead of dev gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'geokit' # clinic_finder service lat-lng
 gem 'state_geo_tools' # state list 
 gem 'httparty' # easier http calls
 gem 'view_component', '~> 3.12' # build reusable & encapsulated view components in Ruby
+gem 'i18n-js', '~> 4.2' # Export i18n translations to JSON
 
 # Stuff that we're targeting removal of
 gem 'figaro' # we handle secrets differently now
@@ -71,7 +72,6 @@ gem 'loofah', '>= 2.3.1'
 gem 'rails-html-sanitizer', '>= 1.4.3'
 
 group :development do
-  gem 'i18n-js', '~> 4.2' # Export i18n translations to JSON
   gem 'i18n-tasks', '~> 1.0.14' # check and clean i18n keys
   gem 'rails-i18n', '~> 7.0' # dependency of i18n-tasks
   gem 'shog' # makes rails s output color!

--- a/app/javascript/locales.json
+++ b/app/javascript/locales.json
@@ -6665,9 +6665,7 @@
           "date": "DATE",
           "remove_button": "Remove",
           "result": "RESULT",
-          "time": "TIME",
-          "view_less": "Limit list",
-          "view_more": "View all calls heyo"
+          "time": "TIME"
         },
         "title": "Call Log"
       },
@@ -10987,9 +10985,7 @@
           "date": "FECHA",
           "remove_button": "Retirar",
           "result": "RESULTADO",
-          "time": "HORA",
-          "view less": "Limitar la lista",
-          "view_more": "Ver todas las llamadas"
+          "time": "HORA"
         },
         "title": "Registro de Llamadas"
       },


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This gem needs to be in dev since it's part of an initializer. my mistake for not snagging this!

This pull request makes the following changes:
*  moves the gem over
* reracks i18n

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
