### PR TITLE
Add Patient#appointment_time

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -183,7 +183,7 @@ class PatientsController < ApplicationController
   ABORTION_INFORMATION_PARAMS = [
     :clinic_id, :resolved_without_fund, :referred_to_clinic, :completed_ultrasound,
     :procedure_cost, :patient_contribution, :naf_pledge, :fund_pledge,
-    :fund_pledged_at, :pledge_sent_at, :solidarity, :solidarity_lead
+    :fund_pledged_at, :pledge_sent_at, :solidarity, :solidarity_lead, :appointment_time
   ].freeze
 
   FULFILLMENT_PARAMS = [

--- a/app/models/concerns/attribute_displayable.rb
+++ b/app/models/concerns/attribute_displayable.rb
@@ -14,7 +14,12 @@ module AttributeDisplayable
 
   def appointment_date_display
     return nil unless appointment_date.present?
-    "#{appointment_date.strftime("%m/%d/%Y")}"
+    day = appointment_date.strftime("%m/%d/%Y")
+    if appointment_time
+      time = appointment_time.strftime("%I:%M %p")
+      return "#{day} @ #{time}"
+    end
+    return day
   end
 
   def procedure_date_display

--- a/app/models/concerns/attribute_displayable.rb
+++ b/app/models/concerns/attribute_displayable.rb
@@ -16,7 +16,7 @@ module AttributeDisplayable
     return nil unless appointment_date.present?
     day = appointment_date.strftime("%m/%d/%Y")
     if appointment_time
-      time = appointment_time.strftime("%I:%M %p")
+      time = appointment_time.strftime("%l:%M %p").strip
       return "#{day} @ #{time}"
     end
     return day

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -19,6 +19,7 @@
         <%= f.select :clinic_id,
                      options_for_select(clinic_options, patient.clinic.try(:id)),
                      label: t('patient.abortion_information.clinic_section.clinic') %>
+        <%= f.time_field :appointment_time, include_seconds: false %>
 
         <%= f.form_group :clinic_filters do %>
           <%= f.check_box :naf_filter, label: t('patient.abortion_information.clinic_section.naf_only_toggle') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
         age: Age
         amount: Amount
         appointment_date: Appointment date
+        appointment_time: Appointment time
         audited: Audited
         check_number: Check number
         city: City

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -49,6 +49,7 @@ es:
         age: Edad
         amount: Monto
         appointment_date: Día de la cita
+        appointment_time: Hora de la cita
         audited: Auditada
         check_number: 'Cheque #'
         city: Ciudad

--- a/db/migrate/20240630034228_add_appointment_time_to_patient.rb
+++ b/db/migrate/20240630034228_add_appointment_time_to_patient.rb
@@ -1,0 +1,5 @@
+class AddAppointmentTimeToPatient < ActiveRecord::Migration[7.1]
+  def change
+    add_column :patients, :appointment_time, :time, comment: "A patient's appointment time"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_27_174820) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_30_034228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -306,6 +306,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_27_174820) do
     t.boolean "solidarity"
     t.string "solidarity_lead"
     t.string "procedure_type"
+    t.time "appointment_time", comment: "A patient's appointment time"
     t.index ["clinic_id"], name: "index_patients_on_clinic_id"
     t.index ["fund_id"], name: "index_patients_on_fund_id"
     t.index ["identifier"], name: "index_patients_on_identifier"

--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -32,6 +32,7 @@ Field | Description | Exportable? | Reported by | Input Type
 **Adults in Household** | Number of adults (relatives, roommates, other adults) that live most of the time in the patient's household. | Exportable | Patient Reported | Text field
 **Minors in Household**| Number of children under the age of 18 (patient's children, relatives, other children) that live most of the time in the patient's household. | Exportable | Patient Reported | Text field
 **Clinic name** | Name of the clinic where the patient will have their procedure. | Exportable | Patient Reported | Dropdown
+**Appointment time** | Time of patient's appointment, for funds that need to know for practical support reasons. | Not Exportable | Patient Reported | Text field
 **Resolved Without Fund** | The patient has resolved their case without the aid of the Fund. This could be a patient chooses to continue the pregnancy, has found other sources of funding, or any other circumstances the Fund should not continue contacting the patient. | Exportable | Patient Reported | Checkbox
 **Full Cost of Appointment** | The full cost of the patient's appointment as reported by the patient. | Exportable | Patient Reported | Text field
 **Patient Contribution** | The amount of money contributed by the patient. This amount may change at the actual appointment, but is used during case management to record how much a patient can possibly contribute. | Exportable | Patient Reported | Text field

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -361,10 +361,10 @@ class PatientTest < ActiveSupport::TestCase
       assert_nil @patient.appointment_date_display
 
       @patient.appointment_date = Time.new 2022, 10, 31
-      assert_equal @patient.appointment_date_display, '10/31/2022'
+      assert_equal '10/31/2022', @patient.appointment_date_display
 
       @patient.appointment_time = '17:30'
-      assert_equal @patient.appointment_date_display, '10/31/2022 @ 5:30 PM'
+      assert_equal '10/31/2022 @ 5:30 PM', @patient.appointment_date_display
     end
   end
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -356,6 +356,16 @@ class PatientTest < ActiveSupport::TestCase
       assert @patient.respond_to? :created_by
       assert @patient.respond_to? :created_by_id
     end
+
+    it 'should show appointment date + time' do
+      assert_nil @patient.appointment_date_display
+
+      @patient.appointment_date = Time.new 2022, 10, 31
+      assert_equal @patient.appointment_date_display, '10/31/2022'
+
+      @patient.appointment_time = '17:30'
+      assert_equal @patient.appointment_date_display, '10/31/2022 @ 5:30 PM'
+    end
   end
 
   describe 'methods' do

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -140,7 +140,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     before do
       click_link 'Abortion Information'
       select @clinic.name, from: 'patient_clinic_id'
-      fill_in 'Appointment time', with: '12:30 PM'
+      fill_in 'Appointment time', with: '4:30PM'
       check 'Resolved without assistance from CATF'
       check 'Referred to clinic'
       check 'Ultrasound completed?'
@@ -176,7 +176,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     it 'should alter the abortion information' do
       within :css, '#abortion_information' do
         assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
-        assert has_field 'Appointment time', with: '12:30 PM'
+        assert has_field? 'Appointment time', with: '16:30'
         assert has_checked_field?('Resolved without assistance from CATF')
         assert has_checked_field?('Referred to clinic')
         assert has_checked_field?('Ultrasound completed?')

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -140,6 +140,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     before do
       click_link 'Abortion Information'
       select @clinic.name, from: 'patient_clinic_id'
+      fill_in 'Appointment time', with: '12:30 PM'
       check 'Resolved without assistance from CATF'
       check 'Referred to clinic'
       check 'Ultrasound completed?'
@@ -175,6 +176,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     it 'should alter the abortion information' do
       within :css, '#abortion_information' do
         assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
+        assert has_field 'Appointment time', with: '12:30 PM'
         assert has_checked_field?('Resolved without assistance from CATF')
         assert has_checked_field?('Referred to clinic')
         assert has_checked_field?('Ultrasound completed?')


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds a highly optional appointment time field to abortion information.

This pull request makes the following changes:
* Add an appointment time field

<img width="1173" alt="image" src="https://github.com/user-attachments/assets/4c4dbd61-3da7-4e3e-af34-da7e6173415a">
<img width="803" alt="image" src="https://github.com/user-attachments/assets/da8cbfa1-3a3f-405e-9f43-ad974ecb7f98">


It relates to the following issue #s: 
* Fixes #3221

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
