### PR TITLE
Revert Patient Dashboard to non-React

### DIFF
--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -1,16 +1,77 @@
 <div id="patient_dashboard_content">
-  
-    
+  <%= bootstrap_form_with model: patient,
+                         html: { id: 'patient_dashboard_form' },
+                         local: false,
+                         method: 'patch',
+                         class: 'edit_patient' do |f| %>
+    <div class="row">
 
-    <%= render ReactComponent.new("PatientDashboardForm", raw_props: { 
-      patient: patient.as_json, 
-      weeksOptions: weeks_options.map { |opt| { label: opt[0], value: opt[1] } },
-      daysOptions: days_options.map { |opt| { label: opt[0], value: opt[1] } },
-      initialCallDate: patient.initial_call_date.strftime("%m/%d/%Y"),
-      statusHelpText: status_help_text(patient),
-      isAdmin: current_user.admin?,
-      patientPath: patient_path(patient),
-      formAuthenticityToken: form_authenticity_token
-    }) %>
+      <div class="col-4">
+        <%= f.text_field :name,
+                         label: t('patient.shared.name'),
+                         autocomplete: 'off' %>
+      </div>
+      
+      <div class="col">
+        <%= f.select :last_menstrual_period_weeks,
+                     options_for_select(weeks_options, patient.last_menstrual_period_weeks ),
+                     label: t('patient.dashboard.weeks_along'),
+                     autocomplete: 'off',
+                     help: t('patient.dashboard.currently', weeks: patient.last_menstrual_period_now_weeks, days: patient.last_menstrual_period_now_days) %>
+      </div>
 
+      <div class="col mt-4">
+        <%= f.select :last_menstrual_period_days,
+                     options_for_select(days_options, patient.last_menstrual_period_days),
+                     autocomplete: 'off',
+                     skip_label: true,
+                     help: t('patient.dashboard.called_on', date: patient.initial_call_date.strftime("%m/%d/%Y")) %>
+        <%= f.label :last_menstrual_period_days, t('common.days_along'), class: "sr-only" %>
+      </div>          
+
+      <div class="col-3">
+        <%= f.date_field :appointment_date,
+                         label: t('patient.shared.appt_date'),
+                         autocomplete: 'off',
+                         help: t('patient.dashboard.approx_gestation', weeks: patient.last_menstrual_period_at_appt_weeks, days: patient.last_menstrual_period_at_appt_days) %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-4">
+        <%= f.text_field :primary_phone,
+                         value: patient.primary_phone_display,
+                         label: t('patient.dashboard.phone'),
+                         autocomplete: 'off' %>
+      </div>
+
+      <div class="col">
+        <%= f.text_field :pronouns,
+                         value: patient.pronouns,
+                         autocomplete: 'off' %>
+      </div>
+
+      <div class="col">
+        <div class="form-group">
+          <label for="status"><%= t 'patient.shared.status' %> <%= tooltip_shell status_help_text(patient) %></label>
+          <input type="text" value="<%= patient.status %>" class="form-control form-control-plaintext" id="patient_status_display" autocomplete="off">
+        </div>
+      </div>
+
+      <div class="col-3">
+        <% if current_user.admin? %>
+          <div class="form-group">
+            <label for="admin-delete"><%= t 'patient.dashboard.delete_label' %></label>
+            <div>
+              <%= link_to t('patient.dashboard.delete'),
+                          patient_path(patient),
+                          class: 'btn btn-danger',
+                          method: :delete,
+                          data: { confirm: t('patient.dashboard.confirm_del', name: patient.name) } %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -293,7 +293,8 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
 
     it 'should flash failure on a bad field change' do
       fill_in 'Phone number', with: '111-222-3333445'
-      assert has_text? 'Primary phone is invalid'
+      click_away_from_field
+      assert has_text? 'Primary phone is the wrong length'
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We had reports of users with data issues, and in testing it seems like something slipped through when we reactified that component. Reverting just that erb file until we can dig in more.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
