### PR TITLE
ignore a bootstrap complaint to restore build passing

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -125,5 +125,5 @@ jobs:
       - name: Zeitwerk
         run: bin/rails zeitwerk:check
       - name: yarn npm audit
-        run: yarn npm audit --ignore 1098356
+        run: yarn npm audit --ignore 1098356 --ignore 1098400
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

this audit failure is making builds choke; making the deliberate choice to restore builds so we can keep it moving

This pull request makes the following changes:
* ignore a flag in npm audit

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
