### PR TITLE
adjust initial call / appointment date period to diverge a little bit, for late callers 

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -248,7 +248,7 @@ class Patient < ApplicationRecord
 
   def confirm_appointment_after_initial_call
     if appointment_date.present? && initial_call_date.present? && (initial_call_date - 60.days)&.send(:>, appointment_date)
-      errors.add(:appointment_date, 'must be after date of initial call')
+      errors.add(:appointment_date, 'must be closer to the date of initial call')
     end
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -247,7 +247,7 @@ class Patient < ApplicationRecord
   private
 
   def confirm_appointment_after_initial_call
-    if appointment_date.present? && initial_call_date&.send(:>, appointment_date)
+    if appointment_date.present? && initial_call_date.present? && (initial_call_date - 60.days)&.send(:>, appointment_date)
       errors.add(:appointment_date, 'must be after date of initial call')
     end
   end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -79,19 +79,19 @@ class PatientTest < ActiveSupport::TestCase
       end
     end
 
-    it 'should require appointment_date to be after initial_call_date' do
+    it 'should require appointment_date to be reasonably after initial_call_date' do
       # when initial call date is nil
       @patient.appointment_date = '2016-05-01'
       @patient.initial_call_date = nil
       refute @patient.valid?
       # when initial call date is after appointment date
-      @patient.initial_call_date = '2016-06-01'
+      @patient.initial_call_date = '2016-09-01'
       refute @patient.valid?
       # when appointment date is nil
       @patient.appointment_date = nil
       assert @patient.valid?
       # when appointment date is after initial call date
-      @patient.appointment_date = '2016-07-01'
+      @patient.appointment_date = '2016-08-01'
       assert @patient.valid?
     end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Some of the funds we work with are doing some retroactive pledging; in our data model, this conflicts a bit with a rule we enforce of appointment date being after initial call. This PR loosens that rule with a 60 day window - that felt like the point at which it might become an accident. We'll see if it requires further adjustment.

This pull request makes the following changes:
* allow appointment date to be up to 60 before initial call date

no view changes

It relates to the following issue #s: 
* Fixes #3138 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
