### PR TITLE
In navbar, if 2+ lines add a link to the line switcher

### DIFF
--- a/app/helpers/lines_helper.rb
+++ b/app/helpers/lines_helper.rb
@@ -1,10 +1,22 @@
 # Convenience function for displaying lines around the app.
 module LinesHelper
   def current_line_display
+    return if !session[:line_id]
+
+    # If multiple lines, link to the switcher
+    if Line.count > 2
+      return content_tag :li do
+        link_to t('navigation.current_line.helper') + ": #{current_line.name}",
+                new_line_path,
+                class: 'nav-link navbar-text-alt'
+      end
+    end
+
+    # Otherwise just display the content
     content_tag :li do
       content_tag :span, t('navigation.current_line.helper') + ": #{current_line.name}",
                          class: 'nav-link navbar-text-alt'
-    end if session[:line_id]
+    end
   end
 
   def current_line

--- a/app/helpers/lines_helper.rb
+++ b/app/helpers/lines_helper.rb
@@ -4,7 +4,7 @@ module LinesHelper
     return if !session[:line_id]
 
     # If multiple lines, link to the switcher
-    if Line.count > 2
+    if Line.count > 1
       return content_tag :li do
         link_to t('navigation.current_line.helper') + ": #{current_line.name}",
                 new_line_path,

--- a/test/helpers/lines_helper_test.rb
+++ b/test/helpers/lines_helper_test.rb
@@ -4,25 +4,34 @@ class LinesHelperTest < ActionView::TestCase
   include ERB::Util
 
   describe 'convenience methods' do
-    before do
+    it 'should return empty if not set' do
+      assert_nil current_line
+      assert_nil current_line_display
+    end
+
+    it 'should show a link if 2+ lines' do
       @lines = [
         create(:line, name: 'DC'),
         create(:line, name: 'MD'),
         create(:line, name: 'VA')
       ]
-    end
-
-    it 'should return current line' do
-      assert_nil current_line
-      assert_nil current_line_display
 
       @lines.each do |line|
         session[:line_id] = line.id
         session[:line_name] = line.name
         assert_equal current_line_display,
-                     "<li><span class=\"nav-link navbar-text-alt\">Your current line: #{session[:line_name]}</span></li>"
+                     "<li><a class=\"nav-link navbar-text-alt\" href=\"/lines/new\">Your current line: #{session[:line_name]}</a></li>"
         assert_equal current_line, line
       end
+    end
+
+    it 'should show text if just one line' do
+      line = create(:line, name: 'DC')
+      session[:line_id] = line.id
+      session[:line_name] = line.name
+      assert_equal current_line_display,
+                    "<li><span class=\"nav-link navbar-text-alt\">Your current line: #{session[:line_name]}</span></li>"
+      assert_equal current_line, line
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Secretly, you could switch lines by going to `lines/new` and going thru the flow again. Nobody ever asked about line switching. Until now, when it came up as a request from a new fund. So, the time has come.

The reason we don't do this with 1 line is because it doesn't do anything, but if we would prefer simplicity we could link anyway. I think probably fine to not link and keep the span; open to hearing otherwise.

This pull request makes the following changes:
* Link to the line switcher in the navbar if 2+ line

no view changes really

It relates to the following issue #s: 
* Fixes #3268 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
