### PR TITLE
get build to pass by ignoring npm thing

### DIFF
--- a/.github/workflows/test_dev_env.yml
+++ b/.github/workflows/test_dev_env.yml
@@ -125,5 +125,5 @@ jobs:
       - name: Zeitwerk
         run: bin/rails zeitwerk:check
       - name: yarn npm audit
-        run: yarn npm audit --ignore 1098356 --ignore 1098400 --ignore 1098602
+        run: yarn npm audit --ignore 1098356 --ignore 1098400 --ignore 1098602 --ignore 1099461
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

npm is sad because of a bootstrap thing we aren't going to resolve for a bit

This pull request makes the following changes:
* ignore this bootstrap complaint

no views
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
