### PR TITLE
Add housing_status field.

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -99,6 +99,15 @@ module PatientsHelper
     options_plus_current(full_set, current_value)
   end
 
+  def housing_status_options(curent_value = nil)
+    [
+      nil,
+      [ t('patient.helper.housing_status.secure'), 'Housing secure' ],
+      [ t('patient.helper.housing_status.insecure'), 'Housing insecure' ],
+      [ t('common.prefer_not_to_answer'), 'Prefer not to answer']
+    ]
+  end
+
   def procedure_type_options(current_value = nil)
     procedure_type_options = Config.find_or_create_by(config_key: 'procedure_type').options
 

--- a/app/javascript/locales.json
+++ b/app/javascript/locales.json
@@ -6724,6 +6724,10 @@
           "student": "Student",
           "unemployed": "Unemployed"
         },
+        "housing_status": {
+          "insecure": "Housing insecure",
+          "secure": "Housing secure"
+        },
         "income": {
           "10_to_15": "$10,000-14,999 ($192-287/wk - $834-1250/mo)",
           "15_to_20": "$15,000-19,999 ($288-384/wk - $1251-1666/mo)",
@@ -6790,6 +6794,7 @@
       },
       "information": {
         "household_help": "(including patient)",
+        "housing_status": "Housing status",
         "identifier": "Identifier",
         "income_help": "Employment, Food Stamps, SS, TANF, etc.",
         "insurance": "Patient insurance",
@@ -11063,6 +11068,10 @@
           "student": "Estudiante",
           "unemployed": "Desempleada"
         },
+        "housing_status": {
+          "insecure": "Vivienda insegura",
+          "secure": "Vivienda segura"
+        },
         "income": {
           "10_to_15": "$10,000-14,999 ($192-287/sm - $834-1250/mes)",
           "15_to_20": "$15,000-19,999 ($288-384/sm - $1251-1666/mes)",
@@ -11129,6 +11138,7 @@
       },
       "information": {
         "household_help": "(incluyendo paciente)",
+        "housing_status": "Estado de la vivienda",
         "identifier": "Identificador",
         "income_help": "Empleo, Cupones de Alimentos, SS, TANF, etc.",
         "insurance": "Seguro médico del patiente",

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -100,6 +100,10 @@
                      options_for_select(insurance_options(patient.insurance),
                                         patient.insurance),
                      label: t('patient.information.insurance') %>
+        <%= f.select :housing_status,
+                     options_for_select(housing_status_options(patient.housing_status),
+                                        patient.housing_status),
+                     label: t('patient.information.housing_status') %>
         <%= f.select :referred_by,
                      options_for_select(referred_by_options(patient.referred_by),
                                         patient.referred_by),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -455,6 +455,9 @@ en:
         none: No insurance
         other: Other (add to notes)
         unknown: Don't know
+      housing_status:
+        secure: Housing secure
+        insecure: Housing insecure
       language:
         English: English
       practical_support:
@@ -498,6 +501,7 @@ en:
       household_help: "(including patient)"
       identifier: Identifier
       income_help: Employment, Food Stamps, SS, TANF, etc.
+      housing_status: Housing status
       insurance: Patient insurance
       language: Preferred Language
       other_contact:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -455,6 +455,9 @@ es:
         none: Sin Seguro
         other: Otro (Añadir a las notas)
         unknown: No Se
+      housing_status:
+        secure: Vivienda segura
+        insecure: Vivienda insegura
       language:
         English: Inglés
       practical_support:
@@ -498,6 +501,7 @@ es:
       household_help: "(incluyendo paciente)"
       identifier: Identificador
       income_help: Empleo, Cupones de Alimentos, SS, TANF, etc.
+      housing_status: Estado de la vivienda
       insurance: Seguro médico del patiente
       language: Idioma preferido
       other_contact:

--- a/db/migrate/20240912001804_add_housing_status_to_patient.rb
+++ b/db/migrate/20240912001804_add_housing_status_to_patient.rb
@@ -1,0 +1,5 @@
+class AddHousingStatusToPatient < ActiveRecord::Migration[7.1]
+  def change
+    add_column :patients, :housing_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_18_162657) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_12_001804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -316,6 +316,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_18_162657) do
     t.integer "ultrasound_cost"
     t.boolean "multiday_appointment"
     t.boolean "practical_support_waiver", comment: "Optional practical support services waiver, for funds that use them"
+    t.string "housing_status"
     t.index ["clinic_id"], name: "index_patients_on_clinic_id"
     t.index ["fund_id"], name: "index_patients_on_fund_id"
     t.index ["identifier"], name: "index_patients_on_identifier"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Add housing_status field.
* Remove homelessness special circumstance from UI.

<img width="405" alt="image" src="https://github.com/user-attachments/assets/1b66b12b-dd5c-44dc-997a-c4dd5a1cf249">

It relates to the following issue #s: 
* Implements #3265 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
