### PR TITLE
Fix staging deploy github action

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Deploy sandbox environment
-        uses: akhileshns/heroku-deploy@v3.12.14
+        uses: akhileshns/heroku-deploy@v3.13.15
         with:
           heroku_api_key: ${{secrets.XMUNOZ_HEROKU_API_KEY}}
           heroku_app_name: "daria-services-staging"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Install heroku cli
+        run: |
+          brew tap heroku/brew
+          brew install heroku
       - name: Deploy sandbox environment
         uses: akhileshns/heroku-deploy@v3.13.15
         with:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,9 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install heroku cli
-        run: |
-          brew tap heroku/brew
-          brew install heroku
+        run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
       - name: Deploy sandbox environment
         uses: akhileshns/heroku-deploy@v3.13.15
         with:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Staging is no longer being autodeployed from `main`. This is the error message:
```
/bin/sh: 1: heroku: not found
Created and wrote to ~/.netrc
Successfully logged into heroku
/bin/sh: 1: heroku: not found
```
This is because `heroku` no longer comes packaged with the default image of the [`ubuntu-latest`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) Github-hosted runner (24.04). It was pre-installed on [22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) however, hence the breakage. They claim to have removed it for ["maintenance reasons"](https://github.com/actions/runner-images/issues/9848) 🙄 

This PR explicitly installs heroku cli in the staging deploy workflow, and updates the [heroku-deploy Github Action](https://github.com/AkhileshNS/heroku-deploy/tree/v3.13.15) to the latest version.

https://devcenter.heroku.com/articles/heroku-cli