### PR TITLE
disable form field

### DIFF
--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -54,7 +54,7 @@
       <div class="col">
         <div class="form-group">
           <label for="status"><%= t 'patient.shared.status' %> <%= tooltip_shell status_help_text(patient) %></label>
-          <input type="text" value="<%= patient.status %>" class="form-control form-control-plaintext" id="patient_status_display" autocomplete="off">
+          <input type="text" value="<%= patient.status %>" class="form-control form-control-plaintext" id="patient_status_display" autocomplete="off" disabled>
         </div>
       </div>
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fixes #3233. Literally just adds the "disabled" attribute to a formfield that we don't want to be editable. I had some Docker issues (still not fixed, but I set up the app to run direct on my machine) so this is all I got to do tonight :)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
