### PR TITLE
switch model enums to use positional arguments

### DIFF
--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -18,7 +18,7 @@ class ArchivedPatient < ApplicationRecord
   belongs_to :pledge_sent_by, class_name: 'User', inverse_of: nil, optional: true
 
   # Enums
-  enum age_range: {
+  enum :age_range, {
     not_specified: :not_specified,
     under_18: :under_18,
     age18_24: :age18_24,

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -7,7 +7,7 @@ class Call < ApplicationRecord
   include PaperTrailable
 
   # Enums
-  enum status: {
+  enum :status, {
     reached_patient: 0,
     left_voicemail: 1,
     couldnt_reach_patient: 2

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -43,7 +43,7 @@ class Config < ApplicationRecord
     :voicemail,
   ]
 
-  enum config_key: {
+  enum :config_key, {
     insurance: 0,
     external_pledge_source: 1,
     pledge_limit_help_text: 2,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,7 +9,7 @@ class Event < ApplicationRecord
   encrypts :patient_name
 
   # Enums
-  enum event_type: {
+  enum :event_type, {
     reached_patient: 0,
     couldnt_reach_patient: 1,
     left_voicemail: 2,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   SEARCH_LIMIT = 15
 
   # Enums
-  enum role: {
+  enum :role, {
     cm: 0,
     data_volunteer: 1,
     admin: 2


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Looks like the approach of enums is changing in rails 8 to a positional style. Sure, why not. This adjusts the approach to use that positional style. 

This pull request makes the following changes:
* Adjusts enums to use a positional style instead of a keyword style

no view changes, but here's a proveit to confirm I got everything -- relying on the tests for the rest of it 

```
colin@Colins-Air-2 dcaf_case_management % git grep "enum" | grep "\.rb"                                  
app/models/archived_patient.rb:  enum :age_range, {
app/models/call.rb:  enum :status, {
app/models/config.rb:  enum :config_key, {
app/models/event.rb:  enum :event_type, {
app/models/user.rb:  enum :role, {
```

It relates to the following issue #s: 
* Fixes #3314 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
