### PR TITLE
Change `import` to `use` in sass files

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,25 +1,25 @@
 // Major library config
-@import './styles/bootstrap';
-@import './styles/vendor/jquery-ui';
+@use './styles/bootstrap';
+@use './styles/vendor/jquery-ui';
 
 // Custom styling
-@import './styles/globals';
-@import './styles/call_list';
-@import './styles/devise';
-@import './styles/users';
-@import './styles/budget_bar';
-@import './styles/clinic_finder';
-@import './styles/calls';
-@import './styles/pagination';
-@import './styles/events';
-@import './styles/patient_menu';
-@import './styles/patient_edit';
-@import './styles/tables';
-@import './styles/footer';
-@import './styles/modals';
-@import './styles/navbar';
-@import './styles/tooltips';
-@import './styles/lines';
-@import './styles/flash';
-@import './styles/forms';
-@import './styles/buttons';
+@use './styles/globals';
+@use './styles/call_list';
+@use './styles/devise';
+@use './styles/users';
+@use './styles/budget_bar';
+@use './styles/clinic_finder';
+@use './styles/calls';
+@use './styles/pagination';
+@use './styles/events';
+@use './styles/patient_menu';
+@use './styles/patient_edit';
+@use './styles/tables';
+@use './styles/footer';
+@use './styles/modals';
+@use './styles/navbar';
+@use './styles/tooltips';
+@use './styles/lines';
+@use './styles/flash';
+@use './styles/forms';
+@use './styles/buttons';

--- a/app/assets/stylesheets/styles/bootstrap_config.scss
+++ b/app/assets/stylesheets/styles/bootstrap_config.scss
@@ -1,8 +1,9 @@
+@use "sass:map";
 $spacer: .5rem !default;
 
 $spacers: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
-$spacers: map-merge(
+$spacers: map.merge(
   (
     0: 0,
     1: ($spacer * .25), //.125 rem

--- a/app/assets/stylesheets/styles/budget_bar.scss
+++ b/app/assets/stylesheets/styles/budget_bar.scss
@@ -1,11 +1,11 @@
 // Styling related to the budget bar utility.
 
-@import './_variables';
+@use '_variables';
 
 $budget-bar-font-size: 14px;
 
 .expenditure-block {
-  border-right: 1px solid $black;
-  color: $black !important;
+  border-right: 1px solid variables.$black;
+  color: variables.$black !important;
   font-size: $budget-bar-font-size;
 }

--- a/app/assets/stylesheets/styles/budget_bar.scss
+++ b/app/assets/stylesheets/styles/budget_bar.scss
@@ -1,6 +1,6 @@
 // Styling related to the budget bar utility.
 
-@use '_variables';
+@use './_variables';
 
 $budget-bar-font-size: 14px;
 

--- a/app/assets/stylesheets/styles/buttons.scss
+++ b/app/assets/stylesheets/styles/buttons.scss
@@ -1,69 +1,70 @@
 // Button styling.
-@import './_variables';
+@use "sass:color";
+@use '_variables';
 
 // btn-primary
 .btn-primary {
   @extend .btn-primary;
-  background-color: $daria-color;
+  background-color: variables.$daria-color;
   border: none;
-  color: $white;
+  color: variables.$white;
   margin-bottom: 2px;
-  font-size: $font-size;
+  font-size: variables.$font-size;
 }
 
 .btn-primary:hover {
-  background-color: lighten($daria-color,15%);
+  background-color: color.adjust(variables.$daria-color,$lightness: 15%);
 }
 
 .btn-primary:focus {
-  background-color: lighten($daria-color,15%);
-  color: $white;
+  background-color: color.adjust(variables.$daria-color,$lightness: 15%);
+  color: variables.$white;
   text-decoration: none;
 }
 
 // btn-danger
 .btn-danger {
-  background-color: $dark-red !important;
-  border-color: $dark-red !important;
+  background-color: variables.$dark-red !important;
+  border-color: variables.$dark-red !important;
 }
 
 // btn-warning
 .btn-warning {
-  color: $black;
-  border-color: $daria-color;
-  background-color: $white;
+  color: variables.$black;
+  border-color: variables.$daria-color;
+  background-color: variables.$white;
 
   &:hover {
-    background-color: $daria-color-lt;
-    border-color: $daria-color;
+    background-color: variables.$daria-color-lt;
+    border-color: variables.$daria-color;
   }
   &:active {
-    background-color: $soft-blue !important;
+    background-color: variables.$soft-blue !important;
   }
   &:focus {
-    background-color: $daria-color;
+    background-color: variables.$daria-color;
     &:hover {
-      background-color: $daria-color-lt;
+      background-color: variables.$daria-color-lt;
     }
   }
 }
 
 // btn-success
 .btn-success {
-  background-color: $daria-color;
-  border-color: $daria-color;
+  background-color: variables.$daria-color;
+  border-color: variables.$daria-color;
 
   &:hover {
-    background-color: $daria-color-lt;
-    border-color: $daria-color;
+    background-color: variables.$daria-color-lt;
+    border-color: variables.$daria-color;
   }
   &:active {
-    background-color: $soft-blue !important;
+    background-color: variables.$soft-blue !important;
   }
   &:focus {
-    background-color: $daria-color;
+    background-color: variables.$daria-color;
     &:hover {
-      background-color: $daria-color-lt;
+      background-color: variables.$daria-color-lt;
     }
   }
 }
@@ -76,19 +77,19 @@
 
 // Disabled button styling
 @mixin disabled-button {
-  color: $white;
+  color: variables.$white;
   background-color: gray;
-  border-color: $daria-color;
+  border-color: variables.$daria-color;
   &:hover {
     background-color: gray;
-    border-color: $daria-color;
+    border-color: variables.$daria-color;
   }
   &:focus {
     background-color: gray;
-    border-color: $daria-color;
+    border-color: variables.$daria-color;
     &:hover {
       background-color: gray;
-      border-color: $daria-color;
+      border-color: variables.$daria-color;
     }
   }
 }
@@ -103,5 +104,5 @@
 
 // Styling for the cancel button on pledge modal
 .btn[data-orientation='cancel'] {
-  color: $red;
+  color: variables.$red;
 }

--- a/app/assets/stylesheets/styles/buttons.scss
+++ b/app/assets/stylesheets/styles/buttons.scss
@@ -1,6 +1,6 @@
 // Button styling.
 @use "sass:color";
-@use '_variables';
+@use './_variables';
 
 // btn-primary
 .btn-primary {

--- a/app/assets/stylesheets/styles/call_list.scss
+++ b/app/assets/stylesheets/styles/call_list.scss
@@ -1,6 +1,6 @@
 // Styling related to the call list and patient search.
 
-@use '_variables';
+@use './_variables';
 
 .call-icon {
   color: variables.$white;

--- a/app/assets/stylesheets/styles/call_list.scss
+++ b/app/assets/stylesheets/styles/call_list.scss
@@ -1,10 +1,10 @@
 // Styling related to the call list and patient search.
 
-@import './_variables';
+@use '_variables';
 
 .call-icon {
-  color: $white;
-  background-color: $phone-icon-blue;
+  color: variables.$white;
+  background-color: variables.$phone-icon-blue;
   padding: 5px;
   border-radius: 50%;
 }
@@ -29,7 +29,7 @@
 // Drag and drop functionality/stylings
 // Activated when dragging around
 .ui-state-highlight {
-  background-color: $lavendar !important;
+  background-color: variables.$lavendar !important;
 }
 .active-item-shadow {
   -webkit-box-shadow: rgba(133,133,133,0.1) 0 0 5px 2px,rgba(133,133,133,0.3) 0 0 2px;
@@ -38,5 +38,5 @@
 }
 // Keeps the rows white when dragging around
 #call_list tr {
-  background-color: $white;
+  background-color: variables.$white;
 }

--- a/app/assets/stylesheets/styles/calls.scss
+++ b/app/assets/stylesheets/styles/calls.scss
@@ -1,6 +1,6 @@
 // Styling related to log-a-call modals.
 
-@use '_variables';
+@use './_variables';
 
 // Core new call modal
 .calls-layout {

--- a/app/assets/stylesheets/styles/calls.scss
+++ b/app/assets/stylesheets/styles/calls.scss
@@ -1,27 +1,27 @@
 // Styling related to log-a-call modals.
 
-@import './_variables';
+@use '_variables';
 
 // Core new call modal
 .calls-layout {
   padding: 1rem .5rem 1rem 2rem;
 
   .calls-request {
-    font-size: $font-size-large;
+    font-size: variables.$font-size-large;
   }
 
   .calls-phone {
-    font-size: $font-size-xlarge;
+    font-size: variables.$font-size-xlarge;
     font-weight: 900;
   }
 
   .calls-response {
-    font-size: $font-size;
+    font-size: variables.$font-size;
     text-decoration: underline;
   }
 
   .calls-btn {
-    font-size: $font-size;
+    font-size: variables.$font-size;
     padding: 10px 40px;
   }
 }

--- a/app/assets/stylesheets/styles/clinic_finder.scss
+++ b/app/assets/stylesheets/styles/clinic_finder.scss
@@ -3,9 +3,9 @@
 @use './_variables';
 
 .clinic_finder_container {
-  background-color: variables.$grey-color;
+  background-color: variables.$light-gray;
   border-style: solid;
-  border-color: black;
+  border-color: variables.$grey-color;
   border-width: thin;
 
   .button-right {

--- a/app/assets/stylesheets/styles/clinic_finder.scss
+++ b/app/assets/stylesheets/styles/clinic_finder.scss
@@ -1,6 +1,6 @@
 // Styling related to the clinic finder utility.
 
-@use '_variables';
+@use './_variables';
 
 .clinic_finder_container {
   background-color: variables.$grey-color;

--- a/app/assets/stylesheets/styles/clinic_finder.scss
+++ b/app/assets/stylesheets/styles/clinic_finder.scss
@@ -1,9 +1,9 @@
 // Styling related to the clinic finder utility.
 
-@import './_variables';
+@use '_variables';
 
 .clinic_finder_container {
-  background-color: $grey-color;
+  background-color: variables.$grey-color;
   border-style: solid;
   border-color: black;
   border-width: thin;

--- a/app/assets/stylesheets/styles/devise.scss
+++ b/app/assets/stylesheets/styles/devise.scss
@@ -1,5 +1,6 @@
 // Styles pertaining to the login form or other devise-related views.
 
+@use 'bootstrap/scss/bootstrap';
 @use '_variables';
 
 .authform {

--- a/app/assets/stylesheets/styles/devise.scss
+++ b/app/assets/stylesheets/styles/devise.scss
@@ -1,12 +1,12 @@
 // Styles pertaining to the login form or other devise-related views.
 
-@import './_variables';
+@use '_variables';
 
 .authform {
   @extend .card-header;
   @extend .mx-auto;
   padding-top: 20px;
-  border: 1px solid $light-gray;
+  border: 1px solid variables.$light-gray;
   border-radius: 6px;
   margin: 0 auto;
 }

--- a/app/assets/stylesheets/styles/devise.scss
+++ b/app/assets/stylesheets/styles/devise.scss
@@ -1,7 +1,7 @@
 // Styles pertaining to the login form or other devise-related views.
 
 @use 'bootstrap/scss/bootstrap';
-@use '_variables';
+@use './_variables';
 
 .authform {
   @extend .card-header;

--- a/app/assets/stylesheets/styles/events.scss
+++ b/app/assets/stylesheets/styles/events.scss
@@ -1,5 +1,6 @@
 // Styling for the events log on the patient dashboard.
 
+@use 'bootstrap/scss/bootstrap';
 @use '_variables';
 
 svg.event-item {

--- a/app/assets/stylesheets/styles/events.scss
+++ b/app/assets/stylesheets/styles/events.scss
@@ -1,7 +1,7 @@
 // Styling for the events log on the patient dashboard.
 
 @use 'bootstrap/scss/bootstrap';
-@use '_variables';
+@use './_variables';
 
 svg.event-item {
   border-radius: 50%;

--- a/app/assets/stylesheets/styles/events.scss
+++ b/app/assets/stylesheets/styles/events.scss
@@ -1,13 +1,13 @@
 // Styling for the events log on the patient dashboard.
 
-@import './_variables';
+@use '_variables';
 
 svg.event-item {
   border-radius: 50%;
   margin-right: 1em;
   color: white;
   padding: 4px;
-  background-color: $teal;
+  background-color: variables.$teal;
   font-size: 1.25em;
   
   &.fa-thumbs-up {
@@ -15,7 +15,7 @@ svg.event-item {
   }
 
   &.fa-comment {
-    background-color: $light-gray;
+    background-color: variables.$light-gray;
     color: black;
   }
 }  

--- a/app/assets/stylesheets/styles/flash.scss
+++ b/app/assets/stylesheets/styles/flash.scss
@@ -1,7 +1,7 @@
 // Styling around flash messages.
 
 @use 'bootstrap/scss/bootstrap';
-@use '_variables';
+@use './_variables';
 
 #flash {
   position: fixed;

--- a/app/assets/stylesheets/styles/flash.scss
+++ b/app/assets/stylesheets/styles/flash.scss
@@ -1,5 +1,5 @@
 // Styling around flash messages.
-@import './_variables';
+@use '_variables';
 
 #flash {
   position: fixed;

--- a/app/assets/stylesheets/styles/flash.scss
+++ b/app/assets/stylesheets/styles/flash.scss
@@ -1,4 +1,6 @@
 // Styling around flash messages.
+
+@use 'bootstrap/scss/bootstrap';
 @use '_variables';
 
 #flash {

--- a/app/assets/stylesheets/styles/forms.scss
+++ b/app/assets/stylesheets/styles/forms.scss
@@ -1,5 +1,7 @@
 // Styling around forms.
 
+@use './variables';
+
 // Override rails_bootstrap_forms checkbox styling
 .form-check label {
   min-height: 20px;
@@ -13,7 +15,7 @@
 
 // Override rails bootstrap form-text for accessible color contrast
 .form-text {
-  color: $grey-color !important;
+  color: variables.$grey-color !important;
 }
 
 // On date inputs, don't do the annoying

--- a/app/assets/stylesheets/styles/globals.scss
+++ b/app/assets/stylesheets/styles/globals.scss
@@ -1,17 +1,17 @@
 // Global styling patterns.
 
-@import "./_variables";
-@import "./vendor/googleapis_source_sans_pro";
+@use "_variables";
+@use "vendor/googleapis_source_sans_pro";
 
 @charset "utf-8";
 
 html {
-  font-size: $font-size;
+  font-size: variables.$font-size;
 }
 
 body {
   font-family: "Source Sans Pro", sans-serif;
-  font-size: $font-size;
+  font-size: variables.$font-size;
 }
 
 main {
@@ -65,7 +65,7 @@ label {
 
 // Links
 a {
-  color: $link-blue;
+  color: variables.$link-blue;
   text-decoration: none;
 }
 
@@ -73,12 +73,12 @@ a:hover,
 a:active,
 a:visited,
 a:focus {
-  color: $dark-blue;
+  color: variables.$dark-blue;
   text-decoration: underline;
 }
 
 .border-bottom {
-  border-bottom: 1px solid $black;
+  border-bottom: 1px solid variables.$black;
   padding-bottom: 10px;
 }
 

--- a/app/assets/stylesheets/styles/globals.scss
+++ b/app/assets/stylesheets/styles/globals.scss
@@ -2,6 +2,7 @@
 
 @use "_variables";
 @use "vendor/googleapis_source_sans_pro";
+@use 'bootstrap/scss/bootstrap';
 
 @charset "utf-8";
 

--- a/app/assets/stylesheets/styles/globals.scss
+++ b/app/assets/stylesheets/styles/globals.scss
@@ -1,8 +1,8 @@
 // Global styling patterns.
 
-@use "_variables";
-@use "vendor/googleapis_source_sans_pro";
 @use 'bootstrap/scss/bootstrap';
+@use "vendor/googleapis_source_sans_pro";
+@use "./_variables";
 
 @charset "utf-8";
 

--- a/app/assets/stylesheets/styles/globals.scss
+++ b/app/assets/stylesheets/styles/globals.scss
@@ -11,7 +11,6 @@ html {
 }
 
 body {
-  font-family: "Source Sans Pro", sans-serif;
   font-size: variables.$font-size;
 }
 

--- a/app/assets/stylesheets/styles/lines.scss
+++ b/app/assets/stylesheets/styles/lines.scss
@@ -1,7 +1,7 @@
 // Styling related to the lines form.
 
-@import 'bootstrap/scss/bootstrap';
-@import './_variables';
+@use 'bootstrap/scss/bootstrap';
+@use './_variables';
 
 .lines-form {
   input[type="radio"] {
@@ -12,7 +12,7 @@
   }
 
   label {
-    font-size: $font-size-medium;
+    font-size: variables.$font-size-medium;
   }
 
   .form-check-label {

--- a/app/assets/stylesheets/styles/lines.scss
+++ b/app/assets/stylesheets/styles/lines.scss
@@ -16,6 +16,6 @@
   }
 
   .form-check-label {
-    @extend .ml-8;
+    @extend .ml-5;
   }
 }

--- a/app/assets/stylesheets/styles/navbar.scss
+++ b/app/assets/stylesheets/styles/navbar.scss
@@ -1,7 +1,7 @@
 // Styling for the navbar.
 
 @use "sass:color";
-@use '_variables';
+@use './_variables';
 
 .navbar-inverse{
   background-color: variables.$light-gray;

--- a/app/assets/stylesheets/styles/navbar.scss
+++ b/app/assets/stylesheets/styles/navbar.scss
@@ -1,30 +1,31 @@
 // Styling for the navbar.
 
-@import './_variables';
+@use "sass:color";
+@use '_variables';
 
 .navbar-inverse{
-  background-color: $light-gray;
+  background-color: variables.$light-gray;
   border: none;
 
   .navbar-header > a, .navbar-nav > li > a {
-    color: $daria-color;
+    color: variables.$daria-color;
 
     &:hover{
-      color: lighten($daria-color, 20%);
+      color: color.adjust(variables.$daria-color, $lightness: 20%);
       text-decoration: underline;
     }
 
     &:visited{
-      color: $dark-blue;
+      color: variables.$dark-blue;
     }
   }
 
   .navbar-text {
-    color: $daria-color;
+    color: variables.$daria-color;
   }
 
   .navbar-text-alt {
-    color: $grey-color;
+    color: variables.$grey-color;
   }
 }
 

--- a/app/assets/stylesheets/styles/navbar.scss
+++ b/app/assets/stylesheets/styles/navbar.scss
@@ -31,5 +31,5 @@
 
 // override for the 'Home' navigation link
 .navbar-brand {
-  font-size: inherit;
+  font-size: variables.$font-size-medium;
 }

--- a/app/assets/stylesheets/styles/pagination.scss
+++ b/app/assets/stylesheets/styles/pagination.scss
@@ -1,6 +1,6 @@
 // Styling for Kaminari pagination
 
-@use '_variables';
+@use './_variables';
 
 span.page, span.first, span.prev, span.next, span.last {
   font-size: variables.$font-size;

--- a/app/assets/stylesheets/styles/pagination.scss
+++ b/app/assets/stylesheets/styles/pagination.scss
@@ -1,15 +1,15 @@
 // Styling for Kaminari pagination
 
-@import './_variables';
+@use '_variables';
 
 span.page, span.first, span.prev, span.next, span.last {
-  font-size: $font-size;
+  font-size: variables.$font-size;
   margin-right: .5rem;
 }
 
 #accountants-pagination {
   .pagination-entries {
-    font-size: $font-size;
+    font-size: variables.$font-size;
     display: inline-block;
   }
 
@@ -17,7 +17,7 @@ span.page, span.first, span.prev, span.next, span.last {
     display: inline-block;
 
     span {
-      font-size: $font-size;
+      font-size: variables.$font-size;
     }
   }
 }

--- a/app/assets/stylesheets/styles/patient_edit.scss
+++ b/app/assets/stylesheets/styles/patient_edit.scss
@@ -1,5 +1,6 @@
 // Styling related to the larger patient edit page.
 
+@use 'bootstrap/scss/bootstrap';
 @use '_variables';
 
 #patient_dashboard {

--- a/app/assets/stylesheets/styles/patient_edit.scss
+++ b/app/assets/stylesheets/styles/patient_edit.scss
@@ -1,7 +1,7 @@
 // Styling related to the larger patient edit page.
 
 @use 'bootstrap/scss/bootstrap';
-@use '_variables';
+@use './_variables';
 
 #patient_dashboard {
   border-bottom: 1px solid variables.$black;

--- a/app/assets/stylesheets/styles/patient_edit.scss
+++ b/app/assets/stylesheets/styles/patient_edit.scss
@@ -1,20 +1,20 @@
 // Styling related to the larger patient edit page.
 
-@import './_variables';
+@use '_variables';
 
 #patient_dashboard {
-  border-bottom: 1px solid $black;
+  border-bottom: 1px solid variables.$black;
   padding: 15px 0;
 }
 
 #sections {
-  border-left: 1px solid $black;
+  border-left: 1px solid variables.$black;
   padding-left: 9.5%;
 }
 
 .pledge-error {
-  color: $red;
-  font-size: $font-size;
+  color: variables.$red;
+  font-size: variables.$font-size;
 }
 
 // Overrides/styling related to multistep modal
@@ -25,7 +25,7 @@
     font-size: 75%;
     font-weight: 700;
     line-height: 1;
-    color: $white;
+    color: variables.$white;
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
@@ -34,7 +34,7 @@
 }
 
 .label-success {
-  background-color: $daria-color;
+  background-color: variables.$daria-color;
 }
 
 .hide {

--- a/app/assets/stylesheets/styles/patient_menu.scss
+++ b/app/assets/stylesheets/styles/patient_menu.scss
@@ -1,6 +1,6 @@
 // Styling for the patient nav menu.
 
-@use '_variables';
+@use './_variables';
 
 .abortion-left-menu.nav-pills {
   font-size: variables.$font-size;

--- a/app/assets/stylesheets/styles/patient_menu.scss
+++ b/app/assets/stylesheets/styles/patient_menu.scss
@@ -1,18 +1,18 @@
 // Styling for the patient nav menu.
 
-@import './_variables';
+@use '_variables';
 
 .abortion-left-menu.nav-pills {
-  font-size: $font-size;
+  font-size: variables.$font-size;
 
   .nav-link {
-    color: $soft-blue;
-    background-color: $white;
+    color: variables.$soft-blue;
+    background-color: variables.$white;
   }
 
   a.nav-link.active {
-    color: $daria-color;
-    background-color: $white;
+    color: variables.$daria-color;
+    background-color: variables.$white;
 
     // This adds the arrow icon to mark selected status
     &:before {
@@ -22,7 +22,7 @@
       content: "\f054";
       margin-left: -1.5em;
       padding-right: .85em;
-      color: $daria-color;
+      color: variables.$daria-color;
     }
 
     .svg-inline--fa {
@@ -36,7 +36,7 @@ a.submit-pledge-button {
   text-decoration: none;
 
   .submit-btn, .cancel-btn {
-    font-size: $font-size;
+    font-size: variables.$font-size;
     font-weight: bold;    
   }
 }

--- a/app/assets/stylesheets/styles/tables.scss
+++ b/app/assets/stylesheets/styles/tables.scss
@@ -1,6 +1,6 @@
 // Additional styling for table elements.
 
-@use '_variables';
+@use './_variables';
 
 table.border-side {
   th {

--- a/app/assets/stylesheets/styles/tables.scss
+++ b/app/assets/stylesheets/styles/tables.scss
@@ -1,14 +1,14 @@
 // Additional styling for table elements.
 
-@import './_variables';
+@use '_variables';
 
 table.border-side {
   th {
-    font-size: $font-size-small;
-    color: $dark-grey;
+    font-size: variables.$font-size-small;
+    color: variables.$dark-grey;
     text-transform: uppercase;
     letter-spacing: 1.5px;
-    background: $light-gray;
+    background: variables.$light-gray;
     padding-left: 0px !important;
   }
 

--- a/app/assets/stylesheets/styles/tooltips.scss
+++ b/app/assets/stylesheets/styles/tooltips.scss
@@ -1,13 +1,13 @@
 // Styling around bootstrap tooltips.
 
-@import './_variables';
+@use '_variables';
 
 .tooltip-header-help {
-  color: $grey-color;
-  border-bottom: 1px dotted $grey-color;
+  color: variables.$grey-color;
+  border-bottom: 1px dotted variables.$grey-color;
   cursor: pointer;
 }
 
 .tooltip-inner {
-  font-size: $font-size-small;
+  font-size: variables.$font-size-small;
 }

--- a/app/assets/stylesheets/styles/tooltips.scss
+++ b/app/assets/stylesheets/styles/tooltips.scss
@@ -1,6 +1,6 @@
 // Styling around bootstrap tooltips.
 
-@use '_variables';
+@use './_variables';
 
 .tooltip-header-help {
   color: variables.$grey-color;

--- a/app/assets/stylesheets/styles/users.scss
+++ b/app/assets/stylesheets/styles/users.scss
@@ -1,6 +1,6 @@
 // Styling specific to users routes.
 
-@use '_variables';
+@use './_variables';
 
 // Make data-sort elements in user list a pointer.
 #user-list th[data-sort] {

--- a/app/assets/stylesheets/styles/users.scss
+++ b/app/assets/stylesheets/styles/users.scss
@@ -1,6 +1,6 @@
 // Styling specific to users routes.
 
-@import './_variables';
+@use '_variables';
 
 // Make data-sort elements in user list a pointer.
 #user-list th[data-sort] {
@@ -9,6 +9,6 @@
 
 // Highlight user-rows with a light gray.
 .user-row:hover {
-  background-color: $light-gray;
+  background-color: variables.$light-gray;
   border: 2px solid gray;
 }

--- a/app/javascript/locales.json
+++ b/app/javascript/locales.json
@@ -6629,8 +6629,7 @@
           }
         }
       },
-      "nth": {
-      },
+      "nth": {},
       "percentage": {
         "format": {
           "delimiter": "",
@@ -16600,8 +16599,7 @@
           }
         }
       },
-      "nth": {
-      },
+      "nth": {},
       "percentage": {
         "format": {
           "delimiter": "",
@@ -16884,8 +16882,7 @@
           }
         }
       },
-      "nth": {
-      },
+      "nth": {},
       "percentage": {
         "format": {
           "delimiter": "",
@@ -17168,8 +17165,7 @@
           }
         }
       },
-      "nth": {
-      },
+      "nth": {},
       "percentage": {
         "format": {
           "delimiter": "",
@@ -17452,8 +17448,7 @@
           }
         }
       },
-      "nth": {
-      },
+      "nth": {},
       "percentage": {
         "format": {
           "delimiter": "",
@@ -18048,8 +18043,7 @@
           }
         }
       },
-      "nth": {
-      },
+      "nth": {},
       "percentage": {
         "format": {
           "delimiter": "",
@@ -19130,28 +19124,28 @@
     },
     "date": {
       "abbr_day_names": [
-        "ned",
-        "pon",
-        "uto",
-        "sri",
-        "čet",
-        "pet",
-        "sub"
+        "ned.",
+        "pon.",
+        "uto.",
+        "sri.",
+        "čet.",
+        "pet.",
+        "sub."
       ],
       "abbr_month_names": [
         null,
-        "sij",
-        "veǉ",
-        "ožu",
-        "tra",
-        "svi",
-        "lip",
-        "srp",
-        "kol",
-        "ruj",
-        "lis",
-        "stu",
-        "pro"
+        "sij.",
+        "velj.",
+        "ožu.",
+        "tra.",
+        "svi.",
+        "lip.",
+        "srp.",
+        "kol.",
+        "ruj.",
+        "lis.",
+        "stu.",
+        "pro."
       ],
       "day_names": [
         "nedjelja",
@@ -19169,18 +19163,18 @@
       },
       "month_names": [
         null,
-        "siječanj",
-        "veljača",
-        "ožujak",
-        "travanj",
-        "svibanj",
-        "lipanj",
-        "srpanj",
-        "kolovoz",
-        "rujan",
-        "listopad",
-        "studeni",
-        "prosinac"
+        "siječnja",
+        "veljače",
+        "ožujka",
+        "travnja",
+        "svibnja",
+        "lipnja",
+        "srpnja",
+        "kolovoza",
+        "rujna",
+        "listopada",
+        "studenoga",
+        "prosinca"
       ],
       "order": [
         "day",
@@ -22429,9 +22423,11 @@
           "format": "%n%u",
           "units": {
             "byte": "바이트",
+            "eb": "EB",
             "gb": "GB",
             "kb": "KB",
             "mb": "MB",
+            "pb": "PB",
             "tb": "TB"
           }
         }
@@ -23073,6 +23069,11 @@
           "few": "%{count} sekundės",
           "one": "%{count} sekundė",
           "other": "%{count} sekundžių"
+        },
+        "x_years": {
+          "few": "%{count} metai",
+          "one": "%{count} metai",
+          "other": "%{count} metai"
         }
       },
       "prompts": {
@@ -23096,15 +23097,18 @@
         "exclusion": "yra rezervuotas",
         "greater_than": "turi būti didesnis už %{count}",
         "greater_than_or_equal_to": "turi būti didesnis arba lygus %{count}",
+        "in": "turi būti skaičiuje %{count}",
         "inclusion": "nenumatyta reikšmė",
         "invalid": "neteisingas",
         "less_than": "turi būti mažesnis už %{count}",
         "less_than_or_equal_to": "turi būti mažesnis arba lygus %{count}",
+        "model_invalid": "Tikrinimo klaida: %{errors}",
         "not_a_number": "ne skaičius",
         "not_an_integer": "privalo būti sveikas skaičius",
         "odd": "turi būti nelyginis skaičius",
         "other_than": "privalo būti kitoks nei %{count}",
         "present": "turi būti tuščias",
+        "required": "turi egzistuoti",
         "taken": "jau užimtas",
         "too_long": {
           "few": "per ilgas (daugiausiai %{count} simboliai)",
@@ -23161,6 +23165,7 @@
       "format": {
         "delimiter": " ",
         "precision": 3,
+        "round_mode": "default",
         "separator": ",",
         "significant": false,
         "strip_insignificant_zeros": false
@@ -23191,9 +23196,11 @@
               "one": "Baitas",
               "other": "Baitų"
             },
+            "eb": "EB",
             "gb": "GB",
             "kb": "KB",
             "mb": "MB",
+            "pb": "PB",
             "tb": "TB"
           }
         }
@@ -28261,7 +28268,7 @@
       "submit": {
         "create": "Criar %{model}",
         "submit": "Gravar %{model}",
-        "update": "Actualizar %{model}"
+        "update": "Atualizar %{model}"
       }
     },
     "i18n": {
@@ -28304,7 +28311,7 @@
       "currency": {
         "format": {
           "delimiter": ".",
-          "format": "%u %n",
+          "format": "%n %u",
           "precision": 2,
           "separator": ",",
           "significant": false,
@@ -29525,8 +29532,7 @@
           "other"
         ]
       },
-      "transliterate": {
-      }
+      "transliterate": {}
     },
     "i18n_tasks": {
       "add_missing": {
@@ -33589,7 +33595,7 @@
       ],
       "formats": {
         "default": "%d.%m.%Y",
-        "long": "%e %B %Y, %A",
+        "long": "%e %B %Y %A",
         "short": "%e %b"
       },
       "month_names": [
@@ -34698,8 +34704,7 @@
           "other"
         ]
       },
-      "transliterate": {
-      }
+      "transliterate": {}
     },
     "number": {
       "currency": {

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -1,4 +1,4 @@
-<div class="progress mb-5" id='budget-progress-bar'>
+<div class="progress mb-3" id='budget-progress-bar'>
   <% expenditures.each_pair do |type, patient_hashes| %>
     <% patient_hashes.each do |patient| %>
       <div class="progress-bar <%= progress_bar_color type %> expenditure-block" style='<%= progress_bar_width patient[:fund_pledge], limit %>' role='progressbar'>

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -1,6 +1,6 @@
 <!-- locals: title, table_type (for div id and tbody div id), pregnancies, sortable, autosortable -->
 
-<div id="<%= table_type %>" class="margin-bottom mt-5">
+<div id="<%= table_type %>" class="margin-bottom mt-4">
   <h1 class="border-bottom title">
     <%= title %>
     <%= dashboard_table_content_tooltip_shell table_type %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -11,7 +11,7 @@
 	</div>
 </div>
 
-<div class="row mb-6">
+<div class="row mb-3">
 	<div id="app_footer" class="col text-center">
 	  <a href="http://<%= current_tenant.site_domain %>/"><%= current_tenant.full_name %></a> -- <a href="tel:<%= current_tenant.phone %>"><i class="fas fa-phone-alt fa-sm" aria-hidden="true"></i> <%= current_tenant.phone %></a><br>
 

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -1,5 +1,5 @@
 <div id="abortion_information_content">
-  <h2 class="mt-5"><%= t('patient.abortion_information.title') %></h2>
+  <h2><%= t('patient.abortion_information.title') %></h2>
 
   <div class="practical-support-flag">
     <% if patient.practical_supports.any? %>

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -1,5 +1,5 @@
 <div id="call_log_content">
-  <h2 class="mt-5">
+  <h2>
     <%= t('patient.call_log.title') %>
     <small class="float-right"> 
       <%= link_to t('patient.call_log.record_new_call'),

--- a/app/views/patients/_change_log.html.erb
+++ b/app/views/patients/_change_log.html.erb
@@ -1,5 +1,5 @@
 <div id="change_log_content">
-  <h2 class="mt-5"><%= t('patient.change_log.title') %></h2>
+  <h2><%= t('patient.change_log.title') %></h2>
 
   <table class="table border-side" id="change-log-table">
     <thead>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -1,4 +1,4 @@
-<div id='menu-content' class="row mt-5">
+<div id='menu-content' class="row">
   <div class="nav nav-pills flex-column abortion-left-menu" id='menu-list' role='tablist' aria-orientation="vertical">
     <%= render 'menu_item', link_for: 'patient_information', active: true %>
     <%= render 'menu_item', link_for: 'abortion_information', active: false %>

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -1,5 +1,5 @@
 <div id="notes_content">
-  <h2 class="mt-5"><%= t('patient.notes.title') %></h2>
+  <h2><%= t('patient.notes.title') %></h2>
 
   <%# this has a confusing doc structure; the shared flag checkbox needs to be same row as submit btn. %>
   <%= bootstrap_form_with model: [patient, note],

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -1,5 +1,5 @@
 <div id="patient_information_content">
-  <h2 class="mt-5"><%= t 'patient.information.title' %></h2>
+  <h2><%= t 'patient.information.title' %></h2>
 
   <%= bootstrap_form_with model: patient,
                           html: { id: 'patient_information_form' },

--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -1,5 +1,5 @@
 <div id="practical_support_content">
-  <h2 class="mt-5"><%= t 'patient.practical_support.title' %></h2>
+  <h2><%= t 'patient.practical_support.title' %></h2>
   <p class="mb-5"><%= practical_support_guidance_link %></p>
 
   <% if Config.display_practical_support_waiver? %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -5,42 +5,46 @@
 </div>
 
 <div id="patient_detail" class="row">
-  <div id="menu" class="col-3">
+  <div id="menu" class="col-3 mt-3">
     <%= render 'patients/menu', patient: @patient %>
   </div>
 
-  <div id="sections" class="col tab-content">
-    <div id="patient_information" class="patient-info tab-pane active">
-      <%= render 'patients/patient_information', patient: @patient %>
-    </div>
-
-    <div id="abortion_information" class="abortion-info tab-pane">
-      <%= render 'patients/abortion_information', patient: @patient, new_external_pledge: @external_pledge %>
-    </div>
-
-    <div id="change_log" class="change-log tab-pane">
-      <%= render 'patients/change_log', patient: @patient %>
-    </div>
-
-    <div id="call_log" class="call-info tab-pane">
-      <%= render 'patients/call_log', patient: @patient %>
-    </div>
-
-    <div id="notes" class="notes tab-pane">
-      <%= render 'patients/notes', patient: @patient, note: @note %>
-    </div>
 
 
-    <% unless Config.hide_practical_support? %>
-    <div id="practical_support" class="practical_support tab-pane">
-      <%= render 'patients/practical_support', patient: @patient, note: @note %>
-    </div>
-    <% end %>
+  <div id="sections" class="col tab-content mt-3">
 
-    <div id="pledge_fulfillment" class="pledge-fulfillment-info tab-pane">
-      <% if current_user.allowed_data_access? && @patient.pledge_sent? %>
-        <%= render 'patients/fulfillment', patient: @patient %>
+      <div id="patient_information" class="patient-info tab-pane active ">
+        <%= render 'patients/patient_information', patient: @patient %>
+      </div>
+
+      <div id="abortion_information" class="abortion-info tab-pane">
+        <%= render 'patients/abortion_information', patient: @patient, new_external_pledge: @external_pledge %>
+      </div>
+
+      <div id="change_log" class="change-log tab-pane">
+        <%= render 'patients/change_log', patient: @patient %>
+      </div>
+
+      <div id="call_log" class="call-info tab-pane">
+        <%= render 'patients/call_log', patient: @patient %>
+      </div>
+
+      <div id="notes" class="notes tab-pane">
+        <%= render 'patients/notes', patient: @patient, note: @note %>
+      </div>
+
+
+      <% unless Config.hide_practical_support? %>
+      <div id="practical_support" class="practical_support tab-pane">
+        <%= render 'patients/practical_support', patient: @patient, note: @note %>
+      </div>
       <% end %>
+
+      <div id="pledge_fulfillment" class="pledge-fulfillment-info tab-pane">
+        <% if current_user.allowed_data_access? && @patient.pledge_sent? %>
+          <%= render 'patients/fulfillment', patient: @patient %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -9,42 +9,38 @@
     <%= render 'patients/menu', patient: @patient %>
   </div>
 
-
-
   <div id="sections" class="col tab-content mt-3">
+    <div id="patient_information" class="patient-info tab-pane active">
+      <%= render 'patients/patient_information', patient: @patient %>
+    </div>
 
-      <div id="patient_information" class="patient-info tab-pane active ">
-        <%= render 'patients/patient_information', patient: @patient %>
-      </div>
+    <div id="abortion_information" class="abortion-info tab-pane">
+      <%= render 'patients/abortion_information', patient: @patient, new_external_pledge: @external_pledge %>
+    </div>
 
-      <div id="abortion_information" class="abortion-info tab-pane">
-        <%= render 'patients/abortion_information', patient: @patient, new_external_pledge: @external_pledge %>
-      </div>
+    <div id="change_log" class="change-log tab-pane">
+      <%= render 'patients/change_log', patient: @patient %>
+    </div>
 
-      <div id="change_log" class="change-log tab-pane">
-        <%= render 'patients/change_log', patient: @patient %>
-      </div>
+    <div id="call_log" class="call-info tab-pane">
+      <%= render 'patients/call_log', patient: @patient %>
+    </div>
 
-      <div id="call_log" class="call-info tab-pane">
-        <%= render 'patients/call_log', patient: @patient %>
-      </div>
-
-      <div id="notes" class="notes tab-pane">
-        <%= render 'patients/notes', patient: @patient, note: @note %>
-      </div>
+    <div id="notes" class="notes tab-pane">
+      <%= render 'patients/notes', patient: @patient, note: @note %>
+    </div>
 
 
-      <% unless Config.hide_practical_support? %>
-      <div id="practical_support" class="practical_support tab-pane">
-        <%= render 'patients/practical_support', patient: @patient, note: @note %>
-      </div>
+    <% unless Config.hide_practical_support? %>
+    <div id="practical_support" class="practical_support tab-pane">
+      <%= render 'patients/practical_support', patient: @patient, note: @note %>
+    </div>
+    <% end %>
+
+    <div id="pledge_fulfillment" class="pledge-fulfillment-info tab-pane">
+      <% if current_user.allowed_data_access? && @patient.pledge_sent? %>
+        <%= render 'patients/fulfillment', patient: @patient %>
       <% end %>
-
-      <div id="pledge_fulfillment" class="pledge-fulfillment-info tab-pane">
-        <% if current_user.allowed_data_access? && @patient.pledge_sent? %>
-          <%= render 'patients/fulfillment', patient: @patient %>
-        <% end %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -25,7 +25,7 @@
 
 <div class="tab-content" id="nav-tabContent">
   <div class="tab-pane fade show active" id="nav-support" role="tabpanel" aria-labelledby="nav-support-tab">
-    <div class="row practical-support-form mt-5">
+    <div class="row practical-support-form mt-3">
       <%= bootstrap_form_with model: support,
           url: patient_practical_support_path(patient, support),
           html: { class: 'edit_practical_support col-12' },
@@ -65,7 +65,7 @@
   <div class="tab-pane fade" id="nav-notes" role="tabpanel" aria-labelledby="nav-notes-tab">
     <div class="row notes-form">
       <div class="col">
-        <h3 class="mt-5"><%= t('patient.notes.title') %></h3>
+        <h3 class="mt-3"><%= t('patient.notes.title') %></h3>
         <%= bootstrap_form_with model: [support, note],
                                 html: { id: 'notes-form-practical-support' },
                                 local: false do |f| %>
@@ -82,7 +82,7 @@
           </div>
         <% end %>
 
-        <div class="mt-5" id="notes-log-practical-support">
+        <div class="mt-3" id="notes-log-practical-support">
           <%= render partial: 'notes/notes_table',
                      locals: { notes: support.notes.order(created_at: :desc) } %>
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

One of the deprecation warnings we were getting was `import` being deprecated in favor of use. Predictably no good deed goes unpunished here.

This pull request makes the following changes:
* swap `import` out for `use`
* bunch of in-place changes to make things play nice

no meaningful view changes, and counting on system tests to not break anything meaningful (though I also clicked around the app a bunch) 

It relates to the following issue #s: 
* Fixes #3311 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
