### PR TITLE
React autosave: patient dashboard form (bugs fixed 🙂 )

### DIFF
--- a/app/javascript/src/components/PatientDashboardForm.jsx
+++ b/app/javascript/src/components/PatientDashboardForm.jsx
@@ -130,6 +130,7 @@ export default PatientDashboardForm = ({
           label={i18n.t('patient.shared.status')}
           value={patientData.status}
           className="form-control-plaintext"
+          disabled="true"
           tooltip={statusTooltip}
           onChange={e => debouncedAutosave({ status: e.target.value })}
         />

--- a/app/javascript/src/components/PatientDashboardForm.jsx
+++ b/app/javascript/src/components/PatientDashboardForm.jsx
@@ -26,7 +26,6 @@ export default PatientDashboardForm = ({
 
   const autosave = async (updatedData) => {
     const updatedPatientData = { ...patientData, ...updatedData }
-    setPatientData(updatedPatientData)
 
     const putData = {
       name: updatedPatientData.name,
@@ -44,9 +43,9 @@ export default PatientDashboardForm = ({
     }
   }
 
-  const debouncedAutosave = useMemo((params) => {
-    return debounce(autosave, 300)
-  }, []);
+  const debouncedAutosave = (params) => {
+    return debounce(autosave(params), 300)
+  };
 
   // Stop the invocation of the debounced function after unmounting
   useEffect(() => {

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -1,77 +1,12 @@
 <div id="patient_dashboard_content">
-  <%= bootstrap_form_with model: patient,
-                         html: { id: 'patient_dashboard_form' },
-                         local: false,
-                         method: 'patch',
-                         class: 'edit_patient' do |f| %>
-    <div class="row">
-
-      <div class="col-4">
-        <%= f.text_field :name,
-                         label: t('patient.shared.name'),
-                         autocomplete: 'off' %>
-      </div>
-      
-      <div class="col">
-        <%= f.select :last_menstrual_period_weeks,
-                     options_for_select(weeks_options, patient.last_menstrual_period_weeks ),
-                     label: t('patient.dashboard.weeks_along'),
-                     autocomplete: 'off',
-                     help: t('patient.dashboard.currently', weeks: patient.last_menstrual_period_now_weeks, days: patient.last_menstrual_period_now_days) %>
-      </div>
-
-      <div class="col mt-4">
-        <%= f.select :last_menstrual_period_days,
-                     options_for_select(days_options, patient.last_menstrual_period_days),
-                     autocomplete: 'off',
-                     skip_label: true,
-                     help: t('patient.dashboard.called_on', date: patient.initial_call_date.strftime("%m/%d/%Y")) %>
-        <%= f.label :last_menstrual_period_days, t('common.days_along'), class: "sr-only" %>
-      </div>          
-
-      <div class="col-3">
-        <%= f.date_field :appointment_date,
-                         label: t('patient.shared.appt_date'),
-                         autocomplete: 'off',
-                         help: t('patient.dashboard.approx_gestation', weeks: patient.last_menstrual_period_at_appt_weeks, days: patient.last_menstrual_period_at_appt_days) %>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-4">
-        <%= f.text_field :primary_phone,
-                         value: patient.primary_phone_display,
-                         label: t('patient.dashboard.phone'),
-                         autocomplete: 'off' %>
-      </div>
-
-      <div class="col">
-        <%= f.text_field :pronouns,
-                         value: patient.pronouns,
-                         autocomplete: 'off' %>
-      </div>
-
-      <div class="col">
-        <div class="form-group">
-          <label for="status"><%= t 'patient.shared.status' %> <%= tooltip_shell status_help_text(patient) %></label>
-          <input type="text" value="<%= patient.status %>" class="form-control form-control-plaintext" id="patient_status_display" autocomplete="off" disabled>
-        </div>
-      </div>
-
-      <div class="col-3">
-        <% if current_user.admin? %>
-          <div class="form-group">
-            <label for="admin-delete"><%= t 'patient.dashboard.delete_label' %></label>
-            <div>
-              <%= link_to t('patient.dashboard.delete'),
-                          patient_path(patient),
-                          class: 'btn btn-danger',
-                          method: :delete,
-                          data: { confirm: t('patient.dashboard.confirm_del', name: patient.name) } %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
+  <%= render ReactComponent.new("PatientDashboardForm", raw_props: { 
+    patient: patient.as_json, 
+    weeksOptions: weeks_options.map { |opt| { label: opt[0], value: opt[1] } },
+    daysOptions: days_options.map { |opt| { label: opt[0], value: opt[1] } },
+    initialCallDate: patient.initial_call_date.strftime("%m/%d/%Y"),
+    statusHelpText: status_help_text(patient),
+    isAdmin: current_user.admin?,
+    patientPath: patient_path(patient),
+    formAuthenticityToken: form_authenticity_token
+  }) %>
 </div>

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -298,7 +298,6 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
 
     it 'should flash failure on a bad field change' do
       fill_in 'Phone number', with: '111-222-3333445'
-      click_away_from_field
       assert has_text? 'Primary phone is the wrong length'
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR rewrites the patient dashboard form in React with safe autosave. This is mostly the same as #3216 but with the identified bugs fixed.

Let me know if anything else pops up. I'm sorry for the long delay on this 🫣 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
