### PR TITLE
Implement workaround for teamcapybara/capybara#2800

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :test do
   # Systemtest related tools
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'webdrivers'
   gem 'capybara-screenshot'
   gem 'launchy' # open up capybara screenshots automatically with `save_and_open_screenshot`
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '3.2.4'
 gem 'rails', '~> 7.2.2.1'
 gem 'puma', '~> 6.6' # roar
 gem 'sdoc', '~> 2.6.0', group: :doc
-gem 'nokogiri', '>= 1.13.4'
+gem 'nokogiri', '>= 1.18.4'
 gem 'tzinfo-data', require: false
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rexml' # not a ruby default in 3, but a requirement of bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,6 +477,10 @@ GEM
       method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
@@ -560,6 +564,7 @@ DEPENDENCIES
   twilio-ruby
   tzinfo-data
   view_component (~> 3.21)
+  webdrivers
   wicked
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,10 +259,10 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.3)
+    nokogiri (1.18.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.3-x86_64-linux-gnu)
+    nokogiri (1.18.6-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -527,7 +527,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  nokogiri (>= 1.13.4)
+  nokogiri (>= 1.18.4)
   omniauth-google-oauth2 (~> 1.2.1)
   omniauth-rails_csrf_protection (~> 1.0)
   paper_trail (~> 16.0)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,6 +7,20 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include IntegrationHelper
   include OmniauthMocker
 
+  # Use Capybara's built-in headless Chrome driver
+  if ENV['GITHUB_WORKFLOW'] || ENV['DOCKER']
+    driven_by :selenium, using: :selenium_chrome_headless do |driver|
+      driver.add_argument('--headless=new')
+      driver.add_argument('--disable-gpu')
+      driver.add_argument('--disable-site-isolation-trials')
+      driver.add_argument('--disable-background-timer-throttling')
+      driver.add_argument('--disable-backgrounding-occluded-windows')
+      driver.add_argument('--disable-renderer-backgrounding')
+    end
+  else
+    driven_by :selenium, using: :chrome
+  end
+
   before do
     Capybara.reset_sessions!
     PaperTrail.enabled = true
@@ -16,21 +30,5 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   after do
     PaperTrail.enabled = false
     PaperTrail.request.enabled = false
-  end
-   # Use Capybara's built-in headless Chrome driver
-  if ENV['GITHUB_WORKFLOW'] || ENV['DOCKER']
-    driven_by :selenium, using: :selenium_chrome_headless do |driver_options|
-      browser_options = Selenium::WebDriver::Chrome::Options.new
-      browser_options.add_argument('--headless=new')
-      browser_options.add_argument('--disable-gpu')
-      browser_options.add_argument('--disable-site-isolation-trials')
-      browser_options.add_argument('--disable-background-timer-throttling')
-      browser_options.add_argument('--disable-backgrounding-occluded-windows')
-      browser_options.add_argument('--disable-renderer-backgrounding')
-
-      driver_options[:options] = browser_options
-    end
-  else
-    driven_by :selenium, using: :chrome
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -16,34 +16,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     PaperTrail.enabled = false
     PaperTrail.request.enabled = false
   end
-
-  Capybara.register_driver :local_selenium_chrome_headless do |app|
-    version = Capybara::Selenium::Driver.load_selenium
-    options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
-    browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-      # These are defaults from capybara
-      # https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/drivers.rb#L31-L39
-  
-      opts.add_argument('--headless=new')
-      opts.add_argument('--disable-gpu') if Gem.win_platform?
-      # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
-      opts.add_argument('--disable-site-isolation-trials')
-  
-      # These are ones we are adding to try to workaround chrome race condition
-      # weirdness.
-      # https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2750363862
-      # Disable timers being throttled in background pages/tabs
-      opts.add_argument '--disable-background-timer-throttling'
-  
-      # Normally, Chrome will treat a 'foreground' tab instead as backgrounded if the surrounding window is occluded (aka
-      # visually covered) by another window. This flag disables that.
-      opts.add_argument '--disable-backgrounding-occluded-windows'
-  
-      # This disables non-foreground tabs from getting a lower process priority.
-      opts.add_argument '--disable-renderer-backgrounding'
+   # Use Capybara's built-in headless Chrome driver
+  if ENV['GITHUB_WORKFLOW'] || ENV['DOCKER']
+    driven_by :selenium, using: :selenium_chrome_headless do |options|
+      options.add_argument('--disable-site-isolation-trials')
+      options.add_argument('--disable-background-timer-throttling')
+      options.add_argument('--disable-backgrounding-occluded-windows')
+      options.add_argument('--disable-renderer-backgrounding')
     end
-  
-    Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
+  else
+    driven_by :selenium, using: :chrome
   end
-  driven_by :selenium, using: (ENV['GITHUB_WORKFLOW'] || ENV['DOCKER']) ? :local_selenium_chrome_headless : :chrome
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'integration_helper'
+require 'capybara/selenium/driver'
 
 # Set systemtest behavior
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
@@ -18,11 +19,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
    # Use Capybara's built-in headless Chrome driver
   if ENV['GITHUB_WORKFLOW'] || ENV['DOCKER']
-    driven_by :selenium, using: :selenium_chrome_headless do |options|
-      options.add_argument('--disable-site-isolation-trials')
-      options.add_argument('--disable-background-timer-throttling')
-      options.add_argument('--disable-backgrounding-occluded-windows')
-      options.add_argument('--disable-renderer-backgrounding')
+    driven_by :selenium, using: :selenium_chrome_headless do |driver_options|
+      browser_options = Selenium::WebDriver::Chrome::Options.new
+      browser_options.add_argument('--headless=new')
+      browser_options.add_argument('--disable-gpu')
+      browser_options.add_argument('--disable-site-isolation-trials')
+      browser_options.add_argument('--disable-background-timer-throttling')
+      browser_options.add_argument('--disable-backgrounding-occluded-windows')
+      browser_options.add_argument('--disable-renderer-backgrounding')
+
+      driver_options[:options] = browser_options
     end
   else
     driven_by :selenium, using: :chrome

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -45,12 +45,5 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   
     Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
   end
-
-  # if in CI, run system tests headlessly.
-  browser = ENV['GITHUB_WORKFLOW'] ? :local_selenium_chrome_headless : :chrome
-
-  # if in docker, run headless firefox
-  browser = ENV['DOCKER'] ? :local_selenium_chrome_headless : browser
-
-  driven_by :selenium, using: browser
+  driven_by :selenium, using: (ENV['GITHUB_WORKFLOW'] || ENV['DOCKER']) ? :local_selenium_chrome_headless : :chrome
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,35 +1,6 @@
 require 'test_helper'
 require 'integration_helper'
 
-Capybara.register_driver :local_selenium_chrome_headless do |app|
-  version = Capybara::Selenium::Driver.load_selenium
-  options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
-  browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-    # These are defaults from capybara
-    # https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/drivers.rb#L31-L39
-
-    opts.add_argument('--headless=new')
-    opts.add_argument('--disable-gpu') if Gem.win_platform?
-    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
-    opts.add_argument('--disable-site-isolation-trials')
-
-    # These are ones we are adding to try to workaround chrome race condition
-    # weirdness.
-    # https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2750363862
-    # Disable timers being throttled in background pages/tabs
-    opts.add_argument '--disable-background-timer-throttling'
-
-    # Normally, Chrome will treat a 'foreground' tab instead as backgrounded if the surrounding window is occluded (aka
-    # visually covered) by another window. This flag disables that.
-    opts.add_argument '--disable-backgrounding-occluded-windows'
-
-    # This disables non-foreground tabs from getting a lower process priority.
-    opts.add_argument '--disable-renderer-backgrounding'
-  end
-
-  Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
-end
-
 # Set systemtest behavior
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include IntegrationHelper
@@ -44,6 +15,35 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   after do
     PaperTrail.enabled = false
     PaperTrail.request.enabled = false
+  end
+
+  Capybara.register_driver :local_selenium_chrome_headless do |app|
+    version = Capybara::Selenium::Driver.load_selenium
+    options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+    browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+      # These are defaults from capybara
+      # https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/drivers.rb#L31-L39
+  
+      opts.add_argument('--headless=new')
+      opts.add_argument('--disable-gpu') if Gem.win_platform?
+      # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+      opts.add_argument('--disable-site-isolation-trials')
+  
+      # These are ones we are adding to try to workaround chrome race condition
+      # weirdness.
+      # https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2750363862
+      # Disable timers being throttled in background pages/tabs
+      opts.add_argument '--disable-background-timer-throttling'
+  
+      # Normally, Chrome will treat a 'foreground' tab instead as backgrounded if the surrounding window is occluded (aka
+      # visually covered) by another window. This flag disables that.
+      opts.add_argument '--disable-backgrounding-occluded-windows'
+  
+      # This disables non-foreground tabs from getting a lower process priority.
+      opts.add_argument '--disable-renderer-backgrounding'
+    end
+  
+    Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
   end
 
   # if in CI, run system tests headlessly.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'integration_helper'
+require 'capybara/rails'
 require 'capybara/selenium/driver'
 
 # Set systemtest behavior

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -8,16 +8,31 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include IntegrationHelper
   include OmniauthMocker
 
-  # Use Capybara's built-in headless Chrome driver
+  # Explicitly register a selenium chrome headless driver
+  Capybara.register_driver :headless_chrome do |app|
+    chrome_options = Selenium::WebDriver::Chrome::Options.new(
+      args: [
+        '--headless=new',
+        '--disable-gpu',
+        '--no-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-site-isolation-trials',
+        '--disable-background-timer-throttling',
+        '--disable-backgrounding-occluded-windows',
+        '--disable-renderer-backgrounding'
+      ]
+    )
+
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      options: chrome_options
+    )
+  end
+
+   # Conditionally select driver based on environment
   if ENV['GITHUB_WORKFLOW'] || ENV['DOCKER']
-    driven_by :selenium, using: :selenium_chrome_headless do |driver|
-      driver.add_argument('--headless=new')
-      driver.add_argument('--disable-gpu')
-      driver.add_argument('--disable-site-isolation-trials')
-      driver.add_argument('--disable-background-timer-throttling')
-      driver.add_argument('--disable-backgrounding-occluded-windows')
-      driver.add_argument('--disable-renderer-backgrounding')
-    end
+    driven_by :selenium, using: :headless_chrome
   else
     driven_by :selenium, using: :chrome
   end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,6 +1,35 @@
 require 'test_helper'
 require 'integration_helper'
 
+Capybara.register_driver :local_selenium_chrome_headless do |app|
+  version = Capybara::Selenium::Driver.load_selenium
+  options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+  browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    # These are defaults from capybara
+    # https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/drivers.rb#L31-L39
+
+    opts.add_argument('--headless=new')
+    opts.add_argument('--disable-gpu') if Gem.win_platform?
+    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+    opts.add_argument('--disable-site-isolation-trials')
+
+    # These are ones we are adding to try to workaround chrome race condition
+    # weirdness.
+    # https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2750363862
+    # Disable timers being throttled in background pages/tabs
+    opts.add_argument '--disable-background-timer-throttling'
+
+    # Normally, Chrome will treat a 'foreground' tab instead as backgrounded if the surrounding window is occluded (aka
+    # visually covered) by another window. This flag disables that.
+    opts.add_argument '--disable-backgrounding-occluded-windows'
+
+    # This disables non-foreground tabs from getting a lower process priority.
+    opts.add_argument '--disable-renderer-backgrounding'
+  end
+
+  Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
+end
+
 # Set systemtest behavior
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include IntegrationHelper
@@ -18,10 +47,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   # if in CI, run system tests headlessly.
-  browser = ENV['GITHUB_WORKFLOW'] ? :headless_chrome : :chrome
+  browser = ENV['GITHUB_WORKFLOW'] ? :local_selenium_chrome_headless : :chrome
 
   # if in docker, run headless firefox
-  browser = ENV['DOCKER'] ? :headless_firefox : browser
+  browser = ENV['DOCKER'] ? :local_selenium_chrome_headless : browser
 
   driven_by :selenium, using: browser
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,11 +2,15 @@ require 'test_helper'
 require 'integration_helper'
 require 'capybara/rails'
 require 'capybara/selenium/driver'
+require 'webdrivers'
 
 # Set systemtest behavior
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include IntegrationHelper
   include OmniauthMocker
+
+  # Configure webdrivers to use the latest compatible version
+  Webdrivers::Chromedriver.update
 
   # Explicitly register a selenium chrome headless driver
   Capybara.register_driver :headless_chrome do |app|


### PR DESCRIPTION
It's not registering the new driver:
```
ArgumentError: unknown driver: :local_selenium_chrome_headless
```