### PR TITLE
Fix validators and unit test failures

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -278,8 +278,9 @@ class Config < ApplicationRecord
       cleaners.each { |cleaner| method(cleaner).call }
     end
 
-    # parent function. will handle errors; child validators should return true
-    # if value is valid for key, and false otherwise.
+    # parent function. will handle errors;
+    # child validators should return nil
+    # if value is valid for key, and a string otherwise.
     def validate_config
       # don't try to validate if no key or no value
       return if config_key.nil? || options.last.nil?
@@ -310,9 +311,7 @@ class Config < ApplicationRecord
 
     # generic validator for numerics
     def validate_number
-      if options.last !=~ /\A\d+\z/
-        'Must be number'
-      end
+      'Must be number' if !Integer(options.last, exception: false)
     end
 
     # validator for singletons (no lists allowed)
@@ -333,11 +332,8 @@ class Config < ApplicationRecord
       url = UriService.new(maybe_url).uri
 
       # uriservice returns nil if there's a problem.
-      return false unless url
-
-
+      return 'Invalid url' unless url
       config_value['options'] = [url]
-      return true
     end
 
     ### Start of Week
@@ -393,7 +389,7 @@ class Config < ApplicationRecord
     ARCHIVE_MAX_DAYS = 550  # 1.5 years
 
     def validate_patient_archive
-      if !validate_number || !options.last.to_i.between?(ARCHIVE_MIN_DAYS, ARCHIVE_MAX_DAYS)
+      if validate_number || !options.last.to_i.between?(ARCHIVE_MIN_DAYS, ARCHIVE_MAX_DAYS)
         "Must be between #{ARCHIVE_MIN_DAYS} and #{ARCHIVE_MAX_DAYS} days."
       end
     end
@@ -403,7 +399,7 @@ class Config < ApplicationRecord
     SHARED_MAX_DAYS = 7 * 6  # 6 weeks
 
     def validate_shared_reset_days
-      if !validate_number || !options.last.to_i.between?(SHARED_MIN_DAYS, SHARED_MAX_DAYS)
+      if validate_number || !options.last.to_i.between?(SHARED_MIN_DAYS, SHARED_MAX_DAYS)
         "Must be between #{SHARED_MIN_DAYS} and #{SHARED_MAX_DAYS} days."
       end
     end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -326,14 +326,15 @@ class Config < ApplicationRecord
     def validate_url
       maybe_url = options.last
       return if maybe_url.blank?
-
-      return false unless maybe_url.length <= 300
-
-      url = UriService.new(maybe_url).uri
+      return 'URL too long' if maybe_url.length >= 300
 
       # uriservice returns nil if there's a problem.
-      return 'Invalid url' unless url
+      url = UriService.new(maybe_url).uri.to_s
+      return 'Invalid URL' if url.blank?
+
+      # Use clean url
       config_value['options'] = [url]
+      return
     end
 
     ### Start of Week

--- a/test/controllers/clinicfinders_controller_test.rb
+++ b/test/controllers/clinicfinders_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ostruct'
 
 # For tooling related to using the clinicfinder gem
 class ClinicfindersControllerTest < ActionDispatch::IntegrationTest

--- a/test/helpers/clinicfinders_helper_test.rb
+++ b/test/helpers/clinicfinders_helper_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ostruct'
 
 # Test the field parser
 class ClinicfindersHelperTest < ActionView::TestCase

--- a/test/models/clinic_test.rb
+++ b/test/models/clinic_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ostruct'
 
 class ClinicTest < ActiveSupport::TestCase
   before { @clinic = create :clinic }

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -191,7 +191,7 @@ class ConfigTest < ActiveSupport::TestCase
 
       it 'should return another amount if configured' do
         c = Config.find_or_create_by(config_key: 'budget_bar_max')
-        c.config_value = { options: [2000] }
+        c.config_value = { options: ["2000"] }
         c.save!
         assert_equal 2_000, Config.budget_bar_max
       end

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -191,7 +191,7 @@ class ConfigTest < ActiveSupport::TestCase
 
       it 'should return another amount if configured' do
         c = Config.find_or_create_by(config_key: 'budget_bar_max')
-        c.config_value = { options: ["2000"] }
+        c.config_value = { options: [2000] }
         c.save!
         assert_equal 2_000, Config.budget_bar_max
       end
@@ -199,8 +199,8 @@ class ConfigTest < ActiveSupport::TestCase
 
     describe 'archive_patients' do
       it 'should return proper defaults' do
-        assert_equal Config::DEFAULTS['days_to_keep_fulfilled_patients'], Config.archive_fulfilled_patients
-        assert_equal Config::DEFAULTS['days_to_keep_all_patients'], Config.archive_all_patients
+        assert_equal Config::DEFAULTS[:days_to_keep_fulfilled_patients], Config.archive_fulfilled_patients
+        assert_equal Config::DEFAULTS[:days_to_keep_all_patients], Config.archive_all_patients
       end
 
       it 'should validate bounds' do
@@ -335,7 +335,7 @@ class ConfigTest < ActiveSupport::TestCase
 
     describe 'shared_reset_days' do
       it 'should return proper default' do
-        assert_equal Config::DEFAULTS['shared_reset_days'], Config.shared_reset_days
+        assert_equal Config::DEFAULTS[:shared_reset_days], Config.shared_reset_days
       end
 
       it 'should validate bounds' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ostruct'
 
 class UserTest < ActiveSupport::TestCase
   # Since this is a devise install, devise is handling


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We've had a number of unit tests failing in addition to the system tests, and a recent PR split out the unit tests and system tests to more easily identify what was failing. This brings things back to green by the following methods enumerated below. I'm slightly wary of changes to archive patient and so I intend to test on staging but should be fine.

This pull request makes the following changes:
* Fixes some bs test failures caused by openstruct not being available
* fixes `validate_number` such that it follows the new 'return error string on invalid` approach
* fixes `validate_url` such that it follows the new `return error string on invalid` approach
* fixes a few sub-validators to accommodate changes to `validate_number` and `validate_url`

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
