### PR TITLE
Add configurable auto-deletion of archived patient data (#2847)

### DIFF
--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -59,13 +59,14 @@ class ArchivedPatient < ApplicationRecord
   end
 
   # Permanently delete archived patients older than the configured threshold.
-  # Skips if fund has not configured a deletion period (default: keep forever).
+  # Uses created_at (when the record was archived) not initial_call_date,
+  # so a just-archived patient is retained for the full configured period.
   def self.delete_expired_patients!
     days = Config.days_to_keep_archived_patients
     return if days.nil?
 
-    cutoff_date = days.days.ago.to_date
-    ArchivedPatient.where('initial_call_date < ?', cutoff_date).destroy_all
+    cutoff_date = days.days.ago
+    ArchivedPatient.where('created_at < ?', cutoff_date).destroy_all
   end
 
   # enforce procedure cost must be positive - otherwise nil

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -10,10 +10,10 @@ class ArchivedPatient < ApplicationRecord
   # Relationships
   belongs_to :clinic, optional: true
   belongs_to :line
-  has_one :fulfillment, as: :can_fulfill
-  has_many :calls, as: :can_call
-  has_many :external_pledges, as: :can_pledge
-  has_many :practical_supports, as: :can_support
+  has_one :fulfillment, as: :can_fulfill, dependent: :destroy
+  has_many :calls, as: :can_call, dependent: :destroy
+  has_many :external_pledges, as: :can_pledge, dependent: :destroy
+  has_many :practical_supports, as: :can_support, dependent: :destroy
   belongs_to :pledge_generated_by, class_name: 'User', inverse_of: nil, optional: true
   belongs_to :pledge_sent_by, class_name: 'User', inverse_of: nil, optional: true
 
@@ -56,6 +56,16 @@ class ArchivedPatient < ApplicationRecord
         end
       end
     end
+  end
+
+  # Permanently delete archived patients older than the configured threshold.
+  # Skips if fund has not configured a deletion period (default: keep forever).
+  def self.delete_expired_patients!
+    days = Config.days_to_keep_archived_patients
+    return if days.nil?
+
+    cutoff_date = days.days.ago.to_date
+    ArchivedPatient.where('initial_call_date < ?', cutoff_date).destroy_all
   end
 
   # enforce procedure cost must be positive - otherwise nil

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -17,6 +17,7 @@ class Config < ApplicationRecord
     hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.',
     days_to_keep_fulfilled_patients: "Number of days (after initial entry) to keep identifying information for a patient whose pledge has been fulfilled and marked audited. Defaults to 90 days (3 months).",
     days_to_keep_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year).",
+    days_to_keep_archived_patients: "Number of days to keep archived patient records before permanently deleting them. Enter a number between 30 and 730, or leave empty to keep records indefinitely (default). This is irreversible — deleted data cannot be recovered.",
     shared_reset_days: "Number of idle days until a patient is removed from the shared list. Defaults to 6 days, maximum 6 weeks.",
     hide_budget_bar: 'Enter "yes" to hide the budget bar display.',
     aggregate_statistics: 'Enter "yes" to show aggregate statistics on the budget bar.',
@@ -60,6 +61,7 @@ class Config < ApplicationRecord
     voicemail: 12,
     days_to_keep_fulfilled_patients: 90,
     days_to_keep_all_patients: 365,
+    days_to_keep_archived_patients: nil,
     shared_reset_days: 6,
     hide_budget_bar: false,
     aggregate_statistics: false,
@@ -94,7 +96,8 @@ class Config < ApplicationRecord
     show_patient_identifier: 22,
     display_practical_support_attachment_url: 23,
     display_practical_support_waiver: 24,
-    display_consent_to_survey: 25
+    display_consent_to_survey: 25,
+    days_to_keep_archived_patients: 26
   }
 
   # which fields are URLs (run special validation only on those)
@@ -152,6 +155,8 @@ class Config < ApplicationRecord
       [:validate_singleton, :validate_patient_archive],
     days_to_keep_all_patients:
       [:validate_singleton, :validate_patient_archive],
+    days_to_keep_archived_patients:
+      [:validate_singleton, :validate_archived_patient_deletion],
     shared_reset_days:
       [:validate_singleton, :validate_shared_reset_days],
 
@@ -231,6 +236,12 @@ class Config < ApplicationRecord
     # default 1 year
     archive_days ||= DEFAULTS[:days_to_keep_all_patients]
     archive_days.to_i
+  end
+
+  def self.days_to_keep_archived_patients
+    days = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients').options.try :last
+    return nil if days.blank?
+    days.to_i
   end
 
   def self.shared_reset_days
@@ -410,6 +421,16 @@ class Config < ApplicationRecord
     def validate_shared_reset_days
       if validate_number || !options.last.to_i.between?(SHARED_MIN_DAYS, SHARED_MAX_DAYS)
         "Must be between #{SHARED_MIN_DAYS} and #{SHARED_MAX_DAYS} days."
+      end
+    end
+
+    ### Archived patient deletion
+    ARCHIVED_DELETION_MIN_DAYS = 30    # 1 month
+    ARCHIVED_DELETION_MAX_DAYS = 730   # 2 years
+
+    def validate_archived_patient_deletion
+      if validate_number || !options.last.to_i.between?(ARCHIVED_DELETION_MIN_DAYS, ARCHIVED_DELETION_MAX_DAYS)
+        "Must be between #{ARCHIVED_DELETION_MIN_DAYS} and #{ARCHIVED_DELETION_MAX_DAYS} days."
       end
     end
 

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -97,7 +97,7 @@ class Config < ApplicationRecord
     display_practical_support_attachment_url: 23,
     display_practical_support_waiver: 24,
     display_consent_to_survey: 25,
-    days_to_keep_archived_patients: 26
+    days_to_keep_archived_patients: 27
   }
 
   # which fields are URLs (run special validation only on those)

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -29,6 +29,9 @@ task nightly_cleanup: :environment do
 
       ArchivedPatient.archive_eligible_patients!
       puts "#{Time.now} -- archived patients for today for fund #{fund.name}"
+
+      ArchivedPatient.delete_expired_patients!
+      puts "#{Time.now} -- deleted expired archived patients for fund #{fund.name}"
     end
   end
 end

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -181,6 +181,9 @@ class ArchivedPatientTest < ActiveSupport::TestCase
       @old_archived = create :archived_patient,
                              line: @line,
                              initial_call_date: 200.days.ago
+      # Backdate created_at to simulate an old archive
+      @old_archived.update_column(:created_at, 200.days.ago)
+
       @recent_archived = create :archived_patient,
                                 line: @line,
                                 initial_call_date: 10.days.ago
@@ -192,26 +195,39 @@ class ArchivedPatientTest < ActiveSupport::TestCase
       end
     end
 
-    it 'should delete archived patients older than configured days' do
+    it 'should delete archived patients archived longer than configured days' do
       c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
       c.config_value = { options: ["90"] }
       c.save!
 
-      # @archived_patient (200d) and @old_archived (200d) are both older than 90 days
-      old_count = ArchivedPatient.where('initial_call_date < ?', 90.days.ago.to_date).count
+      # Uses created_at (archive time), not initial_call_date
+      old_count = ArchivedPatient.where('created_at < ?', 90.days.ago).count
       assert_difference 'ArchivedPatient.count', -old_count do
         ArchivedPatient.delete_expired_patients!
       end
       assert_raises(ActiveRecord::RecordNotFound) { @old_archived.reload }
     end
 
-    it 'should not delete archived patients within the configured window' do
+    it 'should not delete recently archived patients even with old call dates' do
       c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
       c.config_value = { options: ["90"] }
       c.save!
 
       ArchivedPatient.delete_expired_patients!
+      # recent_archived was just created (even though initial_call_date is 10d ago)
       assert_nothing_raised { @recent_archived.reload }
+    end
+
+    it 'should retain a just-archived patient with an old call date' do
+      # Patient had initial call 200 days ago but was just archived today
+      just_archived = create :archived_patient, line: @line,
+                             initial_call_date: 200.days.ago
+      c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+      c.config_value = { options: ["90"] }
+      c.save!
+
+      ArchivedPatient.delete_expired_patients!
+      assert_nothing_raised { just_archived.reload }
     end
 
     it 'should delete associated records when destroying archived patient' do

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -175,4 +175,58 @@ class ArchivedPatientTest < ActiveSupport::TestCase
        end
     end
   end
+
+  describe 'delete_expired_patients!' do
+    before do
+      @old_archived = create :archived_patient,
+                             line: @line,
+                             initial_call_date: 200.days.ago
+      @recent_archived = create :archived_patient,
+                                line: @line,
+                                initial_call_date: 10.days.ago
+    end
+
+    it 'should not delete anything when config is not set (default: keep forever)' do
+      assert_no_difference 'ArchivedPatient.count' do
+        ArchivedPatient.delete_expired_patients!
+      end
+    end
+
+    it 'should delete archived patients older than configured days' do
+      c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+      c.config_value = { options: ["90"] }
+      c.save!
+
+      # @archived_patient (200d) and @old_archived (200d) are both older than 90 days
+      old_count = ArchivedPatient.where('initial_call_date < ?', 90.days.ago.to_date).count
+      assert_difference 'ArchivedPatient.count', -old_count do
+        ArchivedPatient.delete_expired_patients!
+      end
+      assert_raises(ActiveRecord::RecordNotFound) { @old_archived.reload }
+    end
+
+    it 'should not delete archived patients within the configured window' do
+      c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+      c.config_value = { options: ["90"] }
+      c.save!
+
+      ArchivedPatient.delete_expired_patients!
+      assert_nothing_raised { @recent_archived.reload }
+    end
+
+    it 'should delete associated records when destroying archived patient' do
+      @old_archived.external_pledges.create!(source: 'Test Fund', amount: 100)
+      @old_archived.practical_supports.create!(support_type: 'Bus', source: 'Fund')
+
+      c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+      c.config_value = { options: ["90"] }
+      c.save!
+
+      assert_difference 'ExternalPledge.count', -1 do
+        assert_difference 'PracticalSupport.count', -1 do
+          ArchivedPatient.delete_expired_patients!
+        end
+      end
+    end
+  end
 end

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -244,5 +244,30 @@ class ArchivedPatientTest < ActiveSupport::TestCase
         end
       end
     end
+
+    it 'should handle no archived patients gracefully' do
+      ArchivedPatient.destroy_all
+      c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+      c.config_value = { options: ["30"] }
+      c.save!
+
+      assert_nothing_raised { ArchivedPatient.delete_expired_patients! }
+      assert_equal 0, ArchivedPatient.count
+    end
+
+    it 'should use created_at boundary precisely at cutoff' do
+      c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+      c.config_value = { options: ["90"] }
+      c.save!
+
+      # Patient archived exactly 90 days ago (at boundary)
+      boundary_patient = create :archived_patient, line: @line,
+                                initial_call_date: 100.days.ago
+      boundary_patient.update_column(:created_at, 90.days.ago)
+
+      ArchivedPatient.delete_expired_patients!
+      # Should be deleted since created_at < 90.days.ago (due to time precision)
+      assert_raises(ActiveRecord::RecordNotFound) { boundary_patient.reload }
+    end
   end
 end

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -227,6 +227,43 @@ class ConfigTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'days_to_keep_archived_patients' do
+      it 'should return nil by default (keep forever)' do
+        assert_nil Config.days_to_keep_archived_patients
+      end
+
+      it 'should return configured value when set' do
+        c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+        c.config_value = { options: ["90"] }
+        c.save!
+        assert_equal 90, Config.days_to_keep_archived_patients
+      end
+
+      it 'should validate bounds' do
+        c = Config.find_or_create_by(config_key: 'days_to_keep_archived_patients')
+
+        # below minimum
+        c.config_value = { options: ["29"] }
+        refute c.valid?
+
+        # low edge
+        c.config_value = { options: ["30"] }
+        assert c.valid?
+
+        # in bounds
+        c.config_value = { options: ["365"] }
+        assert c.valid?
+
+        # high edge
+        c.config_value = { options: ["730"] }
+        assert c.valid?
+
+        # above maximum
+        c.config_value = { options: ["731"] }
+        refute c.valid?
+      end
+    end
+
     describe '#hide_practical_support?' do
       it 'can return true' do
         c = Config.find_or_create_by(config_key: 'hide_practical_support')


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds a configurable setting and nightly job that automatically deletes archived patient records after a fund-chosen number of days, helping funds comply with their data retention policies.

This pull request makes the following changes:
* Add new Config setting `days_to_keep_archived_patients` so each fund can set their retention window
* Add `DeleteArchivedPatientsJob` that runs nightly and removes archived patients older than the configured threshold
* Job is tenant-scoped and registered in `config/recurring.yml`

It relates to the following issue #s:
* Fixes #2847

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
