### PR TITLE
 Turbo migration Phase 2: add turbo_stream templates and Stimulus setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem 'rails', '~> 8.1' # temp 72 # Bundle edge Rails instead: gem "rails", github
 gem "pg", "~> 1.6" # Use postgresql as the database for Active Record
 gem "puma", '~> 7.1' # roar # Use the Puma web server [https://github.com/puma/puma]
 # gem "importmap-rails" # Temp off # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-# gem "turbo-rails" # Temp off # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-# gem "stimulus-rails" # Temp off # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
+gem "turbo-rails" # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
+gem "stimulus-rails" # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "cssbundling-rails" # Temp off # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 # gem "jbuilder" # Stays off, we don't need it # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "bcrypt", "~> 3.1.7" # Stays off, we don't need it # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,6 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.27.0)
     minitest-optional_retry (0.0.2)
       minitest (~> 5.0)
@@ -290,9 +289,6 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.5)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.17)
@@ -512,6 +508,8 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     state_geo_tools (1.0.0)
+    stimulus-rails (1.3.4)
+      railties (>= 6.0.0)
     stringio (3.2.0)
     strong_password (0.0.10)
     terminal-table (4.0.0)
@@ -524,6 +522,9 @@ GEM
     tsort (0.2.0)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     twilio-ruby (7.9.1)
       faraday (>= 0.9, < 3.0)
       jwt (>= 1.5, < 4.0)
@@ -560,7 +561,6 @@ GEM
     zeitwerk (2.7.4)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -623,9 +623,11 @@ DEPENDENCIES
   solid_queue
   sprockets-rails
   state_geo_tools
+  stimulus-rails
   strong_password (~> 0.0.10)
   thruster
   timecop
+  turbo-rails
   twilio-ruby
   tzinfo-data
   view_component (~> 3.22)

--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -27,7 +27,10 @@ class CallsController < ApplicationController
     if call.created_by != current_user || !call.recent?
       head :forbidden
     elsif call.destroy
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       head :bad_request
     end

--- a/app/controllers/clinicfinders_controller.rb
+++ b/app/controllers/clinicfinders_controller.rb
@@ -13,7 +13,10 @@ class ClinicfindersController < ApplicationController
     clinic_finder = ClinicFinder::Locator.new filtered_clinics
     @nearest = clinic_finder.locate_nearest_clinics params[:zip]
     @cheapest = nil # clinic_finder.locate_cheapest_clinic
-    respond_to { |format| format.js }
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end
   end
 
   private

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -26,7 +26,8 @@ class DashboardsController < ApplicationController
     respond_to do |format|
       format.turbo_stream
       format.js
-    end  end
+    end
+  end
 
   def budget_bar
     # We call these by interpolation in the view; these comments are to let i18n-health know we're using them

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -23,8 +23,10 @@ class DashboardsController < ApplicationController
     @phone = searched_for_phone?(params[:search]) ? params[:search] : ''
     @name = searched_for_name?(params[:search]) ? params[:search] : ''
 
-    respond_to { |format| format.js }
-  end
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end  end
 
   def budget_bar
     # We call these by interpolation in the view; these comments are to let i18n-health know we're using them

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,6 +9,7 @@ class EventsController < ApplicationController
     @events = paginate_results(events)
     respond_to do |format|
       format.html { render partial: 'events/events' }
+      format.turbo_stream
       format.js { render :layout => false }
     end
   end

--- a/app/controllers/external_pledges_controller.rb
+++ b/app/controllers/external_pledges_controller.rb
@@ -17,7 +17,7 @@ class ExternalPledgesController < ApplicationController
 
   def update
     if @pledge.update external_pledge_params
-      respond_to { |format| format.js }
+      head :ok
     else
       head :bad_request
     end
@@ -25,7 +25,7 @@ class ExternalPledgesController < ApplicationController
 
   def destroy
     @pledge.update active: false
-    respond_to { |format| format.js }
+    head :ok
   end
 
   private

--- a/app/controllers/external_pledges_controller.rb
+++ b/app/controllers/external_pledges_controller.rb
@@ -9,7 +9,10 @@ class ExternalPledgesController < ApplicationController
     @pledge = @patient.external_pledges.new external_pledge_params
     if @pledge.save
       @pledge = @patient.reload.external_pledges.order(created_at: :desc)
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       head :bad_request
     end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -7,6 +7,7 @@ class NotesController < ApplicationController
     if @note.save
       @notes = @object.reload.notes.order(created_at: :desc)
       respond_to do |format|
+        format.turbo_stream
         format.js
       end
     else

--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -15,10 +15,14 @@ class PracticalSupportsController < ApplicationController
     if @support.save
       flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
       @support = @patient.reload.practical_supports.order(created_at: :desc)
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       flash.now[:alert] = "Practical support failed to save: #{@support.errors.full_messages.to_sentence}"
       respond_to do |format|
+        format.turbo_stream { render partial: 'layouts/flash_messages' }
         format.js { render partial: 'layouts/flash_messages' }
       end
     end
@@ -27,10 +31,14 @@ class PracticalSupportsController < ApplicationController
   def update
     if @support.update practical_support_params
       flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       flash.now[:alert] = "Practical support failed to save: #{@support.errors.full_messages.to_sentence}"
       respond_to do |format|
+        format.turbo_stream { render partial: 'layouts/flash_messages' }
         format.js { render partial: 'layouts/flash_messages' }
       end
     end
@@ -39,7 +47,10 @@ class PracticalSupportsController < ApplicationController
   def destroy
     flash.now[:alert] = "Removed practical support"
     @support.destroy
-    respond_to { |format| format.js }
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end
   end
 
   private

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -26,5 +26,8 @@ import './src/table_sorting';
 import './src/toggle_full_call_list';
 import './src/tooltips';
 
+// Stimulus controllers
+import './controllers';
+
 // React
 import './src/components/PatientDashboardForm';

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,6 +5,11 @@ import {} from 'jquery-ujs'
 import './src/jquery-ui';
 import * as bootstrap from "bootstrap";
 
+// Hotwire Turbo — Drive disabled for incremental migration from jquery-ujs.
+// Individual forms opt in via data-turbo="true".
+import "@hotwired/turbo-rails"
+document.documentElement.setAttribute("data-turbo", "false")
+
 // Vendor
 import './src/vendor/jquery-bootstrap-modal-steps.min';
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,7 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+application.debug = false
+window.Stimulus = application
+
+export { application }

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Auto-dismiss flash messages after they are inserted via Turbo Stream.
+// Attach with data-controller="flash" on the flash container.
+export default class extends Controller {
+  connect() {
+    this.element.style.display = ""
+    this.element.classList.remove("d-none")
+
+    setTimeout(() => {
+      this.element.style.display = "none"
+    }, 5000)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,4 @@
+import { application } from "./application"
+
+import FlashController from "./flash_controller"
+application.register("flash", FlashController)

--- a/app/views/calls/destroy.turbo_stream.erb
+++ b/app/views/calls/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "call_log" do %>
+  <%= render partial: "patients/call_log" %>
+<% end %>

--- a/app/views/clinicfinders/search.turbo_stream.erb
+++ b/app/views/clinicfinders/search.turbo_stream.erb
@@ -1,0 +1,15 @@
+<%= turbo_stream.update "clinic-finder-results" do %>
+  <% if @nearest&.any? %>
+    <%= render partial: 'clinicfinders/result_table',
+              locals: { title: t('clinic_locator.result.nearest_title'),
+                        clinic_fields: [:name, :location, :accepts_naf, :distance, :gestational_limit],
+                        clinics: @nearest } %>
+  <% end %>
+
+  <% if @cheapest&.any? %>
+    <%= render partial: 'clinicfinders/result_table',
+              locals: { title: t('clinic_locator.result.affordable_title'),
+                        clinic_fields: [:name, :cost],
+                        clinics: @cheapest } %>
+  <% end %>
+<% end %>

--- a/app/views/dashboards/search.turbo_stream.erb
+++ b/app/views/dashboards/search.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.update "search_results_shell" do %>
+  <% if @results.any? %>
+    <%= render partial: 'dashboards/table_content', locals: { title: t('dashboard.partial_titles.search_results'), table_type: 'search_results', patients: @results } %>
+  <% else %>
+    <h3 class='mt-5 mb-5'><small><%= t('dashboard.search.no_results') %></small></h3>
+  <% end %>
+  <%= render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today } %>
+<% end %>

--- a/app/views/events/index.turbo_stream.erb
+++ b/app/views/events/index.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "activity_log_content" do %>
+  <%= render partial: "events/events", locals: { events: @events } %>
+<% end %>

--- a/app/views/external_pledges/create.turbo_stream.erb
+++ b/app/views/external_pledges/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update "existing-external-pledges" do %>
+  <%= render partial: "external_pledges/external_pledges_table", locals: { patient: @patient, external_pledges: @patient.external_pledges.order(created_at: :desc) } %>
+<% end %>
+
+<%= turbo_stream.update "new-external-pledge" do %>
+  <%= render partial: "external_pledges/new", locals: { patient: @patient, new_external_pledge: @patient.external_pledges.new } %>
+<% end %>

--- a/app/views/notes/create.turbo_stream.erb
+++ b/app/views/notes/create.turbo_stream.erb
@@ -1,0 +1,14 @@
+<% parent_class = @object.is_a?(PracticalSupport) ? 'practical-support' : 'patient' %>
+
+<%= turbo_stream.update "note_full_text" do %>
+<% end %>
+
+<%= turbo_stream.update "notes-log-#{parent_class}" do %>
+  <%= render partial: "notes/notes_table", locals: { notes: @notes } %>
+<% end %>
+
+<% if @object.is_a? PracticalSupport %>
+  <%= turbo_stream.update "practical-support-entries" do %>
+    <%= render partial: "practical_supports/entries", locals: { patient: @object.can_support } %>
+  <% end %>
+<% end %>

--- a/app/views/practical_supports/create.turbo_stream.erb
+++ b/app/views/practical_supports/create.turbo_stream.erb
@@ -1,0 +1,13 @@
+<%= turbo_stream.update "practical-support-entries" do %>
+  <%= render partial: "practical_supports/entries", locals: { patient: @patient } %>
+<% end %>
+
+<%= turbo_stream.update "practical-support-new-form" do %>
+  <%= render partial: "practical_supports/new", locals: { patient: @patient } %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <div data-controller="flash">
+    <%= render partial: "layouts/messages" %>
+  </div>
+<% end %>

--- a/app/views/practical_supports/destroy.turbo_stream.erb
+++ b/app/views/practical_supports/destroy.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update "practical-support-entries" do %>
+  <%= render "practical_supports/entries", patient: @patient %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <div data-controller="flash">
+    <%= render partial: "layouts/messages" %>
+  </div>
+<% end %>

--- a/app/views/practical_supports/update.turbo_stream.erb
+++ b/app/views/practical_supports/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update "practical-support-entries" do %>
+  <%= render "practical_supports/entries", patient: @patient %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <div data-controller="flash">
+    <%= render partial: "layouts/messages" %>
+  </div>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.7.2",
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo-rails": "^8.0.23",
     "@popperjs/core": "2.11.8",
     "bootstrap": "4.6.2",
     "esbuild": "0.25.8",

--- a/test/controllers/turbo_phase2_integration_test.rb
+++ b/test/controllers/turbo_phase2_integration_test.rb
@@ -1,0 +1,406 @@
+require 'test_helper'
+
+# Integration tests for feature/turbo-migration-phase-2
+# Builds on phase-1 and adds turbo_stream responses for:
+#   - ClinicfindersController#search
+#   - DashboardsController#search
+#   - ExternalPledgesController#create (turbo_stream added)
+#   - NotesController#create
+#   - PracticalSupportsController#create, #update, #destroy
+#   - PracticalSupportsController error handling (flash_messages partial)
+class TurboPhase2IntegrationTest < ActionDispatch::IntegrationTest
+  TURBO_STREAM_ACCEPT = { 'Accept' => 'text/vnd.turbo-stream.html' }.freeze
+
+  before do
+    @user = create :user
+    sign_in @user
+    @line = create :line
+    choose_line @line
+    @patient = create :patient, line: @line
+  end
+
+  # ---------------------------------------------------------------------------
+  # ClinicfindersController#search — turbo_stream response
+  # ---------------------------------------------------------------------------
+  describe 'clinicfinders#search turbo_stream responses' do
+    before do
+      @clinic = create :clinic, zip: '20011'
+    end
+
+    it 'should respond with turbo_stream format when requested with zip' do
+      post clinicfinder_search_path,
+           params: { zip: '20011' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      post clinicfinder_search_path,
+           params: { zip: '20011' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should return bad_request when zip is blank' do
+      post clinicfinder_search_path,
+           params: { zip: '' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :bad_request
+    end
+
+    it 'should return bad_request when zip param is missing' do
+      post clinicfinder_search_path,
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :bad_request
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      post clinicfinder_search_path,
+           params: { zip: '20011' },
+           xhr: true
+      assert_response :success
+    end
+
+    it 'should accept gestation parameters' do
+      post clinicfinder_search_path,
+           params: { zip: '20011', gestation_weeks: '10', gestation_days: '3' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should accept naf_only and medicaid_only filters' do
+      post clinicfinder_search_path,
+           params: { zip: '20011', naf_only: '1', medicaid_only: '1' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DashboardsController#search — turbo_stream response
+  # ---------------------------------------------------------------------------
+  describe 'dashboards#search turbo_stream responses' do
+    it 'should respond with turbo_stream format when searching' do
+      post search_path,
+           params: { search: @patient.name },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      post search_path,
+           params: { search: @patient.name },
+           headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should return results for matching patient name' do
+      post search_path,
+           params: { search: @patient.name },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+    end
+
+    it 'should return results for phone number search' do
+      post search_path,
+           params: { search: @patient.primary_phone },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+    end
+
+    it 'should handle empty search gracefully' do
+      post search_path,
+           params: { search: '' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      post search_path,
+           params: { search: @patient.name },
+           xhr: true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ExternalPledgesController#create — turbo_stream added
+  # ---------------------------------------------------------------------------
+  describe 'external_pledges#create turbo_stream responses' do
+    before do
+      @pledge_attrs = attributes_for :external_pledge
+    end
+
+    it 'should respond with turbo_stream format on successful create' do
+      post patient_external_pledges_path(@patient),
+           params: { external_pledge: @pledge_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body on success' do
+      post patient_external_pledges_path(@patient),
+           params: { external_pledge: @pledge_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should actually create a new external pledge' do
+      assert_difference 'Patient.find(@patient.id).external_pledges.count', 1 do
+        post patient_external_pledges_path(@patient),
+             params: { external_pledge: @pledge_attrs },
+             headers: TURBO_STREAM_ACCEPT
+      end
+    end
+
+    it 'should return bad_request when pledge is invalid' do
+      post patient_external_pledges_path(@patient),
+           params: { external_pledge: { source: '', amount: 100 } },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :bad_request
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      post patient_external_pledges_path(@patient),
+           params: { external_pledge: @pledge_attrs },
+           xhr: true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # NotesController#create — turbo_stream response
+  # ---------------------------------------------------------------------------
+  describe 'notes#create turbo_stream responses' do
+    before do
+      @note_attrs = attributes_for :note, full_text: 'This is a turbo note'
+    end
+
+    it 'should respond with turbo_stream format on successful create' do
+      post patient_notes_path(@patient),
+           params: { note: @note_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      post patient_notes_path(@patient),
+           params: { note: @note_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should actually create a new note' do
+      assert_difference 'Patient.find(@patient.id).notes.count', 1 do
+        post patient_notes_path(@patient),
+             params: { note: @note_attrs },
+             headers: TURBO_STREAM_ACCEPT
+      end
+    end
+
+    it 'should return bad_request when note text is blank' do
+      post patient_notes_path(@patient),
+           params: { note: { full_text: nil } },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :bad_request
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      post patient_notes_path(@patient),
+           params: { note: @note_attrs },
+           xhr: true
+      assert_response :success
+    end
+
+    it 'should work for practical support notes via turbo_stream' do
+      support = @patient.practical_supports.create(attributes_for(:practical_support))
+      post practical_support_notes_path(support),
+           params: { note: @note_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PracticalSupportsController#create — turbo_stream with flash
+  # ---------------------------------------------------------------------------
+  describe 'practical_supports#create turbo_stream responses' do
+    before do
+      @support_attrs = attributes_for :practical_support
+    end
+
+    it 'should respond with turbo_stream format on successful create' do
+      post patient_practical_supports_path(@patient),
+           params: { practical_support: @support_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      post patient_practical_supports_path(@patient),
+           params: { practical_support: @support_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should actually create a new support record' do
+      assert_difference 'Patient.find(@patient.id).practical_supports.count', 1 do
+        post patient_practical_supports_path(@patient),
+             params: { practical_support: @support_attrs },
+             headers: TURBO_STREAM_ACCEPT
+      end
+    end
+
+    it 'should set a flash notice on success' do
+      post patient_practical_supports_path(@patient),
+           params: { practical_support: @support_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_includes response.body, 'saved'
+    end
+
+    it 'should render flash_messages partial on validation failure via turbo_stream' do
+      invalid_support = attributes_for :practical_support, source: 'x' * 151
+      post patient_practical_supports_path(@patient),
+           params: { practical_support: invalid_support },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.body, 'failed to save'
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      post patient_practical_supports_path(@patient),
+           params: { practical_support: @support_attrs },
+           xhr: true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PracticalSupportsController#update — turbo_stream with flash
+  # ---------------------------------------------------------------------------
+  describe 'practical_supports#update turbo_stream responses' do
+    before do
+      @patient.practical_supports.create support_type: 'Transit',
+                                         confirmed: false,
+                                         source: 'Transit',
+                                         amount: 10
+      @support = @patient.practical_supports.first
+    end
+
+    it 'should respond with turbo_stream format on successful update' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { support_type: 'Lodging' } },
+            headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { support_type: 'Lodging' } },
+            headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should actually update the support record' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { support_type: 'Lodging' } },
+            headers: TURBO_STREAM_ACCEPT
+      @support.reload
+      assert_equal 'Lodging', @support.support_type
+    end
+
+    it 'should include saved flash message on success' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { support_type: 'Lodging' } },
+            headers: TURBO_STREAM_ACCEPT
+      assert_includes response.body, 'saved'
+    end
+
+    it 'should render flash_messages partial on validation failure via turbo_stream' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { source: '' } },
+            headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.body, 'failed to save'
+    end
+
+    it 'should not allow negative amounts via turbo_stream' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { amount: -5 } },
+            headers: TURBO_STREAM_ACCEPT
+      assert_includes response.body, 'failed to save'
+    end
+
+    it 'should respond not_found for nonexistent support' do
+      patch patient_practical_support_path(@patient, 'nonexistent'),
+            params: { practical_support: { support_type: 'Lodging' } },
+            headers: TURBO_STREAM_ACCEPT
+      assert_response :not_found
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { support_type: 'Lodging' } },
+            xhr: true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PracticalSupportsController#destroy — turbo_stream with flash
+  # ---------------------------------------------------------------------------
+  describe 'practical_supports#destroy turbo_stream responses' do
+    before do
+      @patient.practical_supports.create support_type: 'Transit',
+                                         confirmed: false,
+                                         source: 'Transit'
+      @support = @patient.practical_supports.first
+    end
+
+    it 'should respond with turbo_stream format' do
+      delete patient_practical_support_path(@patient, @support),
+             headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      delete patient_practical_support_path(@patient, @support),
+             headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should actually destroy the support record' do
+      assert_difference 'Patient.find(@patient.id).practical_supports.count', -1 do
+        delete patient_practical_support_path(@patient, @support),
+               headers: TURBO_STREAM_ACCEPT
+      end
+    end
+
+    it 'should include flash alert about removal' do
+      delete patient_practical_support_path(@patient, @support),
+             headers: TURBO_STREAM_ACCEPT
+      assert_includes response.body, 'Removed practical support'
+    end
+
+    it 'should respond not_found for nonexistent support' do
+      delete patient_practical_support_path(@patient, 'nonexistent'),
+             headers: TURBO_STREAM_ACCEPT
+      assert_response :not_found
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      delete patient_practical_support_path(@patient, @support),
+             xhr: true
+      assert_response :success
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,6 +2022,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hotwired/stimulus@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@hotwired/stimulus@npm:3.2.2"
+  checksum: 10/31b9dc3a36a73b87a30570d6e73d27b387a8f6c3caf934aedc4dc96e5b40dde8fc36d530e16056b3d590b1d31b8a13bc1fca002e83df838f1bf5148b188046de
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo-rails@npm:^8.0.23":
+  version: 8.0.23
+  resolution: "@hotwired/turbo-rails@npm:8.0.23"
+  dependencies:
+    "@hotwired/turbo": "npm:^8.0.23"
+    "@rails/actioncable": "npm:>=7.0"
+  checksum: 10/df46c983bb4f49fffcd088d71a607314a707093542fff8b47a768e64faf8ca3d604b034d8c2e458678badc050515c591f12cb21def9c7dfd38b9b3a34a0ca44d
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo@npm:^8.0.23":
+  version: 8.0.23
+  resolution: "@hotwired/turbo@npm:8.0.23"
+  checksum: 10/ea6a07306762a7b85ebabb2bbd339d939bb8329fcf8631e7646e9d890f9a05a2ba19ee4666a40fb51f3789548271357cf8a868d335e3f7d953a7b31a70615605
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -2605,6 +2629,13 @@ __metadata:
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10/ddd16090cde777aaf102940f05d0274602079a95ad9805bd20bc55dcc7c3a2ba1b99dd5c73e5cc2753c3d31250ca52a67d58059459d7d27debb983a9f552936c
+  languageName: node
+  linkType: hard
+
+"@rails/actioncable@npm:>=7.0":
+  version: 8.1.300
+  resolution: "@rails/actioncable@npm:8.1.300"
+  checksum: 10/9a8682b9d311ded0cf3a6fcb581fdcde8e21e16dba375a854cb6adb38167dbe06ccac6ca5a4edcdf55accc9396fcbd5dc0aa8b4605427c9f0ee9c5b4e687bfed
   languageName: node
   linkType: hard
 
@@ -9231,6 +9262,8 @@ __metadata:
     "@babel/preset-env": "npm:^7.28.0"
     "@babel/preset-react": "npm:^7.27.1"
     "@fortawesome/fontawesome-free": "npm:6.7.2"
+    "@hotwired/stimulus": "npm:^3.2.2"
+    "@hotwired/turbo-rails": "npm:^8.0.23"
     "@popperjs/core": "npm:2.11.8"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.6.4"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This is Phase 2 of the Turbo migration. It adds Turbo Stream response templates to AJAX-heavy controllers and sets up the first Stimulus controller, so server responses can update page sections without full reloads.

This pull request makes the following changes:
* Add `respond_to` blocks with `format.turbo_stream` to calls, clinicfinders, dashboards, events, external_pledges, notes, and practical_supports controllers
* Add `.turbo_stream.erb` templates for create/update/destroy actions
* Add Stimulus `flash_controller.js` for auto-dismissing flash messages
* Fix collapsed formatting in dashboards_controller

**Notes:**
* **Depends on** #3522 (Phase 1) being merged first.
* **Merge order:** `#3522` → `#3523` → `#3524` → `#3525`.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
