### PR TITLE
Turbo migration Phase 3: convert complex .js.erb files to turbo_stream.erb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem 'rails', '~> 8.1' # temp 72 # Bundle edge Rails instead: gem "rails", github
 gem "pg", "~> 1.6" # Use postgresql as the database for Active Record
 gem "puma", '~> 7.1' # roar # Use the Puma web server [https://github.com/puma/puma]
 # gem "importmap-rails" # Temp off # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-# gem "turbo-rails" # Temp off # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-# gem "stimulus-rails" # Temp off # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
+gem "turbo-rails" # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
+gem "stimulus-rails" # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "cssbundling-rails" # Temp off # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 # gem "jbuilder" # Stays off, we don't need it # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "bcrypt", "~> 3.1.7" # Stays off, we don't need it # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,6 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.27.0)
     minitest-optional_retry (0.0.2)
       minitest (~> 5.0)
@@ -290,9 +289,6 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.5)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.17)
@@ -512,6 +508,8 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     state_geo_tools (1.0.0)
+    stimulus-rails (1.3.4)
+      railties (>= 6.0.0)
     stringio (3.2.0)
     strong_password (0.0.10)
     terminal-table (4.0.0)
@@ -524,6 +522,9 @@ GEM
     tsort (0.2.0)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     twilio-ruby (7.9.1)
       faraday (>= 0.9, < 3.0)
       jwt (>= 1.5, < 4.0)
@@ -560,7 +561,6 @@ GEM
     zeitwerk (2.7.4)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -623,9 +623,11 @@ DEPENDENCIES
   solid_queue
   sprockets-rails
   state_geo_tools
+  stimulus-rails
   strong_password (~> 0.0.10)
   thruster
   timecop
+  turbo-rails
   twilio-ruby
   tzinfo-data
   view_component (~> 3.22)

--- a/app/assets/stylesheets/styles/call_list.scss
+++ b/app/assets/stylesheets/styles/call_list.scss
@@ -22,7 +22,7 @@
 // For autosortable columns, make the cursor a pointer
 #call_list th[data-sort],
 #completed_calls th[data-sort],
-#shared_patients th[data-sort] {
+#shared_cases th[data-sort] {
   cursor: pointer;
 }
 

--- a/app/controllers/accountants_controller.rb
+++ b/app/controllers/accountants_controller.rb
@@ -20,7 +20,10 @@ class AccountantsController < ApplicationController
   def edit
     # This is a cheater method that populates the fulfillment partial into a
     # modal via ajax.
-    respond_to { |format| format.js }
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end
   end
 
   private

--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -27,7 +27,10 @@ class CallsController < ApplicationController
     if call.created_by != current_user || !call.recent?
       head :forbidden
     elsif call.destroy
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       head :bad_request
     end

--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -7,7 +7,10 @@ class CallsController < ApplicationController
     if call_saved_and_patient_reached @call, params
       redirect_to edit_patient_path @patient
     elsif @call.save
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       head :bad_request
     end
@@ -18,6 +21,7 @@ class CallsController < ApplicationController
   def new
     @patient = Patient.find params[:patient_id]
     respond_to do |format|
+      format.turbo_stream
       format.js
     end
   end

--- a/app/controllers/clinicfinders_controller.rb
+++ b/app/controllers/clinicfinders_controller.rb
@@ -13,7 +13,10 @@ class ClinicfindersController < ApplicationController
     clinic_finder = ClinicFinder::Locator.new filtered_clinics
     @nearest = clinic_finder.locate_nearest_clinics params[:zip]
     @cheapest = nil # clinic_finder.locate_cheapest_clinic
-    respond_to { |format| format.js }
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end
   end
 
   private

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -26,7 +26,8 @@ class DashboardsController < ApplicationController
     respond_to do |format|
       format.turbo_stream
       format.js
-    end  end
+    end
+  end
 
   def budget_bar
     # We call these by interpolation in the view; these comments are to let i18n-health know we're using them

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -23,8 +23,10 @@ class DashboardsController < ApplicationController
     @phone = searched_for_phone?(params[:search]) ? params[:search] : ''
     @name = searched_for_name?(params[:search]) ? params[:search] : ''
 
-    respond_to { |format| format.js }
-  end
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end  end
 
   def budget_bar
     # We call these by interpolation in the view; these comments are to let i18n-health know we're using them

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,6 +9,7 @@ class EventsController < ApplicationController
     @events = paginate_results(events)
     respond_to do |format|
       format.html { render partial: 'events/events' }
+      format.turbo_stream
       format.js { render :layout => false }
     end
   end

--- a/app/controllers/external_pledges_controller.rb
+++ b/app/controllers/external_pledges_controller.rb
@@ -17,7 +17,7 @@ class ExternalPledgesController < ApplicationController
 
   def update
     if @pledge.update external_pledge_params
-      respond_to { |format| format.js }
+      head :ok
     else
       head :bad_request
     end
@@ -25,7 +25,7 @@ class ExternalPledgesController < ApplicationController
 
   def destroy
     @pledge.update active: false
-    respond_to { |format| format.js }
+    head :ok
   end
 
   private

--- a/app/controllers/external_pledges_controller.rb
+++ b/app/controllers/external_pledges_controller.rb
@@ -9,7 +9,10 @@ class ExternalPledgesController < ApplicationController
     @pledge = @patient.external_pledges.new external_pledge_params
     if @pledge.save
       @pledge = @patient.reload.external_pledges.order(created_at: :desc)
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       head :bad_request
     end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -7,6 +7,7 @@ class NotesController < ApplicationController
     if @note.save
       @notes = @object.reload.notes.order(created_at: :desc)
       respond_to do |format|
+        format.turbo_stream
         format.js
       end
     else

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -33,6 +33,7 @@ class PatientsController < ApplicationController
   def pledge
     @patient = Patient.find params[:patient_id]
     respond_to do |format|
+      format.turbo_stream
       format.js
     end
   end
@@ -120,6 +121,9 @@ class PatientsController < ApplicationController
     @patient.last_edited_by = current_user
 
     respond_to do |format|
+      format.turbo_stream do
+        respond_to_update_for_js_format
+      end
       format.js do
         respond_to_update_for_js_format
       end
@@ -159,7 +163,7 @@ class PatientsController < ApplicationController
 
   private
 
-  # preload patient with versions for edit and js format update requests
+  # preload patient with versions for edit and js/turbo_stream format update requests
   def should_preload_patient_with_versions?
     action_name.to_sym == :edit || (action_name.to_sym == :update && !request.format.json?)
   end

--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -7,7 +7,10 @@ class PracticalSupportsController < ApplicationController
 
   def edit
     @note = @support.notes.new
-    respond_to { |format| format.js }
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end
   end
 
   def create

--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -15,10 +15,14 @@ class PracticalSupportsController < ApplicationController
     if @support.save
       flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
       @support = @patient.reload.practical_supports.order(created_at: :desc)
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       flash.now[:alert] = "Practical support failed to save: #{@support.errors.full_messages.to_sentence}"
       respond_to do |format|
+        format.turbo_stream { render partial: 'layouts/flash_messages' }
         format.js { render partial: 'layouts/flash_messages' }
       end
     end
@@ -27,10 +31,14 @@ class PracticalSupportsController < ApplicationController
   def update
     if @support.update practical_support_params
       flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
-      respond_to { |format| format.js }
+      respond_to do |format|
+        format.turbo_stream
+        format.js
+      end
     else
       flash.now[:alert] = "Practical support failed to save: #{@support.errors.full_messages.to_sentence}"
       respond_to do |format|
+        format.turbo_stream { render partial: 'layouts/flash_messages' }
         format.js { render partial: 'layouts/flash_messages' }
       end
     end
@@ -39,7 +47,10 @@ class PracticalSupportsController < ApplicationController
   def destroy
     flash.now[:alert] = "Removed practical support"
     @support.destroy
-    respond_to { |format| format.js }
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,10 @@ class UsersController < ApplicationController
                else
                  User.search params[:search]
                end
-    respond_to { |format| format.js }
+    respond_to do |format|
+      format.turbo_stream
+      format.js
+    end
   end
 
   def new

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -26,5 +26,8 @@ import './src/table_sorting';
 import './src/toggle_full_call_list';
 import './src/tooltips';
 
+// Stimulus controllers
+import './controllers';
+
 // React
 import './src/components/PatientDashboardForm';

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,6 +5,11 @@ import {} from 'jquery-ujs'
 import './src/jquery-ui';
 import * as bootstrap from "bootstrap";
 
+// Hotwire Turbo — Drive disabled for incremental migration from jquery-ujs.
+// Individual forms opt in via data-turbo="true".
+import "@hotwired/turbo-rails"
+document.documentElement.setAttribute("data-turbo", "false")
+
 // Vendor
 import './src/vendor/jquery-bootstrap-modal-steps.min';
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,7 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+application.debug = false
+window.Stimulus = application
+
+export { application }

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Auto-dismiss flash messages after they are inserted via Turbo Stream.
+// Attach with data-controller="flash" on the flash container.
+export default class extends Controller {
+  connect() {
+    this.element.style.display = ""
+    this.element.classList.remove("d-none")
+
+    setTimeout(() => {
+      this.element.style.display = "none"
+    }, 5000)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,4 @@
+import { application } from "./application"
+
+import FlashController from "./flash_controller"
+application.register("flash", FlashController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,3 +2,9 @@ import { application } from "./application"
 
 import FlashController from "./flash_controller"
 application.register("flash", FlashController)
+
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
+import TableSortController from "./table_sort_controller"
+application.register("table-sort", TableSortController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,12 +1,29 @@
 import { Controller } from "@hotwired/stimulus"
-import * as bootstrap from "bootstrap"
 
-// Opens a Bootstrap 4 modal when the controller connects to the DOM.
-// Use with Turbo Streams to replace modal content, then auto-open.
-// Attach with data-controller="modal" on the .modal element.
+// Opens a Bootstrap 4 modal via jQuery when Turbo Stream injects content.
+// Attach data-controller="modal" on the .modal element.
+// Observes child mutations to auto-show when turbo_stream updates modal content.
 export default class extends Controller {
   connect() {
-    $(this.element).modal('show')
+    // If modal body already has content (e.g., injected by turbo_stream), show immediately
+    const content = this.element.querySelector('.modal-content')
+    if (content && content.children.length > 0 && content.textContent.trim() !== '') {
+      $(this.element).modal('show')
+    }
+
+    // Observe future content changes (turbo_stream updates)
+    this.observer = new MutationObserver(() => {
+      if (content && content.children.length > 0) {
+        $(this.element).modal('show')
+      }
+    })
+    if (content) {
+      this.observer.observe(content, { childList: true })
+    }
+  }
+
+  disconnect() {
+    this.observer?.disconnect()
   }
 
   close() {

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+import * as bootstrap from "bootstrap"
+
+// Opens a Bootstrap 4 modal when the controller connects to the DOM.
+// Use with Turbo Streams to replace modal content, then auto-open.
+// Attach with data-controller="modal" on the .modal element.
+export default class extends Controller {
+  connect() {
+    $(this.element).modal('show')
+  }
+
+  close() {
+    $(this.element).modal('hide')
+    $('body').removeClass('modal-open')
+    $('.modal-backdrop').remove()
+  }
+}

--- a/app/javascript/controllers/table_sort_controller.js
+++ b/app/javascript/controllers/table_sort_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Re-initializes stupidtable sorting when a table is inserted via Turbo Stream.
+// Attach with data-controller="table-sort" on the <table> element.
+export default class extends Controller {
+  connect() {
+    var stupidtable = $(this.element).stupidtable()
+
+    stupidtable.on('beforetablesort', function(event, data) {
+      return stupidtable.find('th').filter(function(i) {
+        return i !== data.column
+      }).find('.arrow').html('[-]')
+    })
+
+    stupidtable.on('aftertablesort', function(event, data) {
+      var arrow = data.direction === $.fn.stupidtable.dir.ASC ? '[&uarr;]' : '[&darr;]'
+      return stupidtable.find('th').eq(data.column).find('.arrow').html(arrow)
+    })
+  }
+}

--- a/app/javascript/src/__tests__/autosave.test.js
+++ b/app/javascript/src/__tests__/autosave.test.js
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/autosave');
+};
+
+describe('autosave', () => {
+  it('submits edit_patient form on change', async () => {
+    document.body.innerHTML = `
+      <form class="edit_patient" id="edit_patient_1">
+        <input id="field1" value="old">
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.querySelector('.edit_patient');
+    form.requestSubmit = jest.fn();
+
+    const input = document.getElementById('field1');
+    input.value = 'new';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(form.requestSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits edit_practical_support form on change', async () => {
+    document.body.innerHTML = `
+      <form class="edit_practical_support" id="support_1">
+        <input id="support_field" value="old">
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.querySelector('.edit_practical_support');
+    form.requestSubmit = jest.fn();
+
+    document.getElementById('support_field').dispatchEvent(new Event('change', { bubbles: true }));
+    expect(form.requestSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits edit_external_pledge form on change', async () => {
+    document.body.innerHTML = `
+      <form class="edit_external_pledge" id="pledge_1">
+        <input id="pledge_field" value="100">
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.querySelector('.edit_external_pledge');
+    form.requestSubmit = jest.fn();
+
+    document.getElementById('pledge_field').dispatchEvent(new Event('change', { bubbles: true }));
+    expect(form.requestSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT submit when form id contains pledge_fulfillment', async () => {
+    document.body.innerHTML = `
+      <form class="edit_patient" id="pledge_fulfillment_edit_patient">
+        <input id="field1" value="old">
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.querySelector('.edit_patient');
+    form.requestSubmit = jest.fn();
+
+    document.getElementById('field1').dispatchEvent(new Event('change', { bubbles: true }));
+    expect(form.requestSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not submit unrelated forms', async () => {
+    document.body.innerHTML = `
+      <form class="new_patient" id="new_patient_form">
+        <input id="field1" value="val">
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.querySelector('.new_patient');
+    form.requestSubmit = jest.fn();
+
+    document.getElementById('field1').dispatchEvent(new Event('change', { bubbles: true }));
+    expect(form.requestSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('autosave – fulfillment form', () => {
+  const buildFulfillmentForm = (fieldValues = {}) => {
+    document.body.innerHTML = `
+      <form id="pledge_fulfillment_form">
+        <input type="checkbox" id="patient_fulfillment_attributes_fulfilled">
+        <input id="patient_fulfillment_attributes_fund_payout" value="${fieldValues.fundPayout || ''}">
+        <input id="patient_fulfillment_attributes_check_number" value="${fieldValues.checkNumber || ''}">
+        <input id="patient_fulfillment_attributes_gestation_at_procedure" value="${fieldValues.gestation || ''}">
+        <input id="patient_fulfillment_attributes_date_of_check" value="${fieldValues.dateOfCheck || ''}">
+        <input id="patient_fulfillment_attributes_procedure_date" value="${fieldValues.procedureDate || ''}">
+      </form>
+    `;
+  };
+
+  it('submits fulfillment form on change', async () => {
+    buildFulfillmentForm();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('pledge_fulfillment_form');
+    form.requestSubmit = jest.fn();
+
+    const input = document.getElementById('patient_fulfillment_attributes_fund_payout');
+    input.value = '500';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(form.requestSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks fulfilled checkbox when any fulfillment field has value', async () => {
+    buildFulfillmentForm({ fundPayout: '500' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('pledge_fulfillment_form');
+    form.requestSubmit = jest.fn();
+
+    const input = document.getElementById('patient_fulfillment_attributes_fund_payout');
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.getElementById('patient_fulfillment_attributes_fulfilled').checked).toBe(true);
+  });
+
+  it('unchecks fulfilled checkbox when all fulfillment fields are empty', async () => {
+    buildFulfillmentForm();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const checkbox = document.getElementById('patient_fulfillment_attributes_fulfilled');
+    checkbox.checked = true; // pre-check
+
+    const form = document.getElementById('pledge_fulfillment_form');
+    form.requestSubmit = jest.fn();
+
+    const input = document.getElementById('patient_fulfillment_attributes_fund_payout');
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('checks fulfilled when multiple fields have values', async () => {
+    buildFulfillmentForm({ fundPayout: '500', checkNumber: '12345' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('pledge_fulfillment_form');
+    form.requestSubmit = jest.fn();
+
+    document.getElementById('patient_fulfillment_attributes_check_number')
+      .dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.getElementById('patient_fulfillment_attributes_fulfilled').checked).toBe(true);
+  });
+
+  it('handles missing fulfilled checkbox gracefully', async () => {
+    document.body.innerHTML = `
+      <form id="pledge_fulfillment_form">
+        <input id="patient_fulfillment_attributes_fund_payout" value="500">
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('pledge_fulfillment_form');
+    form.requestSubmit = jest.fn();
+
+    expect(() => {
+      document.getElementById('patient_fulfillment_attributes_fund_payout')
+        .dispatchEvent(new Event('change', { bubbles: true }));
+    }).not.toThrow();
+  });
+});

--- a/app/javascript/src/__tests__/call_list_drag_and_drop.test.js
+++ b/app/javascript/src/__tests__/call_list_drag_and_drop.test.js
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ */
+import Sortable from 'sortablejs';
+
+jest.mock('sortablejs', () => ({
+  create: jest.fn(() => ({})),
+}));
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  Sortable.create.mockClear();
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  delete global.fetch;
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/call_list_drag_and_drop');
+};
+
+describe('call_list_drag_and_drop', () => {
+  const buildCallList = () => {
+    document.body.innerHTML = `
+      <meta name="csrf-token" content="test-csrf-token">
+      <table id="call_list">
+        <tbody>
+          <tr class="patient-data" id="patient_1"><td>Patient 1</td></tr>
+          <tr class="patient-data" id="patient_2"><td>Patient 2</td></tr>
+          <tr class="patient-data" id="patient_3"><td>Patient 3</td></tr>
+        </tbody>
+      </table>
+    `;
+  };
+
+  it('initializes Sortable on call_list tbody', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Sortable.create).toHaveBeenCalledTimes(1);
+    const tbody = document.querySelector('#call_list tbody');
+    expect(Sortable.create).toHaveBeenCalledWith(tbody, expect.objectContaining({
+      animation: 150,
+      handle: '.patient-data',
+      draggable: '.patient-data',
+      ghostClass: 'ui-state-highlight',
+      chosenClass: 'active-item-shadow',
+    }));
+  });
+
+  it('does not initialize when call_list element is missing', async () => {
+    document.body.innerHTML = '<div>No call list</div>';
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Sortable.create).not.toHaveBeenCalled();
+  });
+
+  it('sends PATCH request with new order on onEnd', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const onEndCb = Sortable.create.mock.calls[0][1].onEnd;
+    const mockItem = document.querySelector('.patient-data');
+
+    onEndCb({
+      item: mockItem,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/call_lists/reorder_call_list',
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-CSRF-Token': 'test-csrf-token',
+        }),
+      })
+    );
+
+    const body = global.fetch.mock.calls[0][1].body;
+    expect(body).toContain('order[]=patient_1');
+    expect(body).toContain('order[]=patient_2');
+    expect(body).toContain('order[]=patient_3');
+  });
+
+  it('highlights dropped row cells temporarily', async () => {
+    jest.useFakeTimers();
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const onEndCb = Sortable.create.mock.calls[0][1].onEnd;
+    const item = document.querySelector('.patient-data');
+
+    onEndCb({ item });
+
+    const td = item.querySelector('td');
+    expect(td.style.backgroundColor).toBe('#ece0ff');
+
+    jest.advanceTimersByTime(500);
+    expect(td.style.backgroundColor).toBe('');
+
+    jest.useRealTimers();
+  });
+
+  it('includes CSRF token from meta tag', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const onEndCb = Sortable.create.mock.calls[0][1].onEnd;
+    onEndCb({ item: document.querySelector('.patient-data') });
+
+    const headers = global.fetch.mock.calls[0][1].headers;
+    expect(headers['X-CSRF-Token']).toBe('test-csrf-token');
+  });
+
+  it('handles missing CSRF token gracefully', async () => {
+    document.body.innerHTML = `
+      <table id="call_list">
+        <tbody>
+          <tr class="patient-data" id="p1"><td>P1</td></tr>
+        </tbody>
+      </table>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const onEndCb = Sortable.create.mock.calls[0][1].onEnd;
+    expect(() => {
+      onEndCb({ item: document.querySelector('.patient-data') });
+    }).not.toThrow();
+  });
+
+  it('falls back to call_list element when no tbody exists', async () => {
+    document.body.innerHTML = `
+      <div id="call_list">
+        <div class="patient-data" id="p1">Patient 1</div>
+      </div>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Sortable.create).toHaveBeenCalledTimes(1);
+    // Falls back to callList itself since there's no tbody
+    const callList = document.getElementById('call_list');
+    expect(Sortable.create).toHaveBeenCalledWith(callList, expect.any(Object));
+  });
+});

--- a/app/javascript/src/__tests__/clinic_finder.test.js
+++ b/app/javascript/src/__tests__/clinic_finder.test.js
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/clinic_finder');
+};
+
+describe('clinic_finder', () => {
+  const buildClinicFinder = () => {
+    document.body.innerHTML = `
+      <button class="clinic-finder-expand">Find Clinic</button>
+      <div id="clinic-finder-search-form" class="d-none">
+        <input type="text" placeholder="Search...">
+      </div>
+    `;
+  };
+
+  it('toggles d-none on search form when expand button is clicked', async () => {
+    buildClinicFinder();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.querySelector('.clinic-finder-expand').click();
+
+    expect(document.getElementById('clinic-finder-search-form').classList.contains('d-none')).toBe(false);
+  });
+
+  it('hides search form on second click', async () => {
+    buildClinicFinder();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const btn = document.querySelector('.clinic-finder-expand');
+    btn.click(); // show
+    btn.click(); // hide
+
+    expect(document.getElementById('clinic-finder-search-form').classList.contains('d-none')).toBe(true);
+  });
+
+  it('handles click on child element of expand button', async () => {
+    document.body.innerHTML = `
+      <button class="clinic-finder-expand"><span class="icon">🔍</span></button>
+      <div id="clinic-finder-search-form" class="d-none">Form</div>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.querySelector('.clinic-finder-expand .icon').click();
+
+    expect(document.getElementById('clinic-finder-search-form').classList.contains('d-none')).toBe(false);
+  });
+
+  it('does nothing when search form element is missing', async () => {
+    document.body.innerHTML = '<button class="clinic-finder-expand">Find</button>';
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(() => {
+      document.querySelector('.clinic-finder-expand').click();
+    }).not.toThrow();
+  });
+
+  it('does nothing for clicks on unrelated elements', async () => {
+    buildClinicFinder();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.body.click();
+
+    expect(document.getElementById('clinic-finder-search-form').classList.contains('d-none')).toBe(true);
+  });
+});

--- a/app/javascript/src/__tests__/clinics.test.js
+++ b/app/javascript/src/__tests__/clinics.test.js
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/clinics');
+};
+
+const buildClinicSelect = () => {
+  document.body.innerHTML = `
+    <select id="patient_clinic_id">
+      <option value="1" data-naf="true" data-medicaid="true">Clinic A</option>
+      <option value="2" data-naf="false" data-medicaid="true">Clinic B</option>
+      <option value="3" data-naf="true" data-medicaid="false">Clinic C</option>
+      <option value="4" data-naf="false" data-medicaid="false">Clinic D</option>
+    </select>
+    <input type="checkbox" id="patient_naf_filter">
+    <input type="checkbox" id="patient_medicaid_filter">
+  `;
+};
+
+describe('filterClinicsByNAF', () => {
+  it('disables options with data-naf="false" when NAF filter is checked', async () => {
+    buildClinicSelect();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const nafFilter = document.getElementById('patient_naf_filter');
+    nafFilter.checked = true;
+    nafFilter.click();
+
+    const options = document.querySelectorAll('#patient_clinic_id > option');
+    expect(options[0].disabled).toBe(false); // naf=true
+    expect(options[1].disabled).toBe(true);  // naf=false
+    expect(options[2].disabled).toBe(false); // naf=true
+    expect(options[3].disabled).toBe(true);  // naf=false
+  });
+
+  it('re-enables options when NAF filter is unchecked', async () => {
+    buildClinicSelect();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const nafFilter = document.getElementById('patient_naf_filter');
+
+    // Check
+    nafFilter.checked = true;
+    nafFilter.click();
+
+    // Uncheck
+    nafFilter.checked = false;
+    nafFilter.click();
+
+    const options = document.querySelectorAll('#patient_clinic_id > option');
+    options.forEach(opt => {
+      expect(opt.disabled).toBe(false);
+    });
+  });
+});
+
+describe('filterClinicsByMedicaid', () => {
+  it('disables options with data-medicaid="false" when Medicaid filter is checked', async () => {
+    buildClinicSelect();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const medicaidFilter = document.getElementById('patient_medicaid_filter');
+    medicaidFilter.checked = true;
+    medicaidFilter.click();
+
+    const options = document.querySelectorAll('#patient_clinic_id > option');
+    expect(options[0].disabled).toBe(false); // medicaid=true
+    expect(options[1].disabled).toBe(false); // medicaid=true
+    expect(options[2].disabled).toBe(true);  // medicaid=false
+    expect(options[3].disabled).toBe(true);  // medicaid=false
+  });
+
+  it('re-enables options when Medicaid filter is unchecked', async () => {
+    buildClinicSelect();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const medicaidFilter = document.getElementById('patient_medicaid_filter');
+
+    medicaidFilter.checked = true;
+    medicaidFilter.click();
+
+    medicaidFilter.checked = false;
+    medicaidFilter.click();
+
+    const options = document.querySelectorAll('#patient_clinic_id > option');
+    options.forEach(opt => {
+      expect(opt.disabled).toBe(false);
+    });
+  });
+});
+
+describe('combined filters', () => {
+  it('applies both filters simultaneously', async () => {
+    buildClinicSelect();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const nafFilter = document.getElementById('patient_naf_filter');
+    const medicaidFilter = document.getElementById('patient_medicaid_filter');
+
+    nafFilter.checked = true;
+    nafFilter.click();
+
+    medicaidFilter.checked = true;
+    medicaidFilter.click();
+
+    const options = document.querySelectorAll('#patient_clinic_id > option');
+    expect(options[0].disabled).toBe(false); // both true
+    expect(options[1].disabled).toBe(true);  // naf=false
+    expect(options[2].disabled).toBe(true);  // medicaid=false
+    expect(options[3].disabled).toBe(true);  // both false
+  });
+
+  it('does not affect options without data attributes', async () => {
+    document.body.innerHTML = `
+      <select id="patient_clinic_id">
+        <option value="">Select a clinic</option>
+        <option value="1" data-naf="false" data-medicaid="false">Clinic A</option>
+      </select>
+      <input type="checkbox" id="patient_naf_filter">
+      <input type="checkbox" id="patient_medicaid_filter">
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const nafFilter = document.getElementById('patient_naf_filter');
+    nafFilter.checked = true;
+    nafFilter.click();
+
+    const options = document.querySelectorAll('#patient_clinic_id > option');
+    expect(options[0].disabled).toBe(false); // no data-naf
+    expect(options[1].disabled).toBe(true);  // naf=false
+  });
+
+  it('does nothing when filter checkbox is missing', async () => {
+    document.body.innerHTML = `
+      <select id="patient_clinic_id">
+        <option value="1" data-naf="false">Clinic A</option>
+      </select>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // No checkbox to click — just ensure no errors
+    expect(document.querySelector('#patient_clinic_id > option').disabled).toBe(false);
+  });
+});

--- a/app/javascript/src/__tests__/multistep_modal.test.js
+++ b/app/javascript/src/__tests__/multistep_modal.test.js
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment jsdom
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/multistep_modal');
+};
+
+const buildModal = (id = 'test-modal', stepCount = 3) => {
+  const steps = Array.from({ length: stepCount }, (_, i) =>
+    `<div class="modal-step" data-step="${i}">Step ${i}</div>`
+  ).join('');
+
+  document.body.innerHTML = `
+    <div id="${id}" class="modal">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          ${steps}
+          <button class="next-step">Next</button>
+          <button class="prev-step">Prev</button>
+        </div>
+      </div>
+    </div>
+  `;
+};
+
+describe('activateMultiModal', () => {
+  it('shows only the first step on initialization', async () => {
+    buildModal();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const steps = document.querySelectorAll('.modal-step');
+    expect(steps[0].style.display).toBe('');
+    expect(steps[1].style.display).toBe('none');
+    expect(steps[2].style.display).toBe('none');
+  });
+
+  it('advances to the next step on next-step click', async () => {
+    buildModal();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.querySelector('.next-step').click();
+
+    const steps = document.querySelectorAll('.modal-step');
+    expect(steps[0].style.display).toBe('none');
+    expect(steps[1].style.display).toBe('');
+    expect(steps[2].style.display).toBe('none');
+  });
+
+  it('goes back to the previous step on prev-step click', async () => {
+    buildModal();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.querySelector('.next-step').click(); // step 1
+    document.querySelector('.prev-step').click(); // back to step 0
+
+    const steps = document.querySelectorAll('.modal-step');
+    expect(steps[0].style.display).toBe('');
+    expect(steps[1].style.display).toBe('none');
+  });
+
+  it('does not advance past the last step', async () => {
+    buildModal('test-modal', 2);
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const next = document.querySelector('.next-step');
+    next.click(); // step 1 (last)
+    next.click(); // should stay at step 1
+
+    const steps = document.querySelectorAll('.modal-step');
+    expect(steps[0].style.display).toBe('none');
+    expect(steps[1].style.display).toBe('');
+  });
+
+  it('does not go before the first step', async () => {
+    buildModal();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.querySelector('.prev-step').click(); // already at 0
+
+    const steps = document.querySelectorAll('.modal-step');
+    expect(steps[0].style.display).toBe('');
+    expect(steps[1].style.display).toBe('none');
+  });
+
+  it('resets to step 0 on show.bs.modal event', async () => {
+    buildModal();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Navigate to step 2
+    document.querySelector('.next-step').click();
+    document.querySelector('.next-step').click();
+
+    const steps = document.querySelectorAll('.modal-step');
+    expect(steps[2].style.display).toBe('');
+
+    // Trigger modal show
+    const modal = document.getElementById('test-modal');
+    modal.dispatchEvent(new Event('show.bs.modal'));
+
+    expect(steps[0].style.display).toBe('');
+    expect(steps[1].style.display).toBe('none');
+    expect(steps[2].style.display).toBe('none');
+  });
+
+  it('handles modals with no steps gracefully', async () => {
+    document.body.innerHTML = '<div id="empty-modal" class="modal"></div>';
+    await loadModule();
+
+    expect(() => {
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+    }).not.toThrow();
+  });
+
+  it('works with next-step button inside nested elements', async () => {
+    document.body.innerHTML = `
+      <div id="nested-modal" class="modal">
+        <div class="modal-step">Step 0</div>
+        <div class="modal-step">Step 1</div>
+        <button class="next-step"><span class="icon">→</span></button>
+      </div>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Click the inner span — event delegation via closest('.next-step')
+    document.querySelector('.next-step .icon').click();
+
+    const steps = document.querySelectorAll('.modal-step');
+    expect(steps[0].style.display).toBe('none');
+    expect(steps[1].style.display).toBe('');
+  });
+
+  it('navigates through all steps sequentially', async () => {
+    buildModal('test-modal', 4);
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const next = document.querySelector('.next-step');
+    const steps = document.querySelectorAll('.modal-step');
+
+    for (let i = 0; i < 3; i++) {
+      next.click();
+      expect(steps[i].style.display).toBe('none');
+      expect(steps[i + 1].style.display).toBe('');
+    }
+  });
+});

--- a/app/javascript/src/__tests__/pledge_calculator.test.js
+++ b/app/javascript/src/__tests__/pledge_calculator.test.js
@@ -1,0 +1,208 @@
+/**
+ * @jest-environment jsdom
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/pledge_calculator');
+};
+
+const buildPledgeForm = (overrides = {}) => {
+  const defaults = {
+    procedureCost: '',
+    ultrasoundCost: '',
+    patientContribution: '',
+    nafPledge: '',
+    fundPledge: '',
+    externalPledges: [],
+  };
+  const vals = { ...defaults, ...overrides };
+
+  document.body.innerHTML = `
+    <form id="abortion-information-form">
+      <input id="patient_procedure_cost" value="${vals.procedureCost}">
+      <input id="patient_ultrasound_cost" value="${vals.ultrasoundCost}">
+      <input id="patient_patient_contribution" value="${vals.patientContribution}">
+      <input id="patient_naf_pledge" value="${vals.nafPledge}">
+      <input id="patient_fund_pledge" value="${vals.fundPledge}">
+      ${vals.externalPledges.map(v => `<input class="external_pledge_amount" value="${v}">`).join('')}
+    </form>
+    <div id="external_pledges">
+      <button id="create-external-pledge">Add</button>
+    </div>
+    <div class="outstanding-balance-ctn d-none">
+      <span id="outstanding-balance"></span>
+    </div>
+  `;
+};
+
+describe('pledge calculator – updateBalance via change events', () => {
+  it('shows the balance container when procedure cost is set', async () => {
+    buildPledgeForm({ procedureCost: '500' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const ctn = document.querySelector('.outstanding-balance-ctn');
+    expect(ctn.classList.contains('d-none')).toBe(false);
+  });
+
+  it('hides balance container when procedure cost is empty', async () => {
+    buildPledgeForm({ procedureCost: '' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const ctn = document.querySelector('.outstanding-balance-ctn');
+    expect(ctn.classList.contains('d-none')).toBe(true);
+  });
+
+  it('calculates remainder correctly: total - contributions', async () => {
+    buildPledgeForm({
+      procedureCost: '1000',
+      ultrasoundCost: '200',
+      patientContribution: '100',
+      nafPledge: '300',
+      fundPledge: '200',
+    });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Remainder = (1000 + 200) - (100 + 300 + 200) = 600
+    const balance = document.getElementById('outstanding-balance');
+    expect(balance.textContent).toBe('$600');
+  });
+
+  it('includes external pledges in the calculation', async () => {
+    buildPledgeForm({
+      procedureCost: '1000',
+      externalPledges: ['100', '200'],
+    });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Remainder = 1000 - (100 + 200) = 700
+    const balance = document.getElementById('outstanding-balance');
+    expect(balance.textContent).toBe('$700');
+  });
+
+  it('handles zero contributions', async () => {
+    buildPledgeForm({ procedureCost: '500' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(document.getElementById('outstanding-balance').textContent).toBe('$500');
+  });
+
+  it('shows negative remainder when overfunded', async () => {
+    buildPledgeForm({
+      procedureCost: '100',
+      fundPledge: '500',
+    });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(document.getElementById('outstanding-balance').textContent).toBe('$-400');
+  });
+
+  it('treats non-numeric input as zero', async () => {
+    buildPledgeForm({
+      procedureCost: '500',
+      patientContribution: 'abc',
+    });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(document.getElementById('outstanding-balance').textContent).toBe('$500');
+  });
+
+  it('recalculates on input change event', async () => {
+    buildPledgeForm({ procedureCost: '500' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(document.getElementById('outstanding-balance').textContent).toBe('$500');
+
+    // Simulate updating patient contribution
+    const input = document.getElementById('patient_patient_contribution');
+    input.value = '200';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.getElementById('outstanding-balance').textContent).toBe('$300');
+  });
+
+  it('updates balance when fund pledge changes', async () => {
+    buildPledgeForm({ procedureCost: '1000' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const input = document.getElementById('patient_fund_pledge');
+    input.value = '400';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.getElementById('outstanding-balance').textContent).toBe('$600');
+  });
+
+  it('hides balance if procedure cost is cleared via change', async () => {
+    buildPledgeForm({ procedureCost: '500' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const costInput = document.getElementById('patient_procedure_cost');
+    costInput.value = '';
+    costInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.querySelector('.outstanding-balance-ctn').classList.contains('d-none')).toBe(true);
+  });
+});
+
+describe('pledge calculator – edge cases', () => {
+  it('does not throw when balance element is missing', async () => {
+    document.body.innerHTML = `
+      <form id="abortion-information-form">
+        <input id="patient_procedure_cost" value="500">
+      </form>
+      <div class="outstanding-balance-ctn d-none"></div>
+    `;
+    await loadModule();
+
+    expect(() => {
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+    }).not.toThrow();
+  });
+
+  it('handles missing form inputs gracefully', async () => {
+    document.body.innerHTML = '<div></div>';
+    await loadModule();
+
+    expect(() => {
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+    }).not.toThrow();
+  });
+
+  it('handles create-external-pledge button click with timeout', async () => {
+    jest.useFakeTimers();
+    buildPledgeForm({ procedureCost: '500' });
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.getElementById('create-external-pledge').click();
+
+    // Add external pledge input dynamically (simulates Rails append)
+    const newInput = document.createElement('input');
+    newInput.className = 'external_pledge_amount';
+    newInput.value = '100';
+    document.getElementById('external_pledges').appendChild(newInput);
+
+    jest.advanceTimersByTime(500);
+
+    expect(document.getElementById('outstanding-balance').textContent).toBe('$400');
+    jest.useRealTimers();
+  });
+});

--- a/app/javascript/src/__tests__/require_pledge_signature.test.js
+++ b/app/javascript/src/__tests__/require_pledge_signature.test.js
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/require_pledge_signature');
+};
+
+describe('require_pledge_signature', () => {
+  const buildPledgeForm = (caseManagerName = '') => {
+    document.body.innerHTML = `
+      <form id="generate-pledge-form" action="/pledges">
+        <input id="case_manager_name" value="${caseManagerName}">
+        <div class="alert" style="display: none;">Please sign the pledge.</div>
+        <button type="submit">Generate Pledge</button>
+      </form>
+    `;
+  };
+
+  it('allows form submission when case_manager_name is filled', async () => {
+    buildPledgeForm('Jane Doe');
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('generate-pledge-form');
+    const event = new Event('submit', { bubbles: true, cancelable: true });
+    const result = form.dispatchEvent(event);
+
+    // Event was not prevented
+    expect(result).toBe(true);
+  });
+
+  it('prevents submission when case_manager_name is empty', async () => {
+    buildPledgeForm('');
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('generate-pledge-form');
+    const event = new Event('submit', { bubbles: true, cancelable: true });
+    const result = form.dispatchEvent(event);
+
+    expect(result).toBe(false);
+  });
+
+  it('shows the alert when submission is prevented', async () => {
+    buildPledgeForm('');
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('generate-pledge-form');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    const alert = form.querySelector('.alert');
+    expect(alert.style.display).toBe('');
+  });
+
+  it('does not show alert when name is provided', async () => {
+    buildPledgeForm('Jane');
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('generate-pledge-form');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    const alert = form.querySelector('.alert');
+    expect(alert.style.display).toBe('none');
+  });
+
+  it('does not interfere with other forms', async () => {
+    document.body.innerHTML = `
+      <form id="other-form" action="/other">
+        <button type="submit">Submit</button>
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('other-form');
+    const event = new Event('submit', { bubbles: true, cancelable: true });
+    const result = form.dispatchEvent(event);
+
+    expect(result).toBe(true);
+  });
+
+  it('handles missing case_manager_name element', async () => {
+    document.body.innerHTML = `
+      <form id="generate-pledge-form">
+        <div class="alert" style="display: none;">Error</div>
+        <button type="submit">Generate</button>
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('generate-pledge-form');
+    const event = new Event('submit', { bubbles: true, cancelable: true });
+    const result = form.dispatchEvent(event);
+
+    // case_manager_name is null, so value is falsy → prevented
+    expect(result).toBe(false);
+  });
+
+  it('handles missing alert element gracefully', async () => {
+    document.body.innerHTML = `
+      <form id="generate-pledge-form">
+        <input id="case_manager_name" value="">
+        <button type="submit">Generate</button>
+      </form>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(() => {
+      const form = document.getElementById('generate-pledge-form');
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    }).not.toThrow();
+  });
+});

--- a/app/javascript/src/__tests__/table_sorting.test.js
+++ b/app/javascript/src/__tests__/table_sorting.test.js
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import Tablesort from 'tablesort';
+
+jest.mock('tablesort', () => {
+  const MockTablesort = jest.fn(() => ({ sort: jest.fn() }));
+  return MockTablesort;
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  Tablesort.mockClear();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/table_sorting');
+};
+
+describe('initSortableTables', () => {
+  it('initializes Tablesort on tables with data-sort attribute', async () => {
+    document.body.innerHTML = `
+      <table data-sort><thead><tr><th>Name</th></tr></thead></table>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Tablesort).toHaveBeenCalledTimes(1);
+    expect(Tablesort).toHaveBeenCalledWith(document.querySelector('table[data-sort]'));
+  });
+
+  it('does not initialize Tablesort on tables without data-sort', async () => {
+    document.body.innerHTML = '<table><thead><tr><th>Name</th></tr></thead></table>';
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Tablesort).not.toHaveBeenCalled();
+  });
+
+  it('caches Tablesort instance on _tablesort property', async () => {
+    document.body.innerHTML = '<table data-sort><thead><tr><th>Col</th></tr></thead></table>';
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const table = document.querySelector('table[data-sort]');
+    expect(table._tablesort).toBeTruthy();
+  });
+
+  it('does not re-initialize when _tablesort already exists', async () => {
+    document.body.innerHTML = '<table data-sort><thead><tr><th>Col</th></tr></thead></table>';
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Tablesort).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles multiple sortable tables', async () => {
+    document.body.innerHTML = `
+      <table data-sort id="t1"><thead><tr><th>A</th></tr></thead></table>
+      <table data-sort id="t2"><thead><tr><th>B</th></tr></thead></table>
+      <table id="t3"><thead><tr><th>C</th></tr></thead></table>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Tablesort).toHaveBeenCalledTimes(2);
+  });
+
+  it('responds to turbo:load event', async () => {
+    document.body.innerHTML = '<table data-sort><thead><tr><th>Col</th></tr></thead></table>';
+    await loadModule();
+    document.dispatchEvent(new Event('turbo:load'));
+
+    expect(Tablesort).toHaveBeenCalledTimes(1);
+  });
+
+  it('responds to turbo:frame-load event', async () => {
+    document.body.innerHTML = '<table data-sort><thead><tr><th>Col</th></tr></thead></table>';
+    await loadModule();
+    document.dispatchEvent(new Event('turbo:frame-load'));
+
+    expect(Tablesort).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when no tables are present', async () => {
+    document.body.innerHTML = '<div>No tables here</div>';
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(Tablesort).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/src/__tests__/toggle_full_call_list.test.js
+++ b/app/javascript/src/__tests__/toggle_full_call_list.test.js
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const loadModule = () => {
+  jest.resetModules();
+  return import('../../app/javascript/src/toggle_full_call_list');
+};
+
+describe('toggle_full_call_list', () => {
+  const buildCallList = () => {
+    document.body.innerHTML = `
+      <button id="toggle-call-log">View all calls</button>
+      <div class="old-calls d-none">Old call 1</div>
+      <div class="old-calls d-none">Old call 2</div>
+    `;
+  };
+
+  it('removes d-none from old-calls on first click', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.getElementById('toggle-call-log').click();
+
+    document.querySelectorAll('.old-calls').forEach(el => {
+      expect(el.classList.contains('d-none')).toBe(false);
+    });
+  });
+
+  it('updates button text to "Limit list" when expanded', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.getElementById('toggle-call-log').click();
+
+    expect(document.getElementById('toggle-call-log').innerHTML).toBe('Limit list');
+  });
+
+  it('re-adds d-none and resets text on second click', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const btn = document.getElementById('toggle-call-log');
+    btn.click(); // expand
+    btn.click(); // collapse
+
+    document.querySelectorAll('.old-calls').forEach(el => {
+      expect(el.classList.contains('d-none')).toBe(true);
+    });
+    expect(btn.innerHTML).toBe('View all calls');
+  });
+
+  it('toggles correctly through multiple cycles', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const btn = document.getElementById('toggle-call-log');
+    for (let i = 0; i < 4; i++) {
+      btn.click();
+      const hidden = document.querySelector('.old-calls').classList.contains('d-none');
+      if (i % 2 === 0) {
+        expect(hidden).toBe(false);
+        expect(btn.innerHTML).toBe('Limit list');
+      } else {
+        expect(hidden).toBe(true);
+        expect(btn.innerHTML).toBe('View all calls');
+      }
+    }
+  });
+
+  it('handles click on child element of toggle button', async () => {
+    document.body.innerHTML = `
+      <button id="toggle-call-log"><span class="icon">▼</span> View all calls</button>
+      <div class="old-calls d-none">Old call</div>
+    `;
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.querySelector('#toggle-call-log .icon').click();
+
+    expect(document.querySelector('.old-calls').classList.contains('d-none')).toBe(false);
+  });
+
+  it('does nothing when no old-calls elements exist', async () => {
+    document.body.innerHTML = '<button id="toggle-call-log">View all calls</button>';
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(() => {
+      document.getElementById('toggle-call-log').click();
+    }).not.toThrow();
+  });
+
+  it('does nothing for clicks on unrelated elements', async () => {
+    buildCallList();
+    await loadModule();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.body.click();
+
+    document.querySelectorAll('.old-calls').forEach(el => {
+      expect(el.classList.contains('d-none')).toBe(true);
+    });
+  });
+});

--- a/app/javascript/src/__tests__/tooltips.test.js
+++ b/app/javascript/src/__tests__/tooltips.test.js
@@ -1,0 +1,248 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createPopper } from '@popperjs/core';
+import { activateTooltips } from '../../app/javascript/src/tooltips';
+
+jest.mock('@popperjs/core', () => ({
+  createPopper: jest.fn(() => ({ destroy: jest.fn() })),
+}));
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  createPopper.mockClear();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('escapeHTML (via tooltip rendering)', () => {
+  it('escapes HTML entities in non-html mode', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="<script>alert(1)</script>">hover</span>';
+    activateTooltips();
+
+    const el = document.querySelector('.daria-tooltip');
+    el.dispatchEvent(new MouseEvent('mouseenter'));
+
+    const inner = document.querySelector('.tooltip-inner');
+    expect(inner.textContent).toBe('<script>alert(1)</script>');
+    expect(inner.innerHTML).not.toContain('<script>');
+  });
+
+  it('escapes ampersands and quotes', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="A &amp; B &quot;quoted&quot;">hover</span>';
+    activateTooltips();
+
+    const el = document.querySelector('.daria-tooltip');
+    el.dispatchEvent(new MouseEvent('mouseenter'));
+
+    const inner = document.querySelector('.tooltip-inner');
+    expect(inner).toBeTruthy();
+  });
+});
+
+describe('initTooltip', () => {
+  it('creates a Popper tooltip on mouseenter and removes on mouseleave', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="Hello">hover me</span>';
+    activateTooltips();
+
+    const el = document.querySelector('.daria-tooltip');
+
+    // Show
+    el.dispatchEvent(new MouseEvent('mouseenter'));
+    expect(createPopper).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.tooltip')).toBeTruthy();
+    expect(document.querySelector('.tooltip').classList.contains('show')).toBe(true);
+    expect(document.querySelector('.tooltip-inner').textContent).toBe('Hello');
+
+    // Hide
+    el.dispatchEvent(new MouseEvent('mouseleave'));
+    expect(document.querySelector('.tooltip')).toBeNull();
+  });
+
+  it('creates tooltip on focusin and removes on focusout', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="Focus tip">focus me</span>';
+    activateTooltips();
+
+    const el = document.querySelector('.daria-tooltip');
+
+    el.dispatchEvent(new FocusEvent('focusin'));
+    expect(createPopper).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.tooltip')).toBeTruthy();
+
+    el.dispatchEvent(new FocusEvent('focusout'));
+    expect(document.querySelector('.tooltip')).toBeNull();
+  });
+
+  it('uses top placement by default', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="Top">tip</span>';
+    activateTooltips();
+
+    const el = document.querySelector('.daria-tooltip');
+    el.dispatchEvent(new MouseEvent('mouseenter'));
+
+    expect(createPopper).toHaveBeenCalledWith(
+      el,
+      expect.any(HTMLElement),
+      expect.objectContaining({ placement: 'top' })
+    );
+    expect(document.querySelector('.tooltip').classList.contains('bs-tooltip-top')).toBe(true);
+  });
+
+  it('removes the title attribute to prevent native tooltip', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="Native">tip</span>';
+    activateTooltips();
+
+    const el = document.querySelector('.daria-tooltip');
+    expect(el.getAttribute('title')).toBeNull();
+  });
+
+  it('includes an arrow element in the tooltip', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="Arrow">tip</span>';
+    activateTooltips();
+
+    document.querySelector('.daria-tooltip').dispatchEvent(new MouseEvent('mouseenter'));
+    expect(document.querySelector('.tooltip .arrow')).toBeTruthy();
+  });
+
+  it('does nothing when content is empty', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="">empty</span>';
+    activateTooltips();
+
+    document.querySelector('.daria-tooltip').dispatchEvent(new MouseEvent('mouseenter'));
+    expect(createPopper).not.toHaveBeenCalled();
+    expect(document.querySelector('.tooltip')).toBeNull();
+  });
+});
+
+describe('activateTooltips', () => {
+  it('skips elements already bound (data-tooltipBound flag)', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="Once">tip</span>';
+    activateTooltips();
+    activateTooltips(); // call again
+
+    const el = document.querySelector('.daria-tooltip');
+    el.dispatchEvent(new MouseEvent('mouseenter'));
+
+    // Should only have one tooltip, not two stacked
+    expect(createPopper).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets data-tooltipBound on processed elements', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" title="Bound">tip</span>';
+    activateTooltips();
+
+    expect(document.querySelector('.daria-tooltip').dataset.tooltipBound).toBe('1');
+  });
+
+  it('reads data-original-title as fallback', () => {
+    document.body.innerHTML = '<span class="daria-tooltip" data-original-title="Fallback">tip</span>';
+    activateTooltips();
+
+    const el = document.querySelector('.daria-tooltip');
+    el.dispatchEvent(new MouseEvent('mouseenter'));
+    expect(document.querySelector('.tooltip-inner').textContent).toBe('Fallback');
+  });
+
+  it('handles multiple tooltip elements', () => {
+    document.body.innerHTML = `
+      <span class="daria-tooltip" title="First">a</span>
+      <span class="daria-tooltip" title="Second">b</span>
+    `;
+    activateTooltips();
+
+    const els = document.querySelectorAll('.daria-tooltip');
+    expect(els[0].dataset.tooltipBound).toBe('1');
+    expect(els[1].dataset.tooltipBound).toBe('1');
+  });
+});
+
+describe('tooltip-header-input (form input help icons)', () => {
+  it('injects a help span and binds a tooltip from input data-tooltip-text', () => {
+    document.body.innerHTML = `
+      <div class="form-group">
+        <label class="tooltip-header-input">Label</label>
+        <input class="form-control" data-tooltip-text="Help <b>text</b>">
+      </div>
+    `;
+    activateTooltips();
+
+    const helpSpan = document.querySelector('.tooltip-header-help');
+    expect(helpSpan).toBeTruthy();
+    expect(helpSpan.textContent).toBe('(?)');
+    expect(helpSpan.dataset.tooltipBound).toBe('1');
+
+    // Show tooltip — html mode uses bottom placement
+    helpSpan.dispatchEvent(new MouseEvent('mouseenter'));
+    expect(createPopper).toHaveBeenCalledWith(
+      helpSpan,
+      expect.any(HTMLElement),
+      expect.objectContaining({ placement: 'bottom' })
+    );
+  });
+
+  it('does not duplicate help span on second activation', () => {
+    document.body.innerHTML = `
+      <div class="form-group">
+        <label class="tooltip-header-input">Label</label>
+        <input class="form-control" data-tooltip-text="Info">
+      </div>
+    `;
+    activateTooltips();
+    activateTooltips();
+
+    expect(document.querySelectorAll('.tooltip-header-help').length).toBe(1);
+  });
+
+  it('skips when form-group has no form-control', () => {
+    document.body.innerHTML = `
+      <div class="form-group">
+        <label class="tooltip-header-input">Label</label>
+      </div>
+    `;
+    activateTooltips();
+
+    const helpSpan = document.querySelector('.tooltip-header-help');
+    expect(helpSpan).toBeTruthy();
+    // No tooltip bound since no input
+    expect(helpSpan.dataset.tooltipBound).toBeUndefined();
+  });
+
+  it('skips when input has no tooltip-text data attribute', () => {
+    document.body.innerHTML = `
+      <div class="form-group">
+        <label class="tooltip-header-input">Label</label>
+        <input class="form-control">
+      </div>
+    `;
+    activateTooltips();
+    expect(document.querySelector('.tooltip-header-help').dataset.tooltipBound).toBeUndefined();
+  });
+});
+
+describe('tooltip-header-checkbox (checkbox help icons)', () => {
+  it('injects help span and binds tooltip from checkbox data-tooltip-text', () => {
+    document.body.innerHTML = `
+      <div>
+        <label class="tooltip-header-checkbox">Check</label>
+        <input type="checkbox" data-tooltip-text="Checkbox help">
+      </div>
+    `;
+    activateTooltips();
+
+    const helpSpan = document.querySelector('.tooltip-header-help');
+    expect(helpSpan).toBeTruthy();
+    expect(helpSpan.dataset.tooltipBound).toBe('1');
+  });
+
+  it('skips when no checkbox is present', () => {
+    document.body.innerHTML = `
+      <div>
+        <label class="tooltip-header-checkbox">Check</label>
+      </div>
+    `;
+    activateTooltips();
+    expect(document.querySelector('.tooltip-header-help').dataset.tooltipBound).toBeUndefined();
+  });
+});

--- a/app/views/accountants/edit.turbo_stream.erb
+++ b/app/views/accountants/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "fulfillment-modal-content" do %>
+  <%= render partial: 'patients/fulfillment', locals: { patient: @patient } %>
+<% end %>

--- a/app/views/accountants/index.html.erb
+++ b/app/views/accountants/index.html.erb
@@ -23,3 +23,11 @@
 </div>
 
 <%= render partial: "patients/modal" %>
+
+<%# Modal for fulfillment editing (accountants) %>
+<div class="modal fade" tabindex="-1" role="dialog" data-controller="modal">
+  <div class="modal-dialog">
+    <div class="modal-content" id="fulfillment-modal-content">
+    </div>
+  </div>
+</div>

--- a/app/views/calls/create.js.erb
+++ b/app/views/calls/create.js.erb
@@ -28,7 +28,7 @@ if (isOnDashboard) {
                                             utosortable: true }) %>'
   );
 
-  $("#shared_patients").html(
+  $("#shared_cases").html(
     '<%= escape_javascript( render partial: "dashboards/table_content",
                                   locals: { title: t('dashboard.partial_titles.shared_cases'),
                                             table_type: 'shared_cases',

--- a/app/views/calls/create.turbo_stream.erb
+++ b/app/views/calls/create.turbo_stream.erb
@@ -19,7 +19,7 @@
                       autosortable: true } %>
 <% end %>
 
-<%= turbo_stream.update "shared_patients" do %>
+<%= turbo_stream.update "shared_cases" do %>
   <%= render partial: "dashboards/table_content",
             locals: { title: t('dashboard.partial_titles.shared_cases'),
                       table_type: 'shared_cases',

--- a/app/views/calls/create.turbo_stream.erb
+++ b/app/views/calls/create.turbo_stream.erb
@@ -1,0 +1,28 @@
+<%= turbo_stream.update "call_log" do %>
+  <%= render partial: "patients/call_log" %>
+<% end %>
+
+<%= turbo_stream.update "call_list" do %>
+  <%= render partial: "dashboards/table_content",
+            locals: { title: t("dashboard.partial_titles.call_list"),
+                      table_type: "call_list",
+                      patients: current_user.call_list_patients(current_line),
+                      sortable: true,
+                      autosortable: true } %>
+<% end %>
+
+<%= turbo_stream.update "completed_calls" do %>
+  <%= render partial: "dashboards/table_content",
+            locals: { title: t('dashboard.partial_titles.completed_calls'),
+                      table_type: 'completed_calls',
+                      patients: current_user.recently_called_patients(current_line),
+                      autosortable: true } %>
+<% end %>
+
+<%= turbo_stream.update "shared_patients" do %>
+  <%= render partial: "dashboards/table_content",
+            locals: { title: t('dashboard.partial_titles.shared_cases'),
+                      table_type: 'shared_cases',
+                      patients: Patient.shared_patients(current_line),
+                      autosortable: true } %>
+<% end %>

--- a/app/views/calls/destroy.turbo_stream.erb
+++ b/app/views/calls/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "call_log" do %>
+  <%= render partial: "patients/call_log" %>
+<% end %>

--- a/app/views/calls/new.turbo_stream.erb
+++ b/app/views/calls/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "new-call-modal-content" do %>
+  <%= render partial: "calls/new_call", locals: { patient: @patient } %>
+<% end %>

--- a/app/views/clinicfinders/search.turbo_stream.erb
+++ b/app/views/clinicfinders/search.turbo_stream.erb
@@ -1,0 +1,15 @@
+<%= turbo_stream.update "clinic-finder-results" do %>
+  <% if @nearest&.any? %>
+    <%= render partial: 'clinicfinders/result_table',
+              locals: { title: t('clinic_locator.result.nearest_title'),
+                        clinic_fields: [:name, :location, :accepts_naf, :distance, :gestational_limit],
+                        clinics: @nearest } %>
+  <% end %>
+
+  <% if @cheapest&.any? %>
+    <%= render partial: 'clinicfinders/result_table',
+              locals: { title: t('clinic_locator.result.affordable_title'),
+                        clinic_fields: [:name, :cost],
+                        clinics: @cheapest } %>
+  <% end %>
+<% end %>

--- a/app/views/dashboards/_modal.html.erb
+++ b/app/views/dashboards/_modal.html.erb
@@ -1,7 +1,6 @@
-<div class="modal fade new-call" tabindex="-1" role="dialog">
+<div class="modal fade new-call" tabindex="-1" role="dialog" data-controller="modal">
   <div class="modal-dialog">
-    <div class="modal-content">
-      <!-- dynamically load modal-content -->
+    <div class="modal-content" id="new-call-modal-content">
     </div>
   </div>
 </div>

--- a/app/views/dashboards/search.turbo_stream.erb
+++ b/app/views/dashboards/search.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.update "search_results_shell" do %>
+  <% if @results.any? %>
+    <%= render partial: 'dashboards/table_content', locals: { title: t('dashboard.partial_titles.search_results'), table_type: 'search_results', patients: @results } %>
+  <% else %>
+    <h3 class='mt-5 mb-5'><small><%= t('dashboard.search.no_results') %></small></h3>
+  <% end %>
+  <%= render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today } %>
+<% end %>

--- a/app/views/events/index.turbo_stream.erb
+++ b/app/views/events/index.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "activity_log_content" do %>
+  <%= render partial: "events/events", locals: { events: @events } %>
+<% end %>

--- a/app/views/external_pledges/create.turbo_stream.erb
+++ b/app/views/external_pledges/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update "existing-external-pledges" do %>
+  <%= render partial: "external_pledges/external_pledges_table", locals: { patient: @patient, external_pledges: @patient.external_pledges.order(created_at: :desc) } %>
+<% end %>
+
+<%= turbo_stream.update "new-external-pledge" do %>
+  <%= render partial: "external_pledges/new", locals: { patient: @patient, new_external_pledge: @patient.external_pledges.new } %>
+<% end %>

--- a/app/views/notes/create.turbo_stream.erb
+++ b/app/views/notes/create.turbo_stream.erb
@@ -1,0 +1,14 @@
+<% parent_class = @object.is_a?(PracticalSupport) ? 'practical-support' : 'patient' %>
+
+<%= turbo_stream.update "note_full_text" do %>
+<% end %>
+
+<%= turbo_stream.update "notes-log-#{parent_class}" do %>
+  <%= render partial: "notes/notes_table", locals: { notes: @notes } %>
+<% end %>
+
+<% if @object.is_a? PracticalSupport %>
+  <%= turbo_stream.update "practical-support-entries" do %>
+    <%= render partial: "practical_supports/entries", locals: { patient: @object.can_support } %>
+  <% end %>
+<% end %>

--- a/app/views/patients/_modal.html.erb
+++ b/app/views/patients/_modal.html.erb
@@ -1,8 +1,22 @@
-<div class="modal fade new-call" tabindex="-1" role="dialog" id="pledge-modal">
+<div class="modal fade new-call" tabindex="-1" role="dialog" id="pledge-modal" data-controller="modal">
   <div class="modal-dialog">
-    <div class="modal-content modal-body">
+    <div class="modal-content modal-body" id="pledge-modal-content">
+    </div>
+  </div>
+</div>
 
+<%# Separate modal for new calls on the patient page %>
+<div class="modal fade" tabindex="-1" role="dialog" data-controller="modal">
+  <div class="modal-dialog">
+    <div class="modal-content" id="new-call-modal-content">
+    </div>
+  </div>
+</div>
 
+<%# Modal for practical support editing %>
+<div class="modal fade" tabindex="-1" role="dialog" data-controller="modal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content" id="practical-support-edit-modal-content">
     </div>
   </div>
 </div>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -16,8 +16,8 @@
         <%= f.select :last_menstrual_period_weeks,
                      options_for_select(weeks_options, patient.last_menstrual_period_weeks ),
                      label: t('patient.dashboard.weeks_along'),
-                     autocomplete: 'off',
-                     help: t('patient.dashboard.currently', weeks: patient.last_menstrual_period_now_weeks, days: patient.last_menstrual_period_now_days) %>
+                     autocomplete: 'off' %>
+        <small class="form-text text-muted" id="patient_last_menstrual_period_weeks_help"><%= t('patient.dashboard.currently', weeks: patient.last_menstrual_period_now_weeks, days: patient.last_menstrual_period_now_days) %></small>
       </div>
 
       <div class="col mt-4">
@@ -32,8 +32,8 @@
       <div class="col-3">
         <%= f.date_field :appointment_date,
                          label: t('patient.shared.appt_date'),
-                         autocomplete: 'off',
-                         help: t('patient.dashboard.approx_gestation', weeks: patient.last_menstrual_period_at_appt_weeks, days: patient.last_menstrual_period_at_appt_days) %>
+                         autocomplete: 'off' %>
+        <small class="form-text text-muted" id="patient_appointment_date_help"><%= t('patient.dashboard.approx_gestation', weeks: patient.last_menstrual_period_at_appt_weeks, days: patient.last_menstrual_period_at_appt_days) %></small>
       </div>
     </div>
 
@@ -54,7 +54,7 @@
       <div class="col">
         <div class="form-group">
           <label for="status"><%= t 'patient.shared.status' %> <%= tooltip_shell status_help_text(patient) %></label>
-          <input type="text" value="<%= patient.status %>" class="form-control form-control-plaintext" id="patient_status_display" autocomplete="off" disabled>
+          <div id="patient_status_display" class="form-control form-control-plaintext"><%= patient.status %></div>
         </div>
       </div>
 

--- a/app/views/patients/pledge.turbo_stream.erb
+++ b/app/views/patients/pledge.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "pledge-modal-content" do %>
+  <%= render partial: "patients/pledge", locals: { patient: @patient, disable_next: disable_continue?(@patient) } %>
+<% end %>

--- a/app/views/patients/update.turbo_stream.erb
+++ b/app/views/patients/update.turbo_stream.erb
@@ -1,0 +1,34 @@
+<%= turbo_stream.update "patient_appointment_date" do %>
+  <small class="form-text"><%= t('patient.dashboard.approx_gestation', weeks: @patient.last_menstrual_period_at_appt_weeks, days: @patient.last_menstrual_period_at_appt_days) %></small>
+<% end %>
+
+<%= turbo_stream.update "patient_status_display" do %>
+  <%= @patient.status %>
+<% end %>
+
+<%= turbo_stream.update "patient_last_menstrual_period_weeks" do %>
+  <small class="form-text"><%= t('patient.dashboard.currently', weeks: @patient.last_menstrual_period_now_weeks, days: @patient.last_menstrual_period_now_days) %></small>
+<% end %>
+
+<%= turbo_stream.update "change_log" do %>
+  <%= render partial: "patients/change_log", locals: { patient: @patient } %>
+<% end %>
+
+<% if current_user.allowed_data_access? && @patient.pledge_sent? %>
+  <%= turbo_stream.update "pledge_fulfillment" do %>
+    <%= render partial: "patients/fulfillment", locals: { patient: @patient } %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.update "pledge_fulfillment" do %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.update "menu-pledge-button" do %>
+  <%= render "patients/menu_pledge_button", patient: @patient %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <div data-controller="flash">
+    <%= render partial: "layouts/messages" %>
+  </div>
+<% end %>

--- a/app/views/patients/update.turbo_stream.erb
+++ b/app/views/patients/update.turbo_stream.erb
@@ -1,13 +1,13 @@
-<%= turbo_stream.update "patient_appointment_date" do %>
-  <small class="form-text"><%= t('patient.dashboard.approx_gestation', weeks: @patient.last_menstrual_period_at_appt_weeks, days: @patient.last_menstrual_period_at_appt_days) %></small>
+<%= turbo_stream.update "patient_appointment_date_help" do %>
+  <%= t('patient.dashboard.approx_gestation', weeks: @patient.last_menstrual_period_at_appt_weeks, days: @patient.last_menstrual_period_at_appt_days) %>
 <% end %>
 
 <%= turbo_stream.update "patient_status_display" do %>
   <%= @patient.status %>
 <% end %>
 
-<%= turbo_stream.update "patient_last_menstrual_period_weeks" do %>
-  <small class="form-text"><%= t('patient.dashboard.currently', weeks: @patient.last_menstrual_period_now_weeks, days: @patient.last_menstrual_period_now_days) %></small>
+<%= turbo_stream.update "patient_last_menstrual_period_weeks_help" do %>
+  <%= t('patient.dashboard.currently', weeks: @patient.last_menstrual_period_now_weeks, days: @patient.last_menstrual_period_now_days) %>
 <% end %>
 
 <%= turbo_stream.update "change_log" do %>

--- a/app/views/practical_supports/create.turbo_stream.erb
+++ b/app/views/practical_supports/create.turbo_stream.erb
@@ -1,0 +1,13 @@
+<%= turbo_stream.update "practical-support-entries" do %>
+  <%= render partial: "practical_supports/entries", locals: { patient: @patient } %>
+<% end %>
+
+<%= turbo_stream.update "practical-support-new-form" do %>
+  <%= render partial: "practical_supports/new", locals: { patient: @patient } %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <div data-controller="flash">
+    <%= render partial: "layouts/messages" %>
+  </div>
+<% end %>

--- a/app/views/practical_supports/destroy.turbo_stream.erb
+++ b/app/views/practical_supports/destroy.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update "practical-support-entries" do %>
+  <%= render "practical_supports/entries", patient: @patient %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <div data-controller="flash">
+    <%= render partial: "layouts/messages" %>
+  </div>
+<% end %>

--- a/app/views/practical_supports/edit.turbo_stream.erb
+++ b/app/views/practical_supports/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "practical-support-edit-modal-content" do %>
+  <%= render partial: "practical_supports/edit", locals: { patient: @patient, support: @support, note: @note } %>
+<% end %>

--- a/app/views/practical_supports/update.turbo_stream.erb
+++ b/app/views/practical_supports/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update "practical-support-entries" do %>
+  <%= render "practical_supports/entries", patient: @patient %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <div data-controller="flash">
+    <%= render partial: "layouts/messages" %>
+  </div>
+<% end %>

--- a/app/views/users/refresh_patients.js.erb
+++ b/app/views/users/refresh_patients.js.erb
@@ -1,4 +1,4 @@
-$('#call_list, #completed_calls, #shared_patients').empty();
+$('#call_list, #completed_calls, #shared_cases').empty();
 
 $('#call_list').append(
   '<%= escape_javascript(render partial: "dashboards/table_content",
@@ -17,7 +17,7 @@ $('#completed_calls').append(
                                           autosortable: true }) %>'
 );
 
-$("#shared_patients").append(
+$("#shared_cases").append(
   '<%= escape_javascript( render partial: "dashboards/table_content",
                                 locals: { title: t('dashboard.partial_titles.shared_cases'),
                                           table_type: 'shared_cases',

--- a/app/views/users/refresh_patients.turbo_stream.erb
+++ b/app/views/users/refresh_patients.turbo_stream.erb
@@ -15,7 +15,7 @@
                       autosortable: true } %>
 <% end %>
 
-<%= turbo_stream.update "shared_patients" do %>
+<%= turbo_stream.update "shared_cases" do %>
   <%= render partial: "dashboards/table_content",
             locals: { title: t('dashboard.partial_titles.shared_cases'),
                       table_type: 'shared_cases',

--- a/app/views/users/refresh_patients.turbo_stream.erb
+++ b/app/views/users/refresh_patients.turbo_stream.erb
@@ -1,0 +1,24 @@
+<%= turbo_stream.update "call_list" do %>
+  <%= render partial: "dashboards/table_content",
+            locals: { title: t("dashboard.partial_titles.call_list"),
+                      table_type: "call_list",
+                      patients: current_user.call_list_patients(current_line),
+                      sortable: true,
+                      autosortable: true } %>
+<% end %>
+
+<%= turbo_stream.update "completed_calls" do %>
+  <%= render partial: "dashboards/table_content",
+            locals: { title: t('dashboard.partial_titles.completed_calls'),
+                      table_type: 'completed_calls',
+                      patients: current_user.recently_called_patients(current_line),
+                      autosortable: true } %>
+<% end %>
+
+<%= turbo_stream.update "shared_patients" do %>
+  <%= render partial: "dashboards/table_content",
+            locals: { title: t('dashboard.partial_titles.shared_cases'),
+                      table_type: 'shared_cases',
+                      patients: Patient.shared_patients(current_line),
+                      autosortable: true } %>
+<% end %>

--- a/app/views/users/search.turbo_stream.erb
+++ b/app/views/users/search.turbo_stream.erb
@@ -1,0 +1,9 @@
+<% if @results&.any? %>
+  <%= turbo_stream.update "user-list" do %>
+    <%= render partial: 'users/users_table', locals: { users: @results, autosortable: true } %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.update "user-list" do %>
+    <%= render partial: 'users/users_table', locals: { users: nil, autosortable: true } %>
+  <% end %>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.7.2",
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo-rails": "^8.0.23",
     "@popperjs/core": "2.11.8",
     "bootstrap": "4.6.2",
     "esbuild": "0.25.8",

--- a/test/controllers/turbo_phase3_integration_test.rb
+++ b/test/controllers/turbo_phase3_integration_test.rb
@@ -1,0 +1,401 @@
+require 'test_helper'
+
+# Integration tests for feature/turbo-migration-phase-3
+# Builds on phase-2 and adds turbo_stream responses for:
+#   - AccountantsController#edit
+#   - CallsController#new, #create
+#   - PatientsController#pledge, #update
+#   - PracticalSupportsController#edit
+#   - UsersController#search
+class TurboPhase3IntegrationTest < ActionDispatch::IntegrationTest
+  TURBO_STREAM_ACCEPT = { 'Accept' => 'text/vnd.turbo-stream.html' }.freeze
+
+  before do
+    @user = create :user
+    sign_in @user
+    @line = create :line
+    choose_line @line
+    @patient = create :patient, line: @line
+  end
+
+  # ---------------------------------------------------------------------------
+  # AccountantsController#edit — turbo_stream modal content
+  # ---------------------------------------------------------------------------
+  describe 'accountants#edit turbo_stream responses' do
+    before do
+      @admin = create :user, role: :admin
+      @clinic = create :clinic
+      @pledge_patient = create :patient,
+                               line: @line,
+                               pledge_sent: true,
+                               pledge_sent_at: 1.day.ago,
+                               clinic: @clinic,
+                               fund_pledge: 500
+      # Sign in as admin (data_access required)
+      delete destroy_user_session_path
+      sign_in @admin
+    end
+
+    it 'should respond with turbo_stream format' do
+      get edit_accountant_path(@pledge_patient),
+          headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      get edit_accountant_path(@pledge_patient),
+          headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      get edit_accountant_path(@pledge_patient), xhr: true
+      assert_response :success
+    end
+
+    it 'should return unauthorized for non-admin users' do
+      delete destroy_user_session_path
+      sign_in @user  # regular CM user
+
+      get edit_accountant_path(@pledge_patient),
+          headers: TURBO_STREAM_ACCEPT
+      assert_response :unauthorized
+    end
+
+    it 'should return unauthorized for data_volunteer users' do
+      data_vol = create :user, role: :data_volunteer
+      delete destroy_user_session_path
+      sign_in data_vol
+
+      get edit_accountant_path(@pledge_patient),
+          headers: TURBO_STREAM_ACCEPT
+      # data_volunteers have allowed_data_access? == true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CallsController#new — turbo_stream response
+  # ---------------------------------------------------------------------------
+  describe 'calls#new turbo_stream responses' do
+    it 'should respond with turbo_stream format' do
+      get new_patient_call_path(@patient),
+          headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      get new_patient_call_path(@patient),
+          headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      get new_patient_call_path(@patient), xhr: true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CallsController#create — turbo_stream response (non-redirect path)
+  # ---------------------------------------------------------------------------
+  describe 'calls#create turbo_stream responses' do
+    it 'should redirect when patient is reached (regardless of format)' do
+      call_attrs = attributes_for :call, status: :reached_patient
+      post patient_calls_path(@patient),
+           params: { call: call_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_redirected_to edit_patient_path(@patient)
+    end
+
+    it 'should respond with turbo_stream when patient is not reached' do
+      [:left_voicemail, :couldnt_reach_patient].each do |status|
+        call_attrs = attributes_for :call, status: status
+        post patient_calls_path(@patient),
+             params: { call: call_attrs },
+             headers: TURBO_STREAM_ACCEPT
+        assert_response :success
+        assert_includes response.media_type, 'turbo-stream'
+      end
+    end
+
+    it 'should include turbo-stream tags in the body when not redirecting' do
+      call_attrs = attributes_for :call, status: :left_voicemail
+      post patient_calls_path(@patient),
+           params: { call: call_attrs },
+           headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should actually create a new call' do
+      call_attrs = attributes_for :call, status: :left_voicemail
+      assert_difference 'Patient.find(@patient.id).calls.count', 1 do
+        post patient_calls_path(@patient),
+             params: { call: call_attrs },
+             headers: TURBO_STREAM_ACCEPT
+      end
+    end
+
+    it 'should return bad_request for invalid status' do
+      [nil, 'not_a_real_status'].each do |bad_status|
+        call_attrs = attributes_for :call, status: bad_status
+        assert_no_difference 'Call.count' do
+          post patient_calls_path(@patient),
+               params: { call: call_attrs },
+               headers: TURBO_STREAM_ACCEPT
+        end
+        assert_response :bad_request
+      end
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      call_attrs = attributes_for :call, status: :left_voicemail
+      post patient_calls_path(@patient),
+           params: { call: call_attrs },
+           xhr: true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CallsController#destroy — turbo_stream (also phase-1, retested here)
+  # ---------------------------------------------------------------------------
+  describe 'calls#destroy turbo_stream responses' do
+    before do
+      with_versioning(@user) do
+        @patient.calls.create attributes_for(:call)
+      end
+      @call = @patient.calls.first
+    end
+
+    it 'should respond with turbo_stream format' do
+      delete patient_call_path(@patient, @call),
+             params: { id: @call.id },
+             headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      delete patient_call_path(@patient, @call),
+             params: { id: @call.id },
+             headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should return forbidden when user is not the creator' do
+      other_user = create :user
+      with_versioning(other_user) do
+        @patient.calls.create attributes_for(:call)
+      end
+      other_call = @patient.calls.last
+
+      delete patient_call_path(@patient, other_call),
+             params: { id: other_call.id },
+             headers: TURBO_STREAM_ACCEPT
+      assert_response :forbidden
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PatientsController#pledge — turbo_stream response
+  # ---------------------------------------------------------------------------
+  describe 'patients#pledge turbo_stream responses' do
+    it 'should respond with turbo_stream format' do
+      get submit_pledge_path(@patient),
+          headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      get submit_pledge_path(@patient),
+          headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      get submit_pledge_path(@patient), xhr: true
+      assert_response :success
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PatientsController#update — turbo_stream format added alongside js/json
+  # ---------------------------------------------------------------------------
+  describe 'patients#update turbo_stream responses' do
+    before do
+      @clinic = create :clinic
+      @payload = {
+        appointment_date: 5.days.from_now.to_date.strftime('%Y-%m-%d'),
+        name: 'Updated Patient Name',
+        fund_pledge: 200,
+        clinic_id: @clinic.id
+      }
+    end
+
+    it 'should respond with turbo_stream format on successful update' do
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include saved flash message in turbo response body' do
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            headers: TURBO_STREAM_ACCEPT
+      assert_includes response.body, 'saved'
+    end
+
+    it 'should actually update the patient record' do
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            headers: TURBO_STREAM_ACCEPT
+      @patient.reload
+      assert_equal 'Updated Patient Name', @patient.name
+    end
+
+    it 'should update last_edited_by' do
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            headers: TURBO_STREAM_ACCEPT
+      @patient.reload
+      assert_equal @user, @patient.last_edited_by
+    end
+
+    it 'should show error flash on validation failure via turbo_stream' do
+      @payload[:primary_phone] = nil
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            headers: TURBO_STREAM_ACCEPT
+      assert_includes response.body, 'alert'
+    end
+
+    it 'should redirect when patient record does not exist' do
+      patch patient_path('notanactualid'),
+            params: { patient: @payload }
+      assert_redirected_to root_path
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            xhr: true
+      assert_response :success
+      assert_includes response.body, 'saved'
+    end
+
+    it 'should still respond to json format' do
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            as: :json
+      assert_response :success
+      parsed = JSON.parse(response.body)
+      assert_not_nil parsed['patient']
+    end
+
+    it 'should ignore pledge fulfillment attributes for non-admin' do
+      @patient.update appointment_date: 5.days.from_now.to_date,
+                      clinic: @clinic,
+                      fund_pledge: 100
+      @payload[:fulfillment_attributes] = @patient.fulfillment.attributes
+      @payload[:fulfillment_attributes][:fund_payout] = 1_000
+      patch patient_path(@patient),
+            params: { patient: @payload },
+            headers: TURBO_STREAM_ACCEPT
+      assert_includes response.body, 'saved'
+      @patient.fulfillment.reload
+      assert_nil @patient.fulfillment.fund_payout
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PracticalSupportsController#edit — turbo_stream modal content
+  # ---------------------------------------------------------------------------
+  describe 'practical_supports#edit turbo_stream responses' do
+    before do
+      @patient.practical_supports.create support_type: 'Transit',
+                                         confirmed: false,
+                                         source: 'Transit'
+      @support = @patient.practical_supports.first
+    end
+
+    it 'should respond with turbo_stream format' do
+      get edit_patient_practical_support_path(@patient, @support),
+          headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      get edit_patient_practical_support_path(@patient, @support),
+          headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      get edit_patient_practical_support_path(@patient, @support), xhr: true
+      assert_response :success
+    end
+
+    it 'should respond not_found for nonexistent support' do
+      get edit_patient_practical_support_path(@patient, 'nonexistent'),
+          headers: TURBO_STREAM_ACCEPT
+      assert_response :not_found
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # UsersController#search — turbo_stream response (admin only)
+  # ---------------------------------------------------------------------------
+  describe 'users#search turbo_stream responses' do
+    before do
+      @admin = create :user, role: :admin
+      delete destroy_user_session_path
+      sign_in @admin
+    end
+
+    it 'should respond with turbo_stream format' do
+      post users_search_path,
+           params: { search: @user.name },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+      assert_includes response.media_type, 'turbo-stream'
+    end
+
+    it 'should include turbo-stream tags in the response body' do
+      post users_search_path,
+           params: { search: @user.name },
+           headers: TURBO_STREAM_ACCEPT
+      assert_match(/<turbo-stream/, response.body)
+    end
+
+    it 'should return results for empty search (all users)' do
+      post users_search_path,
+           params: { search: '' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :success
+    end
+
+    it 'should return unauthorized for non-admin users' do
+      delete destroy_user_session_path
+      sign_in @user  # regular CM user
+
+      post users_search_path,
+           params: { search: 'test' },
+           headers: TURBO_STREAM_ACCEPT
+      assert_response :unauthorized
+    end
+
+    it 'should still respond to xhr (js) format for backward compatibility' do
+      post users_search_path,
+           params: { search: @user.name },
+           xhr: true
+      assert_response :success
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,6 +2022,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hotwired/stimulus@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@hotwired/stimulus@npm:3.2.2"
+  checksum: 10/31b9dc3a36a73b87a30570d6e73d27b387a8f6c3caf934aedc4dc96e5b40dde8fc36d530e16056b3d590b1d31b8a13bc1fca002e83df838f1bf5148b188046de
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo-rails@npm:^8.0.23":
+  version: 8.0.23
+  resolution: "@hotwired/turbo-rails@npm:8.0.23"
+  dependencies:
+    "@hotwired/turbo": "npm:^8.0.23"
+    "@rails/actioncable": "npm:>=7.0"
+  checksum: 10/df46c983bb4f49fffcd088d71a607314a707093542fff8b47a768e64faf8ca3d604b034d8c2e458678badc050515c591f12cb21def9c7dfd38b9b3a34a0ca44d
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo@npm:^8.0.23":
+  version: 8.0.23
+  resolution: "@hotwired/turbo@npm:8.0.23"
+  checksum: 10/ea6a07306762a7b85ebabb2bbd339d939bb8329fcf8631e7646e9d890f9a05a2ba19ee4666a40fb51f3789548271357cf8a868d335e3f7d953a7b31a70615605
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -2605,6 +2629,13 @@ __metadata:
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10/ddd16090cde777aaf102940f05d0274602079a95ad9805bd20bc55dcc7c3a2ba1b99dd5c73e5cc2753c3d31250ca52a67d58059459d7d27debb983a9f552936c
+  languageName: node
+  linkType: hard
+
+"@rails/actioncable@npm:>=7.0":
+  version: 8.1.300
+  resolution: "@rails/actioncable@npm:8.1.300"
+  checksum: 10/9a8682b9d311ded0cf3a6fcb581fdcde8e21e16dba375a854cb6adb38167dbe06ccac6ca5a4edcdf55accc9396fcbd5dc0aa8b4605427c9f0ee9c5b4e687bfed
   languageName: node
   linkType: hard
 
@@ -9231,6 +9262,8 @@ __metadata:
     "@babel/preset-env": "npm:^7.28.0"
     "@babel/preset-react": "npm:^7.27.1"
     "@fortawesome/fontawesome-free": "npm:6.7.2"
+    "@hotwired/stimulus": "npm:^3.2.2"
+    "@hotwired/turbo-rails": "npm:^8.0.23"
     "@popperjs/core": "npm:2.11.8"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.6.4"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This is Phase 3 of the Turbo migration. It converts the remaining complex JavaScript response templates into Turbo Stream equivalents, continuing the move away from legacy UJS patterns.

This pull request makes the following changes:
* Convert complex `.js.erb` response templates to `.turbo_stream.erb` format
* Fix collapsed formatting in dashboards_controller

**Notes:**
* **Depends on** #3522 (Phase 1) and #3523 (Phase 2) being merged first.
* **Merge order:** `#3522` → `#3523` → `#3524` → `#3525`.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
