### PR TITLE
Upgrade Devise from 4.9 to 5.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,9 @@ gem 'jsbundling-rails'
 gem 'bootstrap_form', '~> 4.5.0'
 
 # Our authentication library is devise, with oauth2 for google signin
-gem 'devise', '~> 4.9'
+gem 'devise', '~> 5.0'
 gem 'devise-security'
+gem 'responders' # Required for respond_with in Devise controllers (was Devise 4.x dep, removed in 5.0)
 gem 'omniauth-google-oauth2', '~> 1.2.1'
 gem 'omniauth-rails_csrf_protection', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,10 +131,10 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (4.9.4)
+    devise (5.0.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     devise-security (0.18.0)
@@ -575,7 +575,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
-  devise (~> 4.9)
+  devise (~> 5.0)
   devise-security
   dotenv-rails
   factory_bot_rails
@@ -611,6 +611,7 @@ DEPENDENCIES
   rails-html-sanitizer (>= 1.4.3)
   rails-i18n (~> 8.0)
   render_async (~> 2.1)
+  responders
   rubocop-rails-omakase
   ruby_audit
   selenium-webdriver


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This upgrades Devise (the authentication library) from version 4.9 to 5.0.3, picking up security fixes and compatibility improvements for the login and session management system.

This pull request makes the following changes:
* Update Devise gem constraint in Gemfile from 4.9 to 5.0.3

**Notes:**
* **Depends on** #3522 (Turbo Phase 1) and #3528 (Ruby 4.0.2) for lockfile compatibility.
* **Merge order:** `#3522` → `#3528` → `#3530` (lockfile chain).
* **Before merging:** Gemfile.lock must be regenerated via `docker compose run --rm web bundle install`.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
