### PR TITLE
Upgrade OpenSSL to 3.5.5 LTS in Docker build

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Colin Fleming <c3flemin@gmail.com>
 # configure environment variable
 # note: move this to three ARG commands when CircleCI updates their docker
 ENV DARIA_DIR=/usr/src/app \
-    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig postgresql libpq-dev libyaml-dev" \
+    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig postgresql libpq-dev libyaml-dev perl wget" \
     APP_DEPENDENCIES="git sudo sassc" \
     AHAB_DEPENDENCIES="ca-certificates curl" \
     FONTCONFIG_PATH=/etc/fonts \
@@ -25,8 +25,7 @@ RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
     ${BUILD_DEPENDENCIES} \
     ${APP_DEPENDENCIES} \
-    ${AHAB_DEPENDENCIES} \
-    perl wget && \
+    ${AHAB_DEPENDENCIES} && \
     gem install bundler --no-document
 
 # Build and install OpenSSL 3.5.5 LTS from source (replaces system OpenSSL 3.0.x)

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -39,6 +39,9 @@ RUN cd /tmp && \
     ldconfig && \
     cd / && rm -rf /tmp/openssl-${OPENSSL_VERSION}*
 
+# Ensure all processes use the compiled OpenSSL 3.5.5 instead of system OpenSSL
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
 # Rebuild Ruby's openssl gem against the new OpenSSL 3.5.5
 RUN gem install openssl -- --with-openssl-dir=/usr/local
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -10,7 +10,8 @@ ENV DARIA_DIR=/usr/src/app \
     FONTCONFIG_PATH=/etc/fonts \
     NODE_ENV=development \
     DOCKER=true \
-    NODE_MAJOR=24
+    NODE_MAJOR=24 \
+    OPENSSL_VERSION=3.5.5
 
 # get our gem house in order
 WORKDIR ${DARIA_DIR}
@@ -24,8 +25,23 @@ RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
     ${BUILD_DEPENDENCIES} \
     ${APP_DEPENDENCIES} \
-    ${AHAB_DEPENDENCIES} && \
+    ${AHAB_DEPENDENCIES} \
+    perl wget && \
     gem install bundler --no-document
+
+# Build and install OpenSSL 3.5.5 LTS from source (replaces system OpenSSL 3.0.x)
+RUN cd /tmp && \
+    wget -q https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz && \
+    tar xzf openssl-${OPENSSL_VERSION}.tar.gz && \
+    cd openssl-${OPENSSL_VERSION} && \
+    ./Configure --prefix=/usr/local --libdir=lib --openssldir=/usr/local/ssl && \
+    make -j$(nproc) && \
+    make install_sw && \
+    ldconfig && \
+    cd / && rm -rf /tmp/openssl-${OPENSSL_VERSION}*
+
+# Rebuild Ruby's openssl gem against the new OpenSSL 3.5.5
+RUN gem install openssl -- --with-openssl-dir=/usr/local
 
 # nodejs installation
 RUN mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This upgrades OpenSSL to 3.5.5 LTS in the Docker image, which is required for post-quantum cryptography support and ensures the app uses the latest long-term-support security library.

This pull request makes the following changes:
* Add `OPENSSL_VERSION=3.5.5` env var to Dockerfile
* Download, compile, and install OpenSSL 3.5.5 from source in the Docker build
* Rebuild Ruby's openssl gem against the new OpenSSL
* Move build-only dependencies (`perl`, `wget`) to `BUILD_DEPENDENCIES` for cleanup in the final image stage

**Notes:**
* **Merge order:** This is independent, but must merge before #3548 (PQC hybrid key wrapping), which needs ML-KEM-1024 support only available in OpenSSL 3.5+. Merge order: `#3531` → `#3548`.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
