### PR TITLE
Upgrade Bootstrap from 4.6.2 to 5.3.8 (comprehensive migration)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'i18n-js', '~> 4.2' # Export i18n translations to JSON
 # Asset pipeline
 gem 'sprockets-rails'
 gem 'jsbundling-rails'
-gem 'bootstrap_form', '~> 4.5.0'
+gem 'bootstrap_form', '~> 5.6.0'
 
 # Our authentication library is devise, with oauth2 for google signin
 gem 'devise', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    bootstrap_form (4.5.0)
-      actionpack (>= 5.2)
-      activemodel (>= 5.2)
+    bootstrap_form (5.6.0)
+      actionpack (>= 7.2)
+      activemodel (>= 7.2)
     brakeman (7.1.2)
       racc
     builder (3.3.0)
@@ -567,7 +567,7 @@ DEPENDENCIES
   activerecord-session_store
   acts_as_tenant (~> 0.6)
   bootsnap
-  bootstrap_form (~> 4.5.0)
+  bootstrap_form (~> 5.6.0)
   brakeman
   bullet
   bundler-audit

--- a/app/assets/stylesheets/styles/lines.scss
+++ b/app/assets/stylesheets/styles/lines.scss
@@ -16,6 +16,6 @@
   }
 
   .form-check-label {
-    @extend .ml-5;
+    @extend .ms-5;
   }
 }

--- a/app/assets/stylesheets/styles/navbar.scss
+++ b/app/assets/stylesheets/styles/navbar.scss
@@ -3,7 +3,7 @@
 @use "sass:color";
 @use './_variables';
 
-.navbar-inverse{
+.navbar-dark{
   background-color: variables.$light-gray;
   border: none;
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,7 @@ import './src/jquery';
 import {} from 'jquery-ujs'
 import './src/jquery-ui';
 import * as bootstrap from "bootstrap";
+window.bootstrap = bootstrap; // Expose for .js.erb inline scripts
 
 // Vendor
 import './src/vendor/jquery-bootstrap-modal-steps.min';

--- a/app/javascript/src/__tests__/bootstrap5_tooltips.test.js
+++ b/app/javascript/src/__tests__/bootstrap5_tooltips.test.js
@@ -1,0 +1,189 @@
+/**
+ * Tests for Bootstrap 5 tooltip initialization (tooltips.js)
+ * Verifies BS5 native Tooltip API usage instead of jQuery .tooltip()
+ */
+import { activateTooltips } from '../../app/javascript/src/tooltips';
+
+// Mock the bootstrap module with Tooltip class
+const mockTooltipInstance = { dispose: jest.fn() };
+const mockGetInstance = jest.fn();
+const MockTooltipConstructor = jest.fn(() => mockTooltipInstance);
+MockTooltipConstructor.getInstance = mockGetInstance;
+
+jest.mock('bootstrap', () => ({
+  Tooltip: MockTooltipConstructor,
+}));
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  jest.clearAllMocks();
+  mockGetInstance.mockReturnValue(null);
+});
+
+describe('activateTooltips — Bootstrap 5 native API', () => {
+  describe('.daria-tooltip elements', () => {
+    it('creates a new bootstrap.Tooltip for each .daria-tooltip element', () => {
+      document.body.innerHTML = `
+        <span class="daria-tooltip">Tip 1</span>
+        <span class="daria-tooltip">Tip 2</span>
+      `;
+
+      activateTooltips();
+
+      expect(MockTooltipConstructor).toHaveBeenCalledTimes(2);
+      const firstEl = document.querySelectorAll('.daria-tooltip')[0];
+      expect(MockTooltipConstructor).toHaveBeenCalledWith(firstEl);
+    });
+
+    it('skips elements that already have a Tooltip instance (getInstance check)', () => {
+      document.body.innerHTML = '<span class="daria-tooltip">Tip</span>';
+      mockGetInstance.mockReturnValue(mockTooltipInstance);
+
+      activateTooltips();
+
+      expect(MockTooltipConstructor).not.toHaveBeenCalled();
+    });
+
+    it('handles zero .daria-tooltip elements gracefully', () => {
+      document.body.innerHTML = '<div>No tooltips here</div>';
+
+      activateTooltips();
+
+      expect(MockTooltipConstructor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('.tooltip-header-input elements', () => {
+    it('injects a help span and creates Tooltip on input labels', () => {
+      document.body.innerHTML = `
+        <div class="mb-3">
+          <label class="tooltip-header-input">Label</label>
+          <input class="form-control" data-tooltip-text="Help text" />
+        </div>
+      `;
+
+      activateTooltips();
+
+      const helpSpan = document.querySelector('.tooltip-header-help');
+      expect(helpSpan).not.toBeNull();
+      expect(helpSpan.textContent).toBe('(?)');
+      expect(MockTooltipConstructor).toHaveBeenCalledWith(helpSpan, {
+        html: true,
+        placement: 'bottom',
+        title: 'Help text',
+      });
+    });
+
+    it('does not double-inject help span if already present', () => {
+      document.body.innerHTML = `
+        <div class="mb-3">
+          <label class="tooltip-header-input">
+            Label <span class="tooltip-header-help">(?)</span>
+          </label>
+          <input class="form-control" data-tooltip-text="Help text" />
+        </div>
+      `;
+
+      activateTooltips();
+
+      const helpSpans = document.querySelectorAll('.tooltip-header-help');
+      expect(helpSpans).toHaveLength(1);
+    });
+
+    it('does not create Tooltip if no .form-control input exists', () => {
+      document.body.innerHTML = `
+        <div class="mb-3">
+          <label class="tooltip-header-input">Label</label>
+        </div>
+      `;
+
+      activateTooltips();
+
+      // Help span injected but no Tooltip created since no input
+      expect(MockTooltipConstructor).not.toHaveBeenCalled();
+    });
+
+    it('skips labels not inside a .mb-3 or .form-group container', () => {
+      document.body.innerHTML = `
+        <div>
+          <label class="tooltip-header-input">Orphan label</label>
+          <input class="form-control" data-tooltip-text="Help text" />
+        </div>
+      `;
+
+      activateTooltips();
+
+      // Help span injected but no Tooltip since no .mb-3/.form-group ancestor
+      expect(MockTooltipConstructor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('.tooltip-header-checkbox elements', () => {
+    it('injects a help span and creates Tooltip on checkbox labels', () => {
+      document.body.innerHTML = `
+        <div>
+          <label class="tooltip-header-checkbox">Check</label>
+          <input type="checkbox" data-tooltip-text="Checkbox help" />
+          <span class="tooltip-header-help">(?)</span>
+        </div>
+      `;
+
+      // Clear to account for the injected span logic
+      jest.clearAllMocks();
+      mockGetInstance.mockReturnValue(null);
+
+      activateTooltips();
+
+      expect(MockTooltipConstructor).toHaveBeenCalledWith(
+        expect.any(Element),
+        expect.objectContaining({
+          html: true,
+          placement: 'bottom',
+          title: 'Checkbox help',
+        })
+      );
+    });
+
+    it('does not create Tooltip when help span already has an instance', () => {
+      document.body.innerHTML = `
+        <div>
+          <label class="tooltip-header-checkbox">Check</label>
+          <input type="checkbox" data-tooltip-text="Checkbox help" />
+          <span class="tooltip-header-help">(?)</span>
+        </div>
+      `;
+      mockGetInstance.mockReturnValue(mockTooltipInstance);
+
+      activateTooltips();
+
+      // getInstance returns truthy, so constructor should not be called for
+      // any checkbox tooltip (daria-tooltip also skipped)
+      expect(MockTooltipConstructor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('event listener registration', () => {
+    it('registers activateTooltips on DOMContentLoaded', () => {
+      const spy = jest.spyOn(document, 'addEventListener');
+      // Re-import to trigger the module-level addEventListener calls
+      jest.isolateModules(() => {
+        require('../../app/javascript/src/tooltips');
+      });
+
+      const calls = spy.mock.calls.map(([event]) => event);
+      expect(calls).toContain('DOMContentLoaded');
+      spy.mockRestore();
+    });
+
+    it('registers activateTooltips on show.bs.modal', () => {
+      const spy = jest.spyOn(document, 'addEventListener');
+      jest.isolateModules(() => {
+        require('../../app/javascript/src/tooltips');
+      });
+
+      const calls = spy.mock.calls.map(([event]) => event);
+      expect(calls).toContain('show.bs.modal');
+      spy.mockRestore();
+    });
+  });
+});

--- a/app/javascript/src/__tests__/components/Tooltip.test.jsx
+++ b/app/javascript/src/__tests__/components/Tooltip.test.jsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for the Bootstrap 5 Tooltip React component (Tooltip.jsx)
+ * Verifies data-bs-* attributes (BS5) instead of data-* (BS4)
+ */
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import Tooltip from "../../app/javascript/src/components/Tooltip";
+
+jest.mock("../../app/javascript/src/tooltips", () => ({
+  activateTooltips: jest.fn(),
+}));
+
+const { activateTooltips } = require("../../app/javascript/src/tooltips");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Tooltip (Bootstrap 5)", () => {
+  it("renders the (?) help indicator", () => {
+    render(<Tooltip text="some helper text" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it("uses data-bs-toggle instead of data-toggle (BS5 migration)", () => {
+    render(<Tooltip text="some helper text" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toHaveAttribute("data-bs-toggle", "tooltip");
+    expect(tooltip).not.toHaveAttribute("data-toggle");
+  });
+
+  it("uses data-bs-html instead of data-html", () => {
+    render(<Tooltip text="some helper text" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toHaveAttribute("data-bs-html", "true");
+    expect(tooltip).not.toHaveAttribute("data-html");
+  });
+
+  it("uses data-bs-placement instead of data-placement", () => {
+    render(<Tooltip text="some helper text" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toHaveAttribute("data-bs-placement", "bottom");
+    expect(tooltip).not.toHaveAttribute("data-placement");
+  });
+
+  it("uses data-bs-title instead of data-title", () => {
+    render(<Tooltip text="some helper text" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toHaveAttribute("data-bs-title", "some helper text");
+    expect(tooltip).not.toHaveAttribute("data-title");
+  });
+
+  it("applies the correct CSS classes", () => {
+    render(<Tooltip text="some helper text" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toHaveClass("daria-tooltip");
+    expect(tooltip).toHaveClass("tooltip-header-help");
+  });
+
+  it("renders as a span element", () => {
+    render(<Tooltip text="some helper text" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip.tagName).toBe("SPAN");
+  });
+
+  it("calls activateTooltips on mount", () => {
+    render(<Tooltip text="some helper text" />);
+    expect(activateTooltips).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call activateTooltips again on re-render", () => {
+    const { rerender } = render(<Tooltip text="first" />);
+    rerender(<Tooltip text="second" />);
+    expect(activateTooltips).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes different text props correctly", () => {
+    render(<Tooltip text="<b>Bold help</b>" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toHaveAttribute("data-bs-title", "<b>Bold help</b>");
+  });
+
+  it("handles empty text prop", () => {
+    render(<Tooltip text="" />);
+    const tooltip = screen.getByText("(?)");
+    expect(tooltip).toHaveAttribute("data-bs-title", "");
+  });
+});

--- a/app/javascript/src/__tests__/components/bootstrap5_components.test.js
+++ b/app/javascript/src/__tests__/components/bootstrap5_components.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tests for Bootstrap 5 accessibility class migration in Input and Select.
+ * BS4 used "sr-only"; BS5 uses "visually-hidden".
+ */
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import Input from "../../app/javascript/src/components/Input";
+import Select from "../../app/javascript/src/components/Select";
+
+describe("Input — Bootstrap 5 visually-hidden migration", () => {
+  it("adds mt-6 to input when labelClassName includes 'visually-hidden'", () => {
+    render(
+      <Input
+        name="input"
+        id="input"
+        label="Hidden Label"
+        labelClassName="visually-hidden"
+      />
+    );
+    const input = screen.getByLabelText("Hidden Label");
+    expect(input.className).toMatch(/mt-6/);
+  });
+
+  it("does NOT add mt-6 when labelClassName is 'sr-only' (old BS4 class)", () => {
+    render(
+      <Input
+        name="input"
+        id="input"
+        label="SR Label"
+        labelClassName="sr-only"
+      />
+    );
+    const input = screen.getByLabelText("SR Label");
+    expect(input.className).not.toMatch(/mt-6/);
+  });
+
+  it("does NOT add mt-6 when no labelClassName is provided", () => {
+    render(<Input name="input" id="input" label="Visible Label" />);
+    const input = screen.getByLabelText("Visible Label");
+    expect(input.className).not.toMatch(/mt-6/);
+  });
+
+  it("applies visually-hidden class to the label element", () => {
+    render(
+      <Input
+        name="input"
+        id="input"
+        label="Hidden"
+        labelClassName="visually-hidden"
+      />
+    );
+    const label = screen.getByText("Hidden");
+    expect(label.className).toMatch(/visually-hidden/);
+  });
+
+  it("preserves required class alongside visually-hidden", () => {
+    render(
+      <Input
+        name="input"
+        id="input"
+        label="Both"
+        labelClassName="visually-hidden"
+        required={true}
+      />
+    );
+    const label = screen.getByText("Both");
+    expect(label.className).toMatch(/required/);
+    expect(label.className).toMatch(/visually-hidden/);
+  });
+
+  it("does NOT add mt-6 for unrelated labelClassName values", () => {
+    render(
+      <Input
+        name="input"
+        id="input"
+        label="Custom"
+        labelClassName="custom-class"
+      />
+    );
+    const input = screen.getByLabelText("Custom");
+    expect(input.className).not.toMatch(/mt-6/);
+  });
+});
+
+describe("Select — Bootstrap 5 visually-hidden migration", () => {
+  const options = [
+    { label: "One", value: 1 },
+    { label: "Two", value: 2 },
+  ];
+
+  it("adds mt-6 to select when labelClassName includes 'visually-hidden'", () => {
+    render(
+      <Select
+        name="select"
+        id="select"
+        label="Hidden Label"
+        options={options}
+        labelClassName="visually-hidden"
+      />
+    );
+    const select = screen.getByLabelText("Hidden Label");
+    expect(select.className).toMatch(/mt-6/);
+  });
+
+  it("does NOT add mt-6 when labelClassName is 'sr-only' (old BS4 class)", () => {
+    render(
+      <Select
+        name="select"
+        id="select"
+        label="SR Label"
+        options={options}
+        labelClassName="sr-only"
+      />
+    );
+    const select = screen.getByLabelText("SR Label");
+    expect(select.className).not.toMatch(/mt-6/);
+  });
+
+  it("does NOT add mt-6 when no labelClassName is provided", () => {
+    render(
+      <Select
+        name="select"
+        id="select"
+        label="Visible"
+        options={options}
+      />
+    );
+    const select = screen.getByLabelText("Visible");
+    expect(select.className).not.toMatch(/mt-6/);
+  });
+
+  it("applies visually-hidden class to the label element", () => {
+    render(
+      <Select
+        name="select"
+        id="select"
+        label="Hidden"
+        options={options}
+        labelClassName="visually-hidden"
+      />
+    );
+    const label = screen.getByText("Hidden");
+    expect(label.className).toMatch(/visually-hidden/);
+  });
+
+  it("preserves required class alongside visually-hidden", () => {
+    render(
+      <Select
+        name="select"
+        id="select"
+        label="Both"
+        options={options}
+        labelClassName="visually-hidden"
+        required={true}
+      />
+    );
+    const label = screen.getByText("Both");
+    expect(label.className).toMatch(/required/);
+    expect(label.className).toMatch(/visually-hidden/);
+  });
+});

--- a/app/javascript/src/components/Input.jsx
+++ b/app/javascript/src/components/Input.jsx
@@ -17,7 +17,7 @@ export default Input = ({
 }) => {
   const [value, setValue] = useState(initialValue || "")
   const labelClassNames = `${required ? 'required' : ''} ${labelClassName || ''}`
-  const inputClassNames = `form-control ${className || ''} ${labelClassNames.includes('sr-only') ? 'mt-6' : ''}`
+  const inputClassNames = `form-control ${className || ''} ${labelClassNames.includes('visually-hidden') ? 'mt-6' : ''}`
 
   const handleChange = (e) => {
     setValue(e.target.value)

--- a/app/javascript/src/components/PatientDashboardForm.jsx
+++ b/app/javascript/src/components/PatientDashboardForm.jsx
@@ -86,7 +86,7 @@ export default PatientDashboardForm = ({
           id="patient_last_menstrual_period_days"
           name="patient[last_menstrual_period_days]"
           label={i18n.t('common.days_along')}
-          labelClassName="sr-only"
+          labelClassName="visually-hidden"
           options={daysOptions}
           value={weeksOptions.find(opt => opt.value === patientData.last_menstrual_period_days)?.value}
           help={i18n.t('patient.dashboard.called_on', { date: initialCallDate })}

--- a/app/javascript/src/components/Select.jsx
+++ b/app/javascript/src/components/Select.jsx
@@ -14,7 +14,7 @@ export default Select = ({
   ...props
 }) => {
   const labelClassNames = `${required ? 'required' : ''} ${labelClassName || ''}`
-  const selectClassNames = `form-control ${className || ''} ${labelClassNames.includes('sr-only') ? 'mt-6' : ''}`
+  const selectClassNames = `form-control ${className || ''} ${labelClassNames.includes('visually-hidden') ? 'mt-6' : ''}`
 
   if (!!onChange) {
     props["value"] = value || ""

--- a/app/javascript/src/components/Tooltip.jsx
+++ b/app/javascript/src/components/Tooltip.jsx
@@ -7,7 +7,7 @@ export default Tooltip = ({text}) => {
   }, [])
 
   return (
-    <span className="daria-tooltip tooltip-header-help" data-toggle="tooltip" data-html={true} data-placement="bottom" data-title={text}>
+    <span className="daria-tooltip tooltip-header-help" data-bs-toggle="tooltip" data-bs-html={true} data-bs-placement="bottom" data-bs-title={text}>
       {' '}(?)
     </span>
   )

--- a/app/javascript/src/components/__tests__/Input.test.js
+++ b/app/javascript/src/components/__tests__/Input.test.js
@@ -40,10 +40,10 @@ describe("Input", () => {
 
   it("adds classes to the label when labelClassName is provided", () => {
     render(
-      <Input name="input" id="input" label="Input" labelClassName="sr-only" />
+      <Input name="input" id="input" label="Input" labelClassName="visually-hidden" />
     );
     const label = screen.queryByText("Input");
-    expect(label).toHaveAttribute("class", expect.stringMatching(/sr-only/));
+    expect(label).toHaveAttribute("class", expect.stringMatching(/visually-hidden/));
   });
 
   it("calls the onChange handler", async () => {

--- a/app/javascript/src/components/__tests__/Select.test.js
+++ b/app/javascript/src/components/__tests__/Select.test.js
@@ -61,11 +61,11 @@ describe("Select", () => {
         id="select"
         label="Select"
         options={options}
-        labelClassName="sr-only"
+        labelClassName="visually-hidden"
       />
     );
     const label = screen.queryByText("Select");
-    expect(label).toHaveAttribute("class", expect.stringMatching(/sr-only/));
+    expect(label).toHaveAttribute("class", expect.stringMatching(/visually-hidden/));
   });
 
   it("renders an uncontrolled select when no onChange handler is provided", async () => {

--- a/app/javascript/src/components/__tests__/Tooltip.test.js
+++ b/app/javascript/src/components/__tests__/Tooltip.test.js
@@ -11,9 +11,9 @@ describe("Tooltip", () => {
     render(<Tooltip text="some helper text" />);
     const tooltip = screen.getByText("(?)");
     expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveAttribute("data-toggle", "tooltip");
-    expect(tooltip).toHaveAttribute("data-html", "true");
-    expect(tooltip).toHaveAttribute("data-placement", "bottom");
-    expect(tooltip).toHaveAttribute("data-title", "some helper text");
+    expect(tooltip).toHaveAttribute("data-bs-toggle", "tooltip");
+    expect(tooltip).toHaveAttribute("data-bs-html", "true");
+    expect(tooltip).toHaveAttribute("data-bs-placement", "bottom");
+    expect(tooltip).toHaveAttribute("data-bs-title", "some helper text");
   });
 });

--- a/app/javascript/src/hooks/useFlash.js
+++ b/app/javascript/src/hooks/useFlash.js
@@ -12,7 +12,7 @@ export default function () {
         const alertClassName = notice ? "alert-success" : "alert-danger";
         const flashHtml = `<div class="col-sm-10 flash-message">
           <div class="alert ${alertClassName}">
-            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-hidden="true"></button>
             ${text}
           </div>
         </div>`;

--- a/app/javascript/src/tooltips.js
+++ b/app/javascript/src/tooltips.js
@@ -1,30 +1,50 @@
 // Helper tooltips.
+import * as bootstrap from 'bootstrap';
+
 export const activateTooltips = () => {
-  // Regular spans
-  $('.daria-tooltip').tooltip();
+  // Regular spans — use Bootstrap 5 native API
+  document.querySelectorAll('.daria-tooltip').forEach(el => {
+    if (!bootstrap.Tooltip.getInstance(el)) {
+      new bootstrap.Tooltip(el);
+    }
+  });
 
   // Some evil magic for things attached to labels with rails-bootstrap-form
-  $(".tooltip-header-input:not(:has(span.tooltip-header-help))").append(' <span class="tooltip-header-help">(?)</span>');
-  $('.tooltip-header-input').parent('.form-group' ).find('.form-control').each((_, x) => {
-    $(x).parents( '.form-group' ).find( '.tooltip-header-help' ).tooltip({
-      html: true,
-      placement: 'bottom',
-      title: $(x).data('tooltip-text')
-    });
+  document.querySelectorAll(".tooltip-header-input:not(:has(span.tooltip-header-help))").forEach(el => {
+    el.insertAdjacentHTML('beforeend', ' <span class="tooltip-header-help">(?)</span>');
+  });
+  document.querySelectorAll('.tooltip-header-input').forEach(label => {
+    const formGroup = label.closest('.mb-3') || label.closest('.form-group');
+    if (!formGroup) return;
+    const input = formGroup.querySelector('.form-control');
+    if (!input) return;
+    const helpSpan = formGroup.querySelector('.tooltip-header-help');
+    if (helpSpan && !bootstrap.Tooltip.getInstance(helpSpan)) {
+      new bootstrap.Tooltip(helpSpan, {
+        html: true,
+        placement: 'bottom',
+        title: input.dataset.tooltipText
+      });
+    }
   });
 
   // Similarly evil magic for checkboxes
-  $(".tooltip-header-checkbox:not(:has(span.tooltip-header-help))").append(' <span class="tooltip-header-help">(?)</span>')
-  $('.tooltip-header-checkbox').each((_, x) => {
-    let text = $(x).parent().find('input[type=checkbox]').data('tooltip-text');
-    $(x).parent().find( 'span.tooltip-header-help' ).tooltip({
-      html: true,
-      placement: 'bottom',
-      title: text,
-    });
+  document.querySelectorAll(".tooltip-header-checkbox:not(:has(span.tooltip-header-help))").forEach(el => {
+    el.insertAdjacentHTML('beforeend', ' <span class="tooltip-header-help">(?)</span>');
+  });
+  document.querySelectorAll('.tooltip-header-checkbox').forEach(el => {
+    const checkbox = el.parentElement?.querySelector('input[type=checkbox]');
+    const helpSpan = el.parentElement?.querySelector('span.tooltip-header-help');
+    if (checkbox && helpSpan && !bootstrap.Tooltip.getInstance(helpSpan)) {
+      new bootstrap.Tooltip(helpSpan, {
+        html: true,
+        placement: 'bottom',
+        title: checkbox.dataset.tooltipText,
+      });
+    }
   });
 
 };
 
-$(document).on('DOMContentLoaded', activateTooltips);
-$('.modal').on('show.bs.modal', activateTooltips);
+document.addEventListener('DOMContentLoaded', activateTooltips);
+document.addEventListener('show.bs.modal', activateTooltips);

--- a/app/javascript/src/vendor/jquery-bootstrap-modal-steps.min.js
+++ b/app/javascript/src/vendor/jquery-bootstrap-modal-steps.min.js
@@ -1,1 +1,152 @@
-!function(a){"use strict";a.fn.modalSteps=function(b){var c=this,d=a.extend({btnCancelHtml:"Cancel",btnPreviousHtml:"Previous",btnNextHtml:"Next",btnLastStepHtml:"Complete",disableNextButton:!1,completeCallback:function(){},callbacks:{}},b),e=function(){var a=d.callbacks["*"];if(void 0!==a&&"function"!=typeof a)throw"everyStepCallback is not a function! I need a function";if("function"!=typeof d.completeCallback)throw"completeCallback is not a function! I need a function";for(var b in d.callbacks)if(d.callbacks.hasOwnProperty(b)){var c=d.callbacks[b];if("*"!==b&&void 0!==c&&"function"!=typeof c)throw"Step "+b+" callback must be a function"}},f=function(a){return void 0!==a&&"function"==typeof a?(a(),!0):!1};return c.on("show.bs.modal",function(){var b,g,h,i,j,k=c.find(".modal-footer"),l=k.find(".js-btn-step[data-orientation=cancel]"),m=k.find(".js-btn-step[data-orientation=previous]"),n=k.find(".js-btn-step[data-orientation=next]"),o=d.callbacks["*"],p=d.callbacks[1];d.disableNextButton&&n.attr("disabled","disabled"),m.attr("disabled","disabled"),e(),f(o),f(p),l.html(d.btnCancelHtml),m.html(d.btnPreviousHtml),n.html(d.btnNextHtml),g=a("<input>").attr({type:"hidden",id:"actual-step",value:"1"}),c.find("#actual-step").remove(),c.append(g),b=1,j=b+1,c.find("[data-step="+b+"]").removeClass("hide"),n.attr("data-step",j),h=c.find("[data-step="+b+"]").data("title"),i=a("<span>").addClass("label label-success").html(b),c.find(".js-title-step").append(i).append(" "+h)}).on("hidden.bs.modal",function(){var a=c.find("#actual-step"),b=c.find(".js-btn-step[data-orientation=next]");c.find("[data-step]").not(c.find(".js-btn-step")).addClass("hide"),a.not(c.find(".js-btn-step")).remove(),b.attr("data-step",1).html(d.btnNextHtml),c.find(".js-title-step").html("")}),c.find(".js-btn-step").on("click",function(){var b,e,g,h,i=a(this),j=c.find("#actual-step"),k=c.find(".js-btn-step[data-orientation=previous]"),l=c.find(".js-btn-step[data-orientation=next]"),m=c.find(".js-title-step"),n=i.data("orientation"),o=parseInt(j.val()),p=d.callbacks["*"];if(b=c.find("div[data-step]").length,"complete"===i.attr("data-step"))return d.completeCallback(),void c.modal("hide");if("next"===n)e=o+1,k.attr("data-step",o),j.val(e);else{if("previous"!==n)return void c.modal("hide");e=o-1,l.attr("data-step",o),k.attr("data-step",e-1),j.val(o-1)}parseInt(j.val())===b?l.attr("data-step","complete").html(d.btnLastStepHtml):l.attr("data-step",e).html(d.btnNextHtml),d.disableNextButton&&l.attr("disabled","disabled"),c.find("[data-step="+o+"]").not(c.find(".js-btn-step")).addClass("hide"),c.find("[data-step="+e+"]").not(c.find(".js-btn-step")).removeClass("hide"),parseInt(k.attr("data-step"))>0?k.removeAttr("disabled"):k.attr("disabled","disabled"),"previous"===n&&l.removeAttr("disabled"),g=c.find("[data-step="+e+"]"),g.attr("data-unlock-continue")&&l.removeAttr("disabled"),h=g.attr("data-title");var q=a("<span>").addClass("label label-success").html(e);m.html(q).append(" "+h);var r=d.callbacks[j.val()];f(p),f(r)}),this}}(jQuery);
+// Bootstrap 5 compatible modal steps plugin (migrated from jQuery BS4 version).
+// Replaces $.fn.modal('hide') calls with bootstrap.Modal API.
+!function($) {
+  "use strict";
+
+  $.fn.modalSteps = function(options) {
+    var modal = this;
+    var settings = $.extend({
+      btnCancelHtml: "Cancel",
+      btnPreviousHtml: "Previous",
+      btnNextHtml: "Next",
+      btnLastStepHtml: "Complete",
+      disableNextButton: false,
+      completeCallback: function() {},
+      callbacks: {}
+    }, options);
+
+    var validateCallbacks = function() {
+      var everyStepCb = settings.callbacks["*"];
+      if (everyStepCb !== undefined && typeof everyStepCb !== "function")
+        throw "everyStepCallback is not a function! I need a function";
+      if (typeof settings.completeCallback !== "function")
+        throw "completeCallback is not a function! I need a function";
+      for (var key in settings.callbacks) {
+        if (settings.callbacks.hasOwnProperty(key)) {
+          var cb = settings.callbacks[key];
+          if (key !== "*" && cb !== undefined && typeof cb !== "function")
+            throw "Step " + key + " callback must be a function";
+        }
+      }
+    };
+
+    var execCb = function(cb) {
+      if (cb !== undefined && typeof cb === "function") { cb(); return true; }
+      return false;
+    };
+
+    var hideModal = function() {
+      var instance = bootstrap.Modal.getInstance(modal[0]);
+      if (instance) instance.hide();
+    };
+
+    modal.on("show.bs.modal", function() {
+      var step, nextStep, title, titleLabel;
+      var footer = modal.find(".modal-footer");
+      var cancelBtn = footer.find(".js-btn-step[data-orientation=cancel]");
+      var prevBtn = footer.find(".js-btn-step[data-orientation=previous]");
+      var nextBtn = footer.find(".js-btn-step[data-orientation=next]");
+      var everyStepCb = settings.callbacks["*"];
+      var firstStepCb = settings.callbacks[1];
+
+      if (settings.disableNextButton) nextBtn.attr("disabled", "disabled");
+      prevBtn.attr("disabled", "disabled");
+
+      validateCallbacks();
+      execCb(everyStepCb);
+      execCb(firstStepCb);
+
+      cancelBtn.html(settings.btnCancelHtml);
+      prevBtn.html(settings.btnPreviousHtml);
+      nextBtn.html(settings.btnNextHtml);
+
+      var hiddenInput = $("<input>").attr({ type: "hidden", id: "actual-step", value: "1" });
+      modal.find("#actual-step").remove();
+      modal.append(hiddenInput);
+
+      step = 1;
+      nextStep = step + 1;
+      modal.find("[data-step=" + step + "]").removeClass("hide");
+      nextBtn.attr("data-step", nextStep);
+
+      title = modal.find("[data-step=" + step + "]").data("title");
+      titleLabel = $("<span>").addClass("badge bg-success").html(step);
+      modal.find(".js-title-step").append(titleLabel).append(" " + title);
+    });
+
+    modal.on("hidden.bs.modal", function() {
+      var actualStep = modal.find("#actual-step");
+      var nextBtn = modal.find(".js-btn-step[data-orientation=next]");
+      modal.find("[data-step]").not(modal.find(".js-btn-step")).addClass("hide");
+      actualStep.not(modal.find(".js-btn-step")).remove();
+      nextBtn.attr("data-step", 1).html(settings.btnNextHtml);
+      modal.find(".js-title-step").html("");
+    });
+
+    modal.find(".js-btn-step").on("click", function() {
+      var totalSteps, targetStep, stepContent, title;
+      var btn = $(this);
+      var actualStepInput = modal.find("#actual-step");
+      var prevBtn = modal.find(".js-btn-step[data-orientation=previous]");
+      var nextBtn = modal.find(".js-btn-step[data-orientation=next]");
+      var titleContainer = modal.find(".js-title-step");
+      var orientation = btn.data("orientation");
+      var currentStep = parseInt(actualStepInput.val());
+      var everyStepCb = settings.callbacks["*"];
+
+      totalSteps = modal.find("div[data-step]").length;
+
+      if (btn.attr("data-step") === "complete") {
+        settings.completeCallback();
+        hideModal();
+        return;
+      }
+
+      if (orientation === "next") {
+        targetStep = currentStep + 1;
+        prevBtn.attr("data-step", currentStep);
+        actualStepInput.val(targetStep);
+      } else if (orientation === "previous") {
+        targetStep = currentStep - 1;
+        nextBtn.attr("data-step", currentStep);
+        prevBtn.attr("data-step", targetStep - 1);
+        actualStepInput.val(currentStep - 1);
+      } else {
+        hideModal();
+        return;
+      }
+
+      if (parseInt(actualStepInput.val()) === totalSteps) {
+        nextBtn.attr("data-step", "complete").html(settings.btnLastStepHtml);
+      } else {
+        nextBtn.attr("data-step", targetStep).html(settings.btnNextHtml);
+      }
+
+      if (settings.disableNextButton) nextBtn.attr("disabled", "disabled");
+
+      modal.find("[data-step=" + currentStep + "]").not(modal.find(".js-btn-step")).addClass("hide");
+      modal.find("[data-step=" + targetStep + "]").not(modal.find(".js-btn-step")).removeClass("hide");
+
+      if (parseInt(prevBtn.attr("data-step")) > 0) {
+        prevBtn.removeAttr("disabled");
+      } else {
+        prevBtn.attr("disabled", "disabled");
+      }
+
+      if (orientation === "previous") nextBtn.removeAttr("disabled");
+
+      stepContent = modal.find("[data-step=" + targetStep + "]");
+      if (stepContent.attr("data-unlock-continue")) nextBtn.removeAttr("disabled");
+
+      title = stepContent.attr("data-title");
+      var titleLabel = $("<span>").addClass("badge bg-success").html(targetStep);
+      titleContainer.html(titleLabel).append(" " + title);
+
+      var stepCallback = settings.callbacks[actualStepInput.val()];
+      execCb(everyStepCb);
+      execCb(stepCallback);
+    });
+
+    return this;
+  };
+}(jQuery);

--- a/app/views/accountants/_search_form.html.erb
+++ b/app/views/accountants/_search_form.html.erb
@@ -8,7 +8,7 @@
                      placeholder: t('accountants.search_placeholder'),
                      hide_label: true,
                      value: params[:search],
-                     class: 'search_form_input accountant mr-4' %>
+                     class: 'search_form_input accountant me-4' %>
 
     <%= f.select :clinic_id,
                  options_for_select(clinic_options.reject{ |x| x.blank? },
@@ -17,7 +17,7 @@
                  include_blank: t('accountants.search_all_clinics'),
                  class: 'search_form_input accountant' %>
 
-    <%= f.button title: t('common.search'), class: 'btn btn-primary ml-4' do %>
+    <%= f.button title: t('common.search'), class: 'btn btn-primary ms-4' do %>
       <i class="fas fa-search"></i>
     <% end %>
   <% end %>

--- a/app/views/accountants/edit.js.erb
+++ b/app/views/accountants/edit.js.erb
@@ -4,4 +4,4 @@ $('.modal-content').html("<%= escape_javascript(render partial: 'patients/fulfil
 $('#pledge_fulfillment_content').addClass('partial_fulfillment_modal');
 
 // TODO pass params from search to patients fulfillment partial up here
-$('.modal').modal('toggle');
+bootstrap.Modal.getOrCreateInstance(document.querySelector('.modal')).toggle();

--- a/app/views/accountants/index.html.erb
+++ b/app/views/accountants/index.html.erb
@@ -5,7 +5,7 @@
 <h1 class='border-bottom title'>
   <%= t 'accountants.title' %>
 
-  <div id="accountants-pagination" class="float-right">
+  <div id="accountants-pagination" class="float-end">
     <small>
       <span class='pagination-entries'>
         <%= page_entries_info @patients, entry_name: t('common.patient').downcase %>

--- a/app/views/calls/_new_call.html.erb
+++ b/app/views/calls/_new_call.html.erb
@@ -1,6 +1,6 @@
 <div class="modal-body">
   <div class="calls-layout">
-    <button type="button" class="close close-terms" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <button type="button" class="btn-close close-terms" data-bs-dismiss="modal" aria-label="Close"></button>
     <h4 class="modal-title calls-request">
       <%= t('call.new.call_now', name: patient.name) %></h4>
       <div><%= language_badge @patient %></div><br>

--- a/app/views/calls/create.js.erb
+++ b/app/views/calls/create.js.erb
@@ -4,7 +4,9 @@ var isOnDashboard = location.pathname === '/';
 if (isOnEditPage) {
   $("#call_log").html("<%= escape_javascript(render partial: 'patients/call_log') %>")
     .promise().done(function() {
-      $(".new-call").modal('hide')
+      var callModalEl = document.querySelector('.new-call');
+      var callModalInstance = bootstrap.Modal.getInstance(callModalEl);
+      if (callModalInstance) callModalInstance.hide();
       $('body').removeClass('modal-open')
       $('.modal-backdrop').remove()
     });
@@ -35,7 +37,9 @@ if (isOnDashboard) {
                                             patients: Patient.shared_patients(current_line),
                                             autosortable: true }) %>'
   );
-  $(".new-call").modal('hide')
+  var dashCallModalEl = document.querySelector('.new-call');
+  var dashCallModal = bootstrap.Modal.getInstance(dashCallModalEl);
+  if (dashCallModal) dashCallModal.hide();
   $('body').removeClass('modal-open')
   $('.modal-backdrop').remove()
 }

--- a/app/views/calls/new.js.erb
+++ b/app/views/calls/new.js.erb
@@ -1,4 +1,4 @@
 $('.modal-content').html('')
 $('.modal').attr('id', '<%= @patient.primary_phone_display %>')
 $('.modal-content').append('<%= escape_javascript(render partial: "calls/new_call", locals: { patient: @patient })%>');
-$('.modal').modal('toggle');
+bootstrap.Modal.getOrCreateInstance(document.querySelector('.modal')).toggle();

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -3,7 +3,7 @@
     <h4 class="clinic-finder-expand patient-section-title">
       <%= t('clinic_locator.title') %>
       <small><%= t('clinic_locator.experimental_note') %></small>
-      <i class='fas fa-plus-circle float-right'></i>
+      <i class='fas fa-plus-circle float-end'></i>
     </h4>
   </div>
 
@@ -34,7 +34,7 @@
                          autocomplete: 'off' %>
             <%= f.label :last_menstrual_period_days,
                         t('common.days_along'),
-                        class: "sr-only" %>
+                        class: "visually-hidden" %>
           </div>
         </div>
       </div>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -2,7 +2,7 @@
   <% expenditures.each_pair do |type, patient_hashes| %>
     <% patient_hashes.each do |patient| %>
       <div class="progress-bar <%= progress_bar_color type %> expenditure-block" style='<%= progress_bar_width patient[:fund_pledge], limit %>' role='progressbar'>
-        <div data-toggle='popover' data-content='<%= budget_bar_expenditure_content(patient) %>' data-placement='bottom' data-html='true' class='expenditure-item'>
+        <div data-bs-toggle='popover' data-bs-content='<%= budget_bar_expenditure_content(patient) %>' data-bs-placement='bottom' data-bs-html='true' class='expenditure-item'>
           <%= t "dashboard.budget_bar.#{type}_item",
                 amount: number_to_currency(patient[:fund_pledge],
                                            precision: 0,

--- a/app/views/dashboards/_overview.html.erb
+++ b/app/views/dashboards/_overview.html.erb
@@ -11,6 +11,6 @@
 
 <%= javascript_tag nonce: true do %>
   document.addEventListener("render_async_loaded", function (event) {
-    $('.expenditure-item').popover();
+    document.querySelectorAll('.expenditure-item').forEach(el => new bootstrap.Popover(el));
   });
 <% end %>

--- a/app/views/dashboards/_search_form.html.erb
+++ b/app/views/dashboards/_search_form.html.erb
@@ -10,7 +10,7 @@
                      placeholder: t('dashboard.search.input_placeholder'),
                      hide_label: true,
                      class: 'search_form_input' %>
-    <%= p.button class: 'btn btn-primary ml-5',
+    <%= p.button class: 'btn btn-primary ms-5',
                  title: t('common.search'),
                  aria: { label: t('common.search') } do %>
       <i class="fas fa-search"></i>

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -61,7 +61,7 @@
                                     name: patient.name)},
                             remote: true do %>
                   <i class="fas fa-xmark fa-fw text-danger" aria-hidden="true"></i>
-                  <span class="sr-only">Remove call</span>
+                  <span class="visually-hidden">Remove call</span>
                 <% end %>
               </td>
             <% else %>
@@ -80,7 +80,7 @@
                         aria: { label: "Call #{patient.primary_phone_display}" },
                         remote: true do %>
               <i class="fas fa-phone-alt fa-lg fa-fw call-icon"></i>
-              <span class="sr-only">Call</span>
+              <span class="visually-hidden">Call</span>
             <% end %>
           </td>
         </tr>
@@ -91,7 +91,7 @@
   <% if table_type == 'call_list' && current_user.call_list_entries.count.nonzero? %>
     <%= link_to t('dashboard.table_content.clear_call_list'),
                 clear_current_user_call_list_path,
-                class: "float-right text-danger",
+                class: "float-end text-danger",
                 data: { confirm: t('dashboard.table_content.clear_call_list_confirm') },
                 method: :patch,
                 remote: true %>

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -3,7 +3,7 @@
   <% flash.each do |name, msg| %>
     <% if name != 'timedout' && msg.length > 0 %>
       <div class="alert alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">
-        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-hidden="true"></button>
         <%= content_tag :div, msg, :id => "flash_#{name}" %>
       </div>
     <% end %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,8 +1,8 @@
-<nav class="navbar navbar-inverse fixed-top navbar-expand-lg">
+<nav class="navbar navbar-dark fixed-top navbar-expand-lg">
   <div class="navbar-header">
     <%= link_to "DARIA - #{current_tenant.full_name}#{' - Development' if Rails.env.development?}", root_path, class: 'navbar-brand' %>
 
-    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse" aria-label="Toggle navigation" aria-controls="navbar-collapse" aria-expanded="false">
+    <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-label="Toggle navigation" aria-controls="navbar-collapse" aria-expanded="false">
       <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -1,4 +1,4 @@
-<ul class="navbar-nav mr-auto">
+<ul class="navbar-nav me-auto">
   <% if current_user %>
     <%= current_line_display %>
     <%= cm_resources_link %>
@@ -9,7 +9,7 @@
 
 <% if current_user.admin? || current_user.data_volunteer? %>
   <div class="dropdown">
-    <button href="#" data-toggle="dropdown" class="btn dropdown-toggle navbar-text" id="admin-dropdown" aria-haspopup="true" aria-expanded="false">
+    <button href="#" data-bs-toggle="dropdown" class="btn dropdown-toggle navbar-text" id="admin-dropdown" aria-haspopup="true" aria-expanded="false">
       <%= t('navigation.admin_tools.label') %> 
     </button>
 
@@ -26,7 +26,7 @@
 <% end %>
 
 <div class="dropdown">
-  <button href="#" data-toggle="dropdown" class="btn dropdown-toggle navbar-text" id="user-dropdown" aria-haspopup="true" aria-expanded="false">
+  <button href="#" data-bs-toggle="dropdown" class="btn dropdown-toggle navbar-text" id="user-dropdown" aria-haspopup="true" aria-expanded="false">
     <%= current_user.name %>
   </button>
 

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -1,7 +1,7 @@
 <div id="call_log_content">
   <h2>
     <%= t('patient.call_log.title') %>
-    <small class="float-right"> 
+    <small class="float-end"> 
       <%= link_to t('patient.call_log.record_new_call'),
                   new_patient_call_path(@patient),
                   class: "call_button call-#{@patient.primary_phone_display}",

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
       <%= bootstrap_form_with model: patient,
-                              html: { id: 'shared-flag-form', class: 'text-right text-danger edit_patient' },
+                              html: { id: 'shared-flag-form', class: 'text-end text-danger edit_patient' },
                               local: false do |f| %>
         <div class="col">
           <%= f.form_group :shared_flag do %>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -26,7 +26,7 @@
                      autocomplete: 'off',
                      skip_label: true,
                      help: t('patient.dashboard.called_on', date: patient.initial_call_date.strftime("%m/%d/%Y")) %>
-        <%= f.label :last_menstrual_period_days, t('common.days_along'), class: "sr-only" %>
+        <%= f.label :last_menstrual_period_days, t('common.days_along'), class: "visually-hidden" %>
       </div>          
 
       <div class="col-3">

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -111,7 +111,7 @@
                      autocomplete: 'off' %>
 
         <fieldset>
-          <legend class="font-weight-bold" id="special_circumstances_label">
+          <legend class="fw-bold" id="special_circumstances_label">
             <%= t 'patient.information.special_circumstances.title' %>
           </legend>
 

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -96,7 +96,7 @@
 
   <div class="modal-footer">
     <div class="col">
-      <button type="button" class="btn btn-outline-secondary js-btn-step float-left" style="color:red;" data-dismiss="modal"><%= t('common.no') %></button>
+      <button type="button" class="btn btn-outline-secondary js-btn-step float-start" style="color:red;" data-bs-dismiss="modal"><%= t('common.no') %></button>
     </div>
 
     <div class="col">
@@ -106,7 +106,7 @@
                               method: 'patch',
                               class: 'edit_patient' do |f| %>
         <%= f.hidden_field :pledge_sent, value: false %>
-        <%= f.submit t('common.yes'), class: "btn btn-success js-btn-step float-right", id: 'cancel-pledge-submit'%>
+        <%= f.submit t('common.yes'), class: "btn btn-success js-btn-step float-end", id: 'cancel-pledge-submit'%>
       <% end %>
     </div>
   </div>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -149,7 +149,7 @@
   <%= f.check_box :resolved_without_fund, label: t('patient.status.key.resolved', fund: current_tenant.name) %>
 
   <fieldset class="mt-5">
-    <legend class="font-weight-bold" id="special_circumstances_label">
+    <legend class="fw-bold" id="special_circumstances_label">
       <%= t 'patient.information.special_circumstances.title' %>    
     </legend>
 

--- a/app/views/patients/pledge.js.erb
+++ b/app/views/patients/pledge.js.erb
@@ -4,7 +4,7 @@ $('.modal-content').append(
   '<%= escape_javascript(render partial: "patients/pledge", locals: { patient: @patient, disable_next: disable_continue?(@patient) })%>'
 );
 
-$('.modal').modal('toggle');
+bootstrap.Modal.getOrCreateInstance(document.querySelector('.modal')).toggle();
 
 <% if (!@patient.pledge_sent) %>
 
@@ -19,6 +19,7 @@ $('.modal').modal('toggle');
 
 <% else %>
   $('#cancel-pledge-form').on('submit', function() {
-    $('.modal').modal('hide');
+    var pledgeModal = bootstrap.Modal.getInstance(document.querySelector('.modal'));
+    if (pledgeModal) pledgeModal.hide();
   })
 <% end %>

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -8,11 +8,16 @@ $('#patient_appointment_date')
 $('#patient_status_display')
   .val('<%= @patient.status %>');
 
-// rerack tooltip content 
-$('.daria-tooltip.tooltip-header-help')
-                  .attr('title', "<%= status_help_text(@patient)%>")
-                  .attr('data-original-title', "<%= status_help_text(@patient)%>")
-                  .tooltip('update');
+// rerack tooltip content
+(function() {
+  var tooltipEl = document.querySelector('.daria-tooltip.tooltip-header-help');
+  if (tooltipEl) {
+    var oldTip = bootstrap.Tooltip.getInstance(tooltipEl);
+    if (oldTip) oldTip.dispose();
+    tooltipEl.setAttribute('title', "<%= status_help_text(@patient)%>");
+    new bootstrap.Tooltip(tooltipEl);
+  }
+})();
 
 // rerack current LMP
 $('#patient_last_menstrual_period_weeks')

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -1,9 +1,9 @@
 <nav>
   <div class="nav nav-tabs" id="nav-tab" role="tablist">
-    <button class="nav-link active" id="nav-support-tab" data-toggle="tab" data-target="#nav-support" type="button" role="tab" aria-controls="nav-support" aria-selected="true">
+    <button class="nav-link active" id="nav-support-tab" data-bs-toggle="tab" data-bs-target="#nav-support" type="button" role="tab" aria-controls="nav-support" aria-selected="true">
       <%= t('common.detail') %>
     </button>
-    <button class="nav-link mr-auto" id="nav-notes-tab" data-toggle="tab" data-target="#nav-notes" type="button" role="tab" aria-controls="nav-notes" aria-selected="false">
+    <button class="nav-link me-auto" id="nav-notes-tab" data-bs-toggle="tab" data-bs-target="#nav-notes" type="button" role="tab" aria-controls="nav-notes" aria-selected="false">
       <%= t('common.notes') %>
     </button>
 
@@ -12,12 +12,12 @@
       remote: true,
       method: :delete,
       data: { confirm: t('patient.practical_support.delete_confirm') },
-      class: "btn btn-danger practical-support-remove mr-3" %>
+      class: "btn btn-danger practical-support-remove me-3" %>
 
 
       <%= button_to t('common.close'),
                     nil,
-                    data: { dismiss: 'modal' },
+                    data: { 'bs-dismiss': 'modal' },
                     class: "btn btn-success" %>
 
   </div>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -22,7 +22,7 @@
           <td>
             <%= link_to t('common.update'),
                         edit_patient_practical_support_path(patient, entry),
-                        class: "btn btn-info btn-sm edit_practical_support practical-support-#{entry.id} ml-3",
+                        class: "btn btn-info btn-sm edit_practical_support practical-support-#{entry.id} ms-3",
                         remote: true %>  
           </td>
         </tr>

--- a/app/views/practical_supports/destroy.js.erb
+++ b/app/views/practical_supports/destroy.js.erb
@@ -11,4 +11,6 @@ setTimeout(function() {
 }, 5000);
 
 // Close the modal
-$('.modal').modal('hide');
+var destroyModalEl = document.querySelector('.modal');
+var destroyModalInstance = bootstrap.Modal.getInstance(destroyModalEl);
+if (destroyModalInstance) destroyModalInstance.hide();

--- a/app/views/practical_supports/edit.js.erb
+++ b/app/views/practical_supports/edit.js.erb
@@ -1,4 +1,4 @@
 $('.modal-content').html('');
 $('.modal').attr('id', 'practical-support-<%= @support.id %>-edit-modal');
 $('.modal-content').append('<%= escape_javascript(render partial: "practical_supports/edit", locals: { patient: @patient, support: @support, note: @note })%>');
-$('.modal').modal('toggle');
+bootstrap.Modal.getOrCreateInstance(document.querySelector('.modal')).toggle();

--- a/app/views/shared/_multi_modal.html.erb
+++ b/app/views/shared/_multi_modal.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-default js-btn-step pull-left" data-orientation="cancel" data-dismiss="modal"></button>
+  <button type="button" class="btn btn-secondary js-btn-step float-start" data-orientation="cancel" data-bs-dismiss="modal"></button>
   <button type="button" id="pledge-previous" class="btn btn-warning js-btn-step" data-orientation="previous"></button>
   <button type="button" id="pledge-next" class="btn btn-success js-btn-step" <%= disable_next %> data-orientation="next"></button>
 </div>

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_with url: users_search_path,
                         local: false,
                         layout: :inline,
-                        html: { class: 'float-right' } do |p| %>
+                        html: { class: 'float-end' } do |p| %>
   <%= p.text_field :search,
                    placeholder: t('user.search.text_field'),
                    skip_label: true,
@@ -9,5 +9,5 @@
                    class: 'search_form_input' %>
   <%= p.submit t('user.search.button'),
                id: 'search_button',
-               class: 'btn btn-primary ml-2' %>
+               class: 'btn btn-primary ms-2' %>
 <% end %>

--- a/package.json
+++ b/package.json
@@ -2,12 +2,11 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.7.2",
     "@popperjs/core": "2.11.8",
-    "bootstrap": "4.6.2",
+    "bootstrap": "5.3.8",
     "esbuild": "0.25.8",
     "i18n-js": "^4.5.1",
     "jquery": "3.7.1",
     "jquery-ujs": "1.2.3",
-    "popper.js": "1.16.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sass": "1.89.2",

--- a/test/helpers/budget_bar_helper_test.rb
+++ b/test/helpers/budget_bar_helper_test.rb
@@ -90,4 +90,122 @@ class BudgetBarHelperTest < ActionView::TestCase
       assert_equal 0, sum_fund_pledges(@expenditures.values.flatten)
     end
   end
+
+  # ----- sum_fund_pledges edge cases -----
+
+  describe 'sum_fund_pledges edge cases' do
+    it 'returns 0 for nil input' do
+      assert_equal 0, sum_fund_pledges(nil)
+    end
+
+    it 'returns 0 for empty array' do
+      assert_equal 0, sum_fund_pledges([])
+    end
+
+    it 'handles a single pledge' do
+      assert_equal 50, sum_fund_pledges([{ fund_pledge: 50 }])
+    end
+
+    it 'handles negative fund_pledge values' do
+      pledges = [{ fund_pledge: -10 }, { fund_pledge: 30 }]
+      assert_equal 20, sum_fund_pledges(pledges)
+    end
+
+    it 'handles very large fund_pledge values' do
+      pledges = [{ fund_pledge: 999_999_999 }, { fund_pledge: 1 }]
+      assert_equal 1_000_000_000, sum_fund_pledges(pledges)
+    end
+
+    it 'handles float fund_pledge values' do
+      pledges = [{ fund_pledge: 10.50 }, { fund_pledge: 20.75 }]
+      assert_in_delta 31.25, sum_fund_pledges(pledges), 0.001
+    end
+
+    it 'handles zero fund_pledge values' do
+      pledges = [{ fund_pledge: 0 }, { fund_pledge: 0 }]
+      assert_equal 0, sum_fund_pledges(pledges)
+    end
+  end
+
+  # ----- budget_bar_remaining edge cases -----
+
+  describe 'budget_bar_remaining edge cases' do
+    it 'returns limit when expenditures is nil' do
+      assert_equal 1000, budget_bar_remaining(nil, 1000)
+    end
+
+    it 'returns limit when expenditures has no :pledged or :sent keys' do
+      assert_equal 500, budget_bar_remaining({}, 500)
+    end
+
+    it 'handles expenditures with only :pledged key (no :sent)' do
+      expenditures = { pledged: [{ fund_pledge: 100 }] }
+      assert_equal 400, budget_bar_remaining(expenditures, 500)
+    end
+
+    it 'handles expenditures with only :sent key (no :pledged)' do
+      expenditures = { sent: [{ fund_pledge: 200 }] }
+      assert_equal 300, budget_bar_remaining(expenditures, 500)
+    end
+
+    it 'can return negative remainder when expenditures exceed limit' do
+      expenditures = {
+        pledged: [{ fund_pledge: 600 }],
+        sent: [{ fund_pledge: 600 }]
+      }
+      assert_equal(-200, budget_bar_remaining(expenditures, 1000))
+    end
+
+    it 'returns limit when both pledged and sent are empty arrays' do
+      expenditures = { pledged: [], sent: [] }
+      assert_equal 1000, budget_bar_remaining(expenditures, 1000)
+    end
+
+    it 'handles zero limit' do
+      expenditures = { pledged: [{ fund_pledge: 50 }], sent: [] }
+      assert_equal(-50, budget_bar_remaining(expenditures, 0))
+    end
+
+    it 'handles float fund_pledge values in remaining calculation' do
+      expenditures = {
+        pledged: [{ fund_pledge: 10.5 }],
+        sent: [{ fund_pledge: 20.25 }]
+      }
+      assert_in_delta 469.25, budget_bar_remaining(expenditures, 500), 0.001
+    end
+  end
+
+  # ----- progress_bar_color edge cases -----
+
+  describe 'progress_bar_color edge cases' do
+    it 'returns bg-warning for :pledged' do
+      assert_equal 'bg-warning', progress_bar_color(:pledged)
+    end
+
+    it 'returns bg-success for :sent' do
+      assert_equal 'bg-success', progress_bar_color(:sent)
+    end
+
+    it 'returns bg- prefix for any unknown type' do
+      result = progress_bar_color(:unknown)
+      assert_match(/^bg-/, result)
+    end
+  end
+
+  # ----- progress_bar_width edge cases -----
+
+  describe 'progress_bar_width edge cases' do
+    it 'returns width: 0% when value is 0' do
+      assert_equal 'width: 0%', progress_bar_width(0)
+    end
+
+    it 'returns width: 0% when cash_ceiling is 0 (avoids division by zero)' do
+      assert_equal 'width: 0%', progress_bar_width(100, 0)
+    end
+
+    it 'handles value exceeding cash_ceiling (over 100%)' do
+      result = progress_bar_width(2000)
+      assert_match(/width: \d+%/, result)
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This upgrades Bootstrap from 4.6.2 to 5.3.8, migrating all views, helpers, and JavaScript across the app. This is a foundational change that several other PRs depend on.

This pull request makes the following changes:
* Update Bootstrap CSS/JS packages to 5.3.8
* Migrate all data attributes (`data-toggle` to `data-bs-toggle`, etc.)
* Migrate utility classes (`mr-*` to `me-*`, `ml-*` to `ms-*`, etc.)
* Update badge classes (`badge-*` to `bg-*`)

**Notes:**
* **Must merge BEFORE** these PRs (they use BS5 classes): #3533 (budget bar), #3538 (notification center) → #3549, #3550, #3551, #3552, and #3540 (note templates).
* **Merge order:** `#3532` → then #3533, #3538, #3540, etc.
* **Before merging:** Gemfile.lock must be regenerated via `docker compose run --rm web bundle install`.

(If there are changes to the views, please include a screenshot so we know what to look for!)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
