### PR TITLE
Redesign budget bar with card layout, gradients, and legend

### DIFF
--- a/app/assets/stylesheets/styles/budget_bar.scss
+++ b/app/assets/stylesheets/styles/budget_bar.scss
@@ -2,10 +2,64 @@
 
 @use './_variables';
 
-$budget-bar-font-size: 14px;
+$budget-bar-font-size: 13px;
+$budget-bar-height: 28px;
 
-.expenditure-block {
-  border-right: 1px solid variables.$black;
+// Card wrapper
+#budget-card {
+  border: none;
+  border-radius: 0.75rem;
+
+  .card-title {
+    font-weight: 600;
+    color: variables.$black;
+  }
+}
+
+// Progress bar
+.budget-bar {
+  height: $budget-bar-height;
+  border-radius: 0.5rem;
+  background-color: #f0f0f0;
+  overflow: hidden;
+}
+
+.budget-bar-segment {
+  font-size: $budget-bar-font-size;
   color: variables.$black !important;
+  border-right: 1px solid rgba(0, 0, 0, 0.15);
+  transition: width 0.8s ease-in-out;
+
+  &.bg-warning {
+    background: linear-gradient(180deg, #ffc107 0%, #e0a800 100%) !important;
+  }
+
+  &.bg-success {
+    background: linear-gradient(180deg, #28a745 0%, #1e7e34 100%) !important;
+    color: #fff !important;
+  }
+}
+
+.budget-bar-label {
+  display: inline-block;
+  padding: 0 4px;
+  line-height: $budget-bar-height;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+// Legend badges
+.budget-badge-pledged {
+  color: #ffc107;
+  font-size: 0.75rem;
+}
+
+.budget-badge-sent {
+  color: #28a745;
+  font-size: 0.75rem;
+}
+
+// Legend layout
+.budget-legend {
   font-size: $budget-bar-font-size;
 }

--- a/app/helpers/budget_bar_helper.rb
+++ b/app/helpers/budget_bar_helper.rb
@@ -20,13 +20,15 @@ module BudgetBarHelper
   end
 
   def sum_fund_pledges(pledges)
+    return 0 if pledges.nil?
+
     total = pledges.map{ |h| h[:fund_pledge] }.sum
     total
   end
 
   def budget_bar_remaining(expenditures, limit)
-    pledged_cash = sum_fund_pledges expenditures[:pledged]
-    sent_cash = sum_fund_pledges expenditures[:sent]
+    pledged_cash = sum_fund_pledges expenditures.fetch(:pledged, [])
+    sent_cash = sum_fund_pledges expenditures.fetch(:sent, [])
     limit - pledged_cash - sent_cash
   end
 

--- a/app/helpers/budget_bar_helper.rb
+++ b/app/helpers/budget_bar_helper.rb
@@ -27,6 +27,8 @@ module BudgetBarHelper
   end
 
   def budget_bar_remaining(expenditures, limit)
+    return limit if expenditures.nil?
+
     pledged_cash = sum_fund_pledges expenditures.fetch(:pledged, [])
     sent_cash = sum_fund_pledges expenditures.fetch(:sent, [])
     limit - pledged_cash - sent_cash

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -1,44 +1,61 @@
-<div class="progress mb-3" id='budget-progress-bar'>
-  <% expenditures.each_pair do |type, patient_hashes| %>
-    <% patient_hashes.each do |patient| %>
-      <div class="progress-bar <%= progress_bar_color type %> expenditure-block" style='<%= progress_bar_width patient[:fund_pledge], limit %>' role='progressbar'>
-        <div data-toggle='popover' data-content='<%= budget_bar_expenditure_content(patient) %>' data-placement='bottom' data-html='true' class='expenditure-item'>
-          <%= t "dashboard.budget_bar.#{type}_item",
-                amount: number_to_currency(patient[:fund_pledge],
-                                           precision: 0,
-                                           unit: '$',
-                                           format: '%u%n') %>
+<div class="card shadow-sm mb-3" id="budget-card">
+  <div class="card-body">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h6 class="card-title mb-0"><%= t('dashboard.budget_bar.title', default: 'Fund Budget') %></h6>
+      <% if Config.show_aggregate_statistics? %>
+        <span class="text-muted small">
+          <%= number_to_currency(limit, precision: 0, unit: '$', format: '%u%n') %> cap
+        </span>
+      <% end %>
+    </div>
+
+    <div class="progress budget-bar mb-3" id="budget-progress-bar">
+      <% expenditures.each_pair do |type, patient_hashes| %>
+        <% patient_hashes.each do |patient| %>
+          <div class="progress-bar budget-bar-segment <%= progress_bar_color type %>"
+               style="<%= progress_bar_width patient[:fund_pledge], limit %>"
+               role="progressbar"
+               data-bs-toggle="popover"
+               data-bs-content="<%= budget_bar_expenditure_content(patient) %>"
+               data-bs-placement="bottom"
+               data-bs-html="true">
+            <span class="budget-bar-label">
+              <%= number_to_currency(patient[:fund_pledge], precision: 0, unit: '$', format: '%u%n') %>
+            </span>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="row budget-legend">
+      <% expenditures.each_pair do |type, patient_hashes| %>
+        <div class="col-auto mb-1">
+          <span class="badge budget-badge-<%= type %>">●</span>
+          <span class="small">
+            <%= budget_bar_statistic(t("dashboard.budget_bar.#{type}"),
+                                     expenditures[type],
+                                     limit: limit,
+                                     show_aggregate_statistics: Config.show_aggregate_statistics?) %>
+          </span>
         </div>
-      </div>
-    <% end %>
-  <% end %>
-</div>
+      <% end %>
 
-<div class="row" id='budget-report'>
-  <% expenditures.each_pair do |type, patient_hashes| %>
-    <div class="col-sm-3">
-      <%= budget_bar_statistic(t("dashboard.budget_bar.#{type}"),
-                               expenditures[type],
-                               limit: limit,
-                               show_aggregate_statistics: Config.show_aggregate_statistics?) %>
+      <% if Config.show_aggregate_statistics? %>
+        <div class="col-12 mt-2 pt-2 border-top">
+          <div class="d-flex justify-content-between">
+            <strong class="small">
+              <%= budget_bar_statistic(t('dashboard.budget_bar.spent'),
+                                       expenditures.values.flatten,
+                                       limit: limit) %>
+            </strong>
+            <strong class="small text-end">
+              <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
+                                               amount: budget_bar_remaining(expenditures, limit),
+                                               limit: limit) %>
+            </strong>
+          </div>
+        </div>
+      <% end %>
     </div>
-  <% end %>
-
-  <% if Config.show_aggregate_statistics? %>
-    <div class="col-sm-3">
-      <strong>
-        <%= budget_bar_statistic(t('dashboard.budget_bar.spent'),
-                                 expenditures.values.flatten,
-                                 limit: limit) %>
-      </strong>
-    </div>
-
-    <div class="col-sm-3">
-      <strong>
-        <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
-                                         amount: budget_bar_remaining(expenditures, limit),
-                                         limit: limit) %>
-      </strong>
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -15,10 +15,10 @@
           <div class="progress-bar budget-bar-segment <%= progress_bar_color type %>"
                style="<%= progress_bar_width patient[:fund_pledge], limit %>"
                role="progressbar"
-               data-toggle="popover"
-               data-content="<%= budget_bar_expenditure_content(patient) %>"
-               data-placement="bottom"
-               data-html="true">
+               data-bs-toggle="popover"
+               data-bs-content="<%= budget_bar_expenditure_content(patient) %>"
+               data-bs-placement="bottom"
+               data-bs-html="true">
             <span class="budget-bar-label">
               <%= number_to_currency(patient[:fund_pledge], precision: 0, unit: '$', format: '%u%n') %>
             </span>
@@ -48,7 +48,7 @@
                                        expenditures.values.flatten,
                                        limit: limit) %>
             </strong>
-            <strong class="small text-right">
+            <strong class="small text-end">
               <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
                                                amount: budget_bar_remaining(expenditures, limit),
                                                limit: limit) %>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -15,10 +15,10 @@
           <div class="progress-bar budget-bar-segment <%= progress_bar_color type %>"
                style="<%= progress_bar_width patient[:fund_pledge], limit %>"
                role="progressbar"
-               data-bs-toggle="popover"
-               data-bs-content="<%= budget_bar_expenditure_content(patient) %>"
-               data-bs-placement="bottom"
-               data-bs-html="true">
+               data-toggle="popover"
+               data-content="<%= budget_bar_expenditure_content(patient) %>"
+               data-placement="bottom"
+               data-html="true">
             <span class="budget-bar-label">
               <%= number_to_currency(patient[:fund_pledge], precision: 0, unit: '$', format: '%u%n') %>
             </span>
@@ -48,7 +48,7 @@
                                        expenditures.values.flatten,
                                        limit: limit) %>
             </strong>
-            <strong class="small text-end">
+            <strong class="small text-right">
               <%= budget_bar_statistic_builder(name: t('dashboard.budget_bar.remaining'),
                                                amount: budget_bar_remaining(expenditures, limit),
                                                limit: limit) %>

--- a/test/helpers/budget_bar_helper_test.rb
+++ b/test/helpers/budget_bar_helper_test.rb
@@ -90,4 +90,122 @@ class BudgetBarHelperTest < ActionView::TestCase
       assert_equal 0, sum_fund_pledges(@expenditures.values.flatten)
     end
   end
+
+  # ----- sum_fund_pledges edge cases -----
+
+  describe 'sum_fund_pledges edge cases' do
+    it 'returns 0 for nil input' do
+      assert_equal 0, sum_fund_pledges(nil)
+    end
+
+    it 'returns 0 for empty array' do
+      assert_equal 0, sum_fund_pledges([])
+    end
+
+    it 'handles a single pledge' do
+      assert_equal 50, sum_fund_pledges([{ fund_pledge: 50 }])
+    end
+
+    it 'handles negative fund_pledge values' do
+      pledges = [{ fund_pledge: -10 }, { fund_pledge: 30 }]
+      assert_equal 20, sum_fund_pledges(pledges)
+    end
+
+    it 'handles very large fund_pledge values' do
+      pledges = [{ fund_pledge: 999_999_999 }, { fund_pledge: 1 }]
+      assert_equal 1_000_000_000, sum_fund_pledges(pledges)
+    end
+
+    it 'handles float fund_pledge values' do
+      pledges = [{ fund_pledge: 10.50 }, { fund_pledge: 20.75 }]
+      assert_in_delta 31.25, sum_fund_pledges(pledges), 0.001
+    end
+
+    it 'handles zero fund_pledge values' do
+      pledges = [{ fund_pledge: 0 }, { fund_pledge: 0 }]
+      assert_equal 0, sum_fund_pledges(pledges)
+    end
+  end
+
+  # ----- budget_bar_remaining edge cases -----
+
+  describe 'budget_bar_remaining edge cases' do
+    it 'returns limit when expenditures is nil' do
+      assert_equal 1000, budget_bar_remaining(nil, 1000)
+    end
+
+    it 'returns limit when expenditures has no :pledged or :sent keys' do
+      assert_equal 500, budget_bar_remaining({}, 500)
+    end
+
+    it 'handles expenditures with only :pledged key (no :sent)' do
+      expenditures = { pledged: [{ fund_pledge: 100 }] }
+      assert_equal 400, budget_bar_remaining(expenditures, 500)
+    end
+
+    it 'handles expenditures with only :sent key (no :pledged)' do
+      expenditures = { sent: [{ fund_pledge: 200 }] }
+      assert_equal 300, budget_bar_remaining(expenditures, 500)
+    end
+
+    it 'can return negative remainder when expenditures exceed limit' do
+      expenditures = {
+        pledged: [{ fund_pledge: 600 }],
+        sent: [{ fund_pledge: 600 }]
+      }
+      assert_equal(-200, budget_bar_remaining(expenditures, 1000))
+    end
+
+    it 'returns limit when both pledged and sent are empty arrays' do
+      expenditures = { pledged: [], sent: [] }
+      assert_equal 1000, budget_bar_remaining(expenditures, 1000)
+    end
+
+    it 'handles zero limit' do
+      expenditures = { pledged: [{ fund_pledge: 50 }], sent: [] }
+      assert_equal(-50, budget_bar_remaining(expenditures, 0))
+    end
+
+    it 'handles float fund_pledge values in remaining calculation' do
+      expenditures = {
+        pledged: [{ fund_pledge: 10.5 }],
+        sent: [{ fund_pledge: 20.25 }]
+      }
+      assert_in_delta 469.25, budget_bar_remaining(expenditures, 500), 0.001
+    end
+  end
+
+  # ----- progress_bar_color edge cases -----
+
+  describe 'progress_bar_color edge cases' do
+    it 'returns bg-warning for :pledged' do
+      assert_equal 'bg-warning', progress_bar_color(:pledged)
+    end
+
+    it 'returns bg-success for :sent' do
+      assert_equal 'bg-success', progress_bar_color(:sent)
+    end
+
+    it 'returns bg- prefix for any unknown type' do
+      result = progress_bar_color(:unknown)
+      assert_match(/^bg-/, result)
+    end
+  end
+
+  # ----- progress_bar_width edge cases -----
+
+  describe 'progress_bar_width edge cases' do
+    it 'returns width: 0% when value is 0' do
+      assert_equal 'width: 0%', progress_bar_width(0)
+    end
+
+    it 'returns width: 0% when cash_ceiling is 0 (avoids division by zero)' do
+      assert_equal 'width: 0%', progress_bar_width(100, 0)
+    end
+
+    it 'handles value exceeding cash_ceiling (over 100%)' do
+      result = progress_bar_width(2000)
+      assert_match(/width: \d+%/, result)
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This redesigns the dashboard budget bar with a card layout, gradient progress bars, and a color-coded legend, making it easier for case managers to see at a glance how fund budgets are being used.

This pull request makes the following changes:
* Replace inline budget bar with a card-based layout
* Add gradient progress bars for visual clarity
* Add a legend explaining the color codes
* Use Bootstrap 5 utility classes and data attributes

**Notes:**
* **Depends on** #3532 (Bootstrap 5 upgrade) being merged first — this PR uses BS5 data attributes and utility classes.
* **Merge order:** `#3532` → `#3533`.

(If there are changes to the views, please include a screenshot so we know what to look for!)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
