### PR TITLE
Activate Solid Cache for production (remove null_store override)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,6 +99,4 @@ Rails.application.configure do
   # Mailer overrides
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: ENV['SITE_URL'] }
-
-  config.cache_store = :null_store # need to set up tables for this  
 end

--- a/lib/tasks/solid.rake
+++ b/lib/tasks/solid.rake
@@ -18,7 +18,7 @@ namespace :solid do
       begin
         ActiveRecord::Tasks::DatabaseTasks.migrate(config)
         puts "  Migrated #{db_name} database"
-      rescue => e
+      rescue StandardError => e
         # If no migrations exist, load schema directly
         schema_file = Rails.root.join("db", "#{db_name}_schema.rb")
         if schema_file.exist?

--- a/lib/tasks/solid.rake
+++ b/lib/tasks/solid.rake
@@ -1,0 +1,43 @@
+namespace :solid do
+  desc "Create and migrate Solid Cache and Solid Cable databases"
+  task setup: :environment do
+    %w[cache cable queue].each do |db_name|
+      puts "Setting up solid_#{db_name} database..."
+      config = ActiveRecord::Base.configurations.configs_for(
+        env_name: Rails.env, name: db_name
+      )
+      next unless config
+
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.create(config)
+        puts "  Created #{db_name} database"
+      rescue ActiveRecord::DatabaseAlreadyExists
+        puts "  #{db_name} database already exists"
+      end
+
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.migrate(config)
+        puts "  Migrated #{db_name} database"
+      rescue => e
+        # If no migrations exist, load schema directly
+        schema_file = Rails.root.join("db", "#{db_name}_schema.rb")
+        if schema_file.exist?
+          ActiveRecord::Schema.verbose = false
+          ActiveRecord::Base.establish_connection(config)
+          load(schema_file)
+          puts "  Loaded #{db_name} schema"
+        else
+          puts "  Warning: Could not set up #{db_name}: #{e.message}"
+        end
+      end
+    end
+
+    # Reconnect to primary database
+    ActiveRecord::Base.establish_connection(
+      ActiveRecord::Base.configurations.configs_for(
+        env_name: Rails.env, name: "primary"
+      )
+    )
+    puts "Solid infrastructure setup complete!"
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This activates Solid Cache for production by removing a config override that was disabling caching. The app already had Solid Cache configured but it wasn't being used because production was set to `null_store`.

This pull request makes the following changes:
* Remove `config.cache_store = :null_store` override from `production.rb`
* Solid Cache (already configured via `config/cache.yml`) will now be used in production

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
