### PR TITLE
Activate Solid Cable for production Action Cable

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,15 +8,13 @@ development:
 test:
   adapter: test
 
-# Deliberately nerfing production to avoid a mysterious install problem
 production:
-  # adapter: solid_cable
-  # connects_to:
-  #   database:
-  #     writing: cable
-  # polling_interval: 0.1.seconds
-  # message_retention: 1.day
-  adapter: async
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
 
 
 # Custom

--- a/lib/tasks/solid.rake
+++ b/lib/tasks/solid.rake
@@ -18,7 +18,7 @@ namespace :solid do
       begin
         ActiveRecord::Tasks::DatabaseTasks.migrate(config)
         puts "  Migrated #{db_name} database"
-      rescue => e
+      rescue StandardError => e
         # If no migrations exist, load schema directly
         schema_file = Rails.root.join("db", "#{db_name}_schema.rb")
         if schema_file.exist?

--- a/lib/tasks/solid.rake
+++ b/lib/tasks/solid.rake
@@ -1,0 +1,43 @@
+namespace :solid do
+  desc "Create and migrate Solid Cache and Solid Cable databases"
+  task setup: :environment do
+    %w[cache cable queue].each do |db_name|
+      puts "Setting up solid_#{db_name} database..."
+      config = ActiveRecord::Base.configurations.configs_for(
+        env_name: Rails.env, name: db_name
+      )
+      next unless config
+
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.create(config)
+        puts "  Created #{db_name} database"
+      rescue ActiveRecord::DatabaseAlreadyExists
+        puts "  #{db_name} database already exists"
+      end
+
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.migrate(config)
+        puts "  Migrated #{db_name} database"
+      rescue => e
+        # If no migrations exist, load schema directly
+        schema_file = Rails.root.join("db", "#{db_name}_schema.rb")
+        if schema_file.exist?
+          ActiveRecord::Schema.verbose = false
+          ActiveRecord::Base.establish_connection(config)
+          load(schema_file)
+          puts "  Loaded #{db_name} schema"
+        else
+          puts "  Warning: Could not set up #{db_name}: #{e.message}"
+        end
+      end
+    end
+
+    # Reconnect to primary database
+    ActiveRecord::Base.establish_connection(
+      ActiveRecord::Base.configurations.configs_for(
+        env_name: Rails.env, name: "primary"
+      )
+    )
+    puts "Solid infrastructure setup complete!"
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This activates Solid Cable as the Action Cable adapter in production, enabling real-time WebSocket features (like live notifications) to work without needing a separate Redis server.

This pull request makes the following changes:
* Configure Action Cable to use the Solid Cable adapter in production
* Solid Cable was already in the Gemfile — this activates it

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
