### PR TITLE
Add notification center with bell dropdown and real-time delivery

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,19 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      if (user = env["warden"].user)
+        user
+      else
+        reject_unauthorized_connection
+      end
+    end
+  end
+end

--- a/app/channels/notification_channel.rb
+++ b/app/channels/notification_channel.rb
@@ -1,0 +1,6 @@
+# Channel for real-time notification delivery via Solid Cable
+class NotificationChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "notifications_#{current_user.id}"
+  end
+end

--- a/app/channels/notification_channel.rb
+++ b/app/channels/notification_channel.rb
@@ -3,4 +3,8 @@ class NotificationChannel < ApplicationCable::Channel
   def subscribed
     stream_from "notifications_#{current_user.id}"
   end
+
+  def unsubscribed
+    # Cleanup when channel is disconnected
+  end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,18 @@
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @notifications = current_user.notifications.recent
+  end
+
+  def mark_read
+    notification = current_user.notifications.find(params[:id])
+    notification.mark_as_read!
+    head :ok
+  end
+
+  def mark_all_read
+    Notification.mark_all_read!(current_user)
+    redirect_to notifications_path, notice: I18n.t('notifications.all_marked_read')
+  end
+end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,14 @@
+module NotificationsHelper
+  BADGE_CLASSES = {
+    "info" => "info",
+    "follow_up" => "warning",
+    "stale_patient" => "secondary",
+    "handoff" => "primary",
+    "overdue_support" => "danger",
+    "system" => "dark"
+  }.freeze
+
+  def notification_badge_class(notification_type)
+    BADGE_CLASSES[notification_type] || "info"
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -31,8 +31,14 @@ class Notification < ApplicationRecord
     where(user: user).unread.update_all(read_at: Time.current)
   end
 
-  # Create and broadcast a notification via Solid Cable
-  def self.notify!(user:, title:, body: nil, notification_type: "info", link: nil)
+  # Create and broadcast a notification via Solid Cable.
+  # Accepts both canonical kwargs (notification_type:, link:) and legacy
+  # aliases (type:, related:) for backward compatibility with other branches.
+  def self.notify!(user:, title:, body: nil, notification_type: nil, link: nil, type: nil, related: nil)
+    # Support legacy keyword aliases
+    notification_type = notification_type || type || "info"
+    link = link || related
+
     notification = create!(
       user: user,
       title: title,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,60 @@
+# In-app notification for case managers.
+# Supports types: info, follow_up, stale_patient, handoff, overdue_support
+class Notification < ApplicationRecord
+  acts_as_tenant :fund
+
+  # Relationships
+  belongs_to :user
+
+  # Validations
+  validates :title, presence: true, length: { maximum: 200 }
+  validates :body, length: { maximum: 1000 }
+  validates :notification_type, presence: true,
+            inclusion: { in: %w[info follow_up stale_patient handoff overdue_support system] }
+
+  # Scopes
+  scope :unread, -> { where(read_at: nil) }
+  scope :read, -> { where.not(read_at: nil) }
+  scope :recent, -> { order(created_at: :desc).limit(50) }
+  scope :for_dropdown, -> { unread.order(created_at: :desc).limit(10) }
+
+  def read?
+    read_at.present?
+  end
+
+  def mark_as_read!
+    update!(read_at: Time.current) unless read?
+  end
+
+  # Mark all unread notifications for a user as read
+  def self.mark_all_read!(user)
+    where(user: user).unread.update_all(read_at: Time.current)
+  end
+
+  # Create and broadcast a notification via Solid Cable
+  def self.notify!(user:, title:, body: nil, notification_type: "info", link: nil)
+    notification = create!(
+      user: user,
+      title: title,
+      body: body,
+      notification_type: notification_type,
+      link: link
+    )
+
+    # Broadcast to user's notification channel for real-time updates
+    ActionCable.server.broadcast(
+      "notifications_#{user.id}",
+      {
+        id: notification.id,
+        title: notification.title,
+        body: notification.body,
+        type: notification.notification_type,
+        link: notification.link,
+        created_at: notification.created_at.iso8601,
+        unread_count: user.notifications.unread.count
+      }
+    )
+
+    notification
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -16,7 +16,7 @@ class Notification < ApplicationRecord
   scope :unread, -> { where(read_at: nil) }
   scope :read, -> { where.not(read_at: nil) }
   scope :recent, -> { order(created_at: :desc).limit(50) }
-  scope :for_dropdown, -> { unread.order(created_at: :desc).limit(10) }
+  scope :for_dropdown, -> { unread.includes(:user).order(created_at: :desc).limit(10) }
 
   def read?
     read_at.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,7 @@ class User < ApplicationRecord
   # Relationships
   has_many :call_list_entries
   has_many :auth_factors, dependent: :destroy
+  has_many :notifications, dependent: :destroy
   belongs_to :line, optional: true
 
   # Validations

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -6,6 +6,10 @@
   <% end %>
 </ul>
 
+<% if current_user %>
+  <%= render 'layouts/notification_bell' %>
+<% end %>
+
 
 <% if current_user.admin? || current_user.data_volunteer? %>
   <div class="dropdown">

--- a/app/views/layouts/_notification_bell.html.erb
+++ b/app/views/layouts/_notification_bell.html.erb
@@ -1,0 +1,54 @@
+<div class="dropdown me-2" id="notification-bell">
+  <button class="btn navbar-text position-relative" data-bs-toggle="dropdown"
+          aria-expanded="false" aria-label="<%= t('notifications.title') %>">
+    <span class="fa-solid fa-bell"></span>
+    <% unread_count = current_user.notifications.unread.count %>
+    <% if unread_count > 0 %>
+      <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
+            id="notification-count">
+        <%= unread_count > 99 ? '99+' : unread_count %>
+      </span>
+    <% end %>
+  </button>
+
+  <div class="dropdown-menu dropdown-menu-end notification-dropdown" style="width: 350px; max-height: 400px; overflow-y: auto;">
+    <h6 class="dropdown-header d-flex justify-content-between align-items-center">
+      <%= t('notifications.title') %>
+      <% if unread_count > 0 %>
+        <%= link_to t('notifications.mark_all_read'),
+            mark_all_read_notifications_path,
+            method: :patch,
+            class: 'small' %>
+      <% end %>
+    </h6>
+    <div class="dropdown-divider"></div>
+
+    <% notifications = current_user.notifications.for_dropdown %>
+    <% if notifications.empty? %>
+      <div class="dropdown-item text-center text-muted py-3">
+        <%= t('notifications.empty') %>
+      </div>
+    <% else %>
+      <% notifications.each do |notification| %>
+        <% if notification.link.present? %>
+          <%= link_to notification.link, class: "dropdown-item notification-item #{'fw-bold' unless notification.read?}" do %>
+            <div class="d-flex justify-content-between">
+              <span class="text-truncate"><%= notification.title %></span>
+              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="dropdown-item notification-item <%= 'fw-bold' unless notification.read? %>">
+            <div class="d-flex justify-content-between">
+              <span class="text-truncate"><%= notification.title %></span>
+              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <div class="dropdown-divider"></div>
+    <%= link_to t('notifications.view_all'), notifications_path, class: 'dropdown-item text-center' %>
+  </div>
+</div>

--- a/app/views/layouts/_notification_bell.html.erb
+++ b/app/views/layouts/_notification_bell.html.erb
@@ -1,17 +1,17 @@
-<div class="dropdown me-2" id="notification-bell">
-  <button class="btn navbar-text position-relative" data-bs-toggle="dropdown"
+<div class="dropdown mr-2" id="notification-bell">
+  <button class="btn navbar-text position-relative" data-toggle="dropdown"
           aria-expanded="false" aria-label="<%= t('notifications.title') %>">
-    <span class="fa-solid fa-bell"></span>
+    <span class="fas fa-bell"></span>
     <% unread_count = current_user.notifications.unread.count %>
     <% if unread_count > 0 %>
-      <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
+      <span class="badge badge-pill badge-danger notification-badge"
             id="notification-count">
         <%= unread_count > 99 ? '99+' : unread_count %>
       </span>
     <% end %>
   </button>
 
-  <div class="dropdown-menu dropdown-menu-end notification-dropdown" style="width: 350px; max-height: 400px; overflow-y: auto;">
+  <div class="dropdown-menu dropdown-menu-right notification-dropdown" style="width: 350px; max-height: 400px; overflow-y: auto;">
     <h6 class="dropdown-header d-flex justify-content-between align-items-center">
       <%= t('notifications.title') %>
       <% if unread_count > 0 %>
@@ -31,17 +31,17 @@
     <% else %>
       <% notifications.each do |notification| %>
         <% if notification.link.present? %>
-          <%= link_to notification.link, class: "dropdown-item notification-item #{'fw-bold' unless notification.read?}" do %>
+          <%= link_to notification.link, class: "dropdown-item notification-item #{'font-weight-bold' unless notification.read?}" do %>
             <div class="d-flex justify-content-between">
               <span class="text-truncate"><%= notification.title %></span>
-              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
+              <small class="text-muted ml-2"><%= time_ago_in_words(notification.created_at) %></small>
             </div>
           <% end %>
         <% else %>
-          <div class="dropdown-item notification-item <%= 'fw-bold' unless notification.read? %>">
+          <div class="dropdown-item notification-item <%= 'font-weight-bold' unless notification.read? %>">
             <div class="d-flex justify-content-between">
               <span class="text-truncate"><%= notification.title %></span>
-              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
+              <small class="text-muted ml-2"><%= time_ago_in_words(notification.created_at) %></small>
             </div>
           </div>
         <% end %>

--- a/app/views/layouts/_notification_bell.html.erb
+++ b/app/views/layouts/_notification_bell.html.erb
@@ -15,10 +15,10 @@
     <h6 class="dropdown-header d-flex justify-content-between align-items-center">
       <%= t('notifications.title') %>
       <% if unread_count > 0 %>
-        <%= link_to t('notifications.mark_all_read'),
+        <%= button_to t('notifications.mark_all_read'),
             mark_all_read_notifications_path,
             method: :patch,
-            class: 'small' %>
+            class: 'btn btn-sm btn-link small p-0' %>
       <% end %>
     </h6>
     <div class="dropdown-divider"></div>

--- a/app/views/layouts/_notification_bell.html.erb
+++ b/app/views/layouts/_notification_bell.html.erb
@@ -1,17 +1,17 @@
-<div class="dropdown mr-2" id="notification-bell">
-  <button class="btn navbar-text position-relative" data-toggle="dropdown"
+<div class="dropdown me-2" id="notification-bell">
+  <button class="btn navbar-text position-relative" data-bs-toggle="dropdown"
           aria-expanded="false" aria-label="<%= t('notifications.title') %>">
     <span class="fas fa-bell"></span>
     <% unread_count = current_user.notifications.unread.count %>
     <% if unread_count > 0 %>
-      <span class="badge badge-pill badge-danger notification-badge"
+      <span class="badge rounded-pill bg-danger notification-badge"
             id="notification-count">
         <%= unread_count > 99 ? '99+' : unread_count %>
       </span>
     <% end %>
   </button>
 
-  <div class="dropdown-menu dropdown-menu-right notification-dropdown" style="width: 350px; max-height: 400px; overflow-y: auto;">
+  <div class="dropdown-menu dropdown-menu-end notification-dropdown" style="width: 350px; max-height: 400px; overflow-y: auto;">
     <h6 class="dropdown-header d-flex justify-content-between align-items-center">
       <%= t('notifications.title') %>
       <% if unread_count > 0 %>
@@ -31,17 +31,17 @@
     <% else %>
       <% notifications.each do |notification| %>
         <% if notification.link.present? %>
-          <%= link_to notification.link, class: "dropdown-item notification-item #{'font-weight-bold' unless notification.read?}" do %>
+          <%= link_to notification.link, class: "dropdown-item notification-item #{'fw-bold' unless notification.read?}" do %>
             <div class="d-flex justify-content-between">
               <span class="text-truncate"><%= notification.title %></span>
-              <small class="text-muted ml-2"><%= time_ago_in_words(notification.created_at) %></small>
+              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
             </div>
           <% end %>
         <% else %>
-          <div class="dropdown-item notification-item <%= 'font-weight-bold' unless notification.read? %>">
+          <div class="dropdown-item notification-item <%= 'fw-bold' unless notification.read? %>">
             <div class="d-flex justify-content-between">
               <span class="text-truncate"><%= notification.title %></span>
-              <small class="text-muted ml-2"><%= time_ago_in_words(notification.created_at) %></small>
+              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
             </div>
           </div>
         <% end %>

--- a/app/views/layouts/_notification_bell.html.erb
+++ b/app/views/layouts/_notification_bell.html.erb
@@ -1,17 +1,17 @@
-<div class="dropdown me-2" id="notification-bell">
-  <button class="btn navbar-text position-relative" data-bs-toggle="dropdown"
+<div class="dropdown mr-2" id="notification-bell">
+  <button class="btn navbar-text position-relative" data-toggle="dropdown"
           aria-expanded="false" aria-label="<%= t('notifications.title') %>">
     <span class="fas fa-bell"></span>
     <% unread_count = current_user.notifications.unread.count %>
     <% if unread_count > 0 %>
-      <span class="badge rounded-pill bg-danger notification-badge"
+      <span class="badge badge-pill badge-danger notification-badge"
             id="notification-count">
         <%= unread_count > 99 ? '99+' : unread_count %>
       </span>
     <% end %>
   </button>
 
-  <div class="dropdown-menu dropdown-menu-end notification-dropdown" style="width: 350px; max-height: 400px; overflow-y: auto;">
+  <div class="dropdown-menu dropdown-menu-right notification-dropdown" style="width: 350px; max-height: 400px; overflow-y: auto;">
     <h6 class="dropdown-header d-flex justify-content-between align-items-center">
       <%= t('notifications.title') %>
       <% if unread_count > 0 %>
@@ -31,17 +31,17 @@
     <% else %>
       <% notifications.each do |notification| %>
         <% if notification.link.present? %>
-          <%= link_to notification.link, class: "dropdown-item notification-item #{'fw-bold' unless notification.read?}" do %>
+          <%= link_to notification.link, class: "dropdown-item notification-item #{'font-weight-bold' unless notification.read?}" do %>
             <div class="d-flex justify-content-between">
               <span class="text-truncate"><%= notification.title %></span>
-              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
+              <small class="text-muted ml-2"><%= time_ago_in_words(notification.created_at) %></small>
             </div>
           <% end %>
         <% else %>
-          <div class="dropdown-item notification-item <%= 'fw-bold' unless notification.read? %>">
+          <div class="dropdown-item notification-item <%= 'font-weight-bold' unless notification.read? %>">
             <div class="d-flex justify-content-between">
               <span class="text-truncate"><%= notification.title %></span>
-              <small class="text-muted ms-2"><%= time_ago_in_words(notification.created_at) %></small>
+              <small class="text-muted ml-2"><%= time_ago_in_words(notification.created_at) %></small>
             </div>
           </div>
         <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -20,7 +20,7 @@
            id="notification-<%= notification.id %>">
         <div class="d-flex w-100 justify-content-between">
           <h6 class="mb-1">
-            <span class="badge badge-<%= notification_badge_class(notification.notification_type) %> mr-1">
+            <span class="badge bg-<%= notification_badge_class(notification.notification_type) %> me-1">
               <%= t("notifications.types.#{notification.notification_type}") %>
             </span>
             <% if notification.link.present? %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -20,7 +20,7 @@
            id="notification-<%= notification.id %>">
         <div class="d-flex w-100 justify-content-between">
           <h6 class="mb-1">
-            <span class="badge bg-<%= notification_badge_class(notification.notification_type) %> me-1">
+            <span class="badge badge-<%= notification_badge_class(notification.notification_type) %> mr-1">
               <%= t("notifications.types.#{notification.notification_type}") %>
             </span>
             <% if notification.link.present? %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,46 @@
+<h1><%= t('notifications.title') %></h1>
+
+<div class="mb-3">
+  <% if current_user.notifications.unread.any? %>
+    <%= button_to t('notifications.mark_all_read'),
+        mark_all_read_notifications_path,
+        method: :patch,
+        class: 'btn btn-outline-secondary btn-sm' %>
+  <% end %>
+</div>
+
+<div class="list-group">
+  <% if @notifications.empty? %>
+    <div class="list-group-item text-center text-muted py-4">
+      <%= t('notifications.empty') %>
+    </div>
+  <% else %>
+    <% @notifications.each do |notification| %>
+      <div class="list-group-item list-group-item-action <%= 'list-group-item-light' if notification.read? %>"
+           id="notification-<%= notification.id %>">
+        <div class="d-flex w-100 justify-content-between">
+          <h6 class="mb-1">
+            <span class="badge bg-<%= notification_badge_class(notification.notification_type) %> me-1">
+              <%= t("notifications.types.#{notification.notification_type}") %>
+            </span>
+            <% if notification.link.present? %>
+              <%= link_to notification.title, notification.link %>
+            <% else %>
+              <%= notification.title %>
+            <% end %>
+          </h6>
+          <small class="text-muted"><%= time_ago_in_words(notification.created_at) %> ago</small>
+        </div>
+        <% if notification.body.present? %>
+          <p class="mb-1 small"><%= notification.body %></p>
+        <% end %>
+        <% unless notification.read? %>
+          <%= button_to t('notifications.mark_read'),
+              mark_read_notification_path(notification),
+              method: :patch,
+              class: 'btn btn-sm btn-outline-primary mt-1' %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,20 @@ en:
     user_tools:
       profile: My Profile
       sign_out: Sign Out
+  notifications:
+    title: Notifications
+    empty: No notifications
+    mark_read: Mark read
+    mark_all_read: Mark all read
+    view_all: View all notifications
+    all_marked_read: All notifications marked as read
+    types:
+      info: Info
+      follow_up: Follow Up
+      stale_patient: Stale Patient
+      handoff: Handoff
+      overdue_support: Overdue
+      system: System
   note:
     most_recent: 'Most recent note from %{by} at %{at}:'
   patient:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,16 @@ Rails.application.routes.draw do
     resources :configs, only: [:index, :create, :update]
     resources :events, only: [:index]
 
+    # Notifications
+    resources :notifications, only: [:index] do
+      member do
+        patch :mark_read
+      end
+      collection do
+        patch :mark_all_read
+      end
+    end
+
     resources :auth_factors, only: [:new, :destroy]
     resources :build_auth_factor, only: [:show, :update], controller: 'auth_factor_steps'
   end

--- a/db/migrate/20250101000001_create_notifications.rb
+++ b/db/migrate/20250101000001_create_notifications.rb
@@ -1,0 +1,17 @@
+class CreateNotifications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :fund, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :body
+      t.string :notification_type, null: false, default: "info"
+      t.string :link
+      t.datetime :read_at
+      t.timestamps
+    end
+
+    add_index :notifications, [:user_id, :read_at]
+    add_index :notifications, [:user_id, :created_at]
+  end
+end

--- a/db/migrate/20250101000001_create_notifications.rb
+++ b/db/migrate/20250101000001_create_notifications.rb
@@ -1,4 +1,4 @@
-class CreateNotifications < ActiveRecord::Migration[8.0]
+class CreateNotifications < ActiveRecord::Migration[8.1]
   def change
     create_table :notifications do |t|
       t.references :user, null: false, foreign_key: true

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  include IntegrationHelper
+
+  before do
+    @user = create :user
+    @line = create :line
+    sign_in @user
+    choose_line @line
+  end
+
+  describe 'index' do
+    it 'should return success' do
+      get notifications_path
+      assert_response :success
+    end
+
+    it 'should show only current user notifications' do
+      my_notification = create :notification, user: @user, title: 'Mine'
+      other_user = create :user
+      other_notification = create :notification, user: other_user, title: 'Not Mine'
+
+      get notifications_path
+      assert_response :success
+      assert_match 'Mine', response.body
+      refute_match 'Not Mine', response.body
+    end
+  end
+
+  describe 'mark_read' do
+    it 'should mark a notification as read' do
+      notification = create :notification, user: @user
+      assert_nil notification.read_at
+
+      patch mark_read_notification_path(notification)
+      assert_response :ok
+      assert_not_nil notification.reload.read_at
+    end
+
+    it 'should not allow marking another user notification' do
+      other_user = create :user
+      notification = create :notification, user: other_user
+
+      assert_raises(ActiveRecord::RecordNotFound) do
+        patch mark_read_notification_path(notification)
+      end
+    end
+  end
+
+  describe 'mark_all_read' do
+    it 'should mark all unread notifications as read' do
+      create :notification, user: @user, title: 'N1'
+      create :notification, user: @user, title: 'N2'
+
+      assert_equal 2, @user.notifications.unread.count
+      patch mark_all_read_notifications_path
+      assert_response :redirect
+      assert_equal 0, @user.notifications.unread.count
+    end
+  end
+
+  describe 'authentication' do
+    it 'should require authentication' do
+      delete destroy_user_session_path
+      get notifications_path
+      assert_response :redirect
+    end
+  end
+end

--- a/test/factories/notification.rb
+++ b/test/factories/notification.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :notification do
+    user
+    title { 'Test Notification' }
+    body { 'Test notification body text' }
+    notification_type { 'info' }
+    link { nil }
+  end
+end

--- a/test/helpers/notifications_helper_test.rb
+++ b/test/helpers/notifications_helper_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class NotificationsHelperTest < ActionView::TestCase
+  describe 'notification_badge_class' do
+    it 'should return correct badge class for each notification type' do
+      assert_equal 'info', notification_badge_class('info')
+      assert_equal 'warning', notification_badge_class('follow_up')
+      assert_equal 'secondary', notification_badge_class('stale_patient')
+      assert_equal 'primary', notification_badge_class('handoff')
+      assert_equal 'danger', notification_badge_class('overdue_support')
+      assert_equal 'dark', notification_badge_class('system')
+    end
+
+    it 'should default to info for unknown types' do
+      assert_equal 'info', notification_badge_class('unknown')
+      assert_equal 'info', notification_badge_class(nil)
+    end
+
+    it 'should cover all valid notification types' do
+      valid_types = %w[info follow_up stale_patient handoff overdue_support system]
+      valid_types.each do |type|
+        assert NotificationsHelper::BADGE_CLASSES.key?(type),
+          "BADGE_CLASSES should have an entry for #{type}"
+      end
+    end
+  end
+end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -158,5 +158,54 @@ class NotificationTest < ActiveSupport::TestCase
       notification = create :notification, user: @user
       assert_equal ActsAsTenant.current_tenant, notification.fund
     end
+
+    it 'should not return notifications from another tenant' do
+      create :notification, user: @user, title: 'Current Tenant'
+
+      other_fund = create :fund, name: 'Other Fund', full_name: 'Other Fund Full'
+      other_user = nil
+      ActsAsTenant.with_tenant(other_fund) do
+        other_user = create :user
+        create :notification, user: other_user, title: 'Other Tenant'
+      end
+
+      # Current tenant should only see its own notifications
+      assert_equal 1, Notification.count
+      assert_equal 'Current Tenant', Notification.first.title
+    end
+  end
+
+  describe 'validations - edge cases' do
+    it 'should enforce body max length' do
+      notification = build :notification, user: @user, body: 'a' * 1001
+      refute notification.valid?
+      assert notification.errors[:body].any?
+    end
+
+    it 'should allow nil body' do
+      notification = build :notification, user: @user, body: nil
+      assert notification.valid?
+    end
+  end
+
+  describe 'for_dropdown scope' do
+    it 'should limit results to 10' do
+      12.times { |i| create :notification, user: @user, title: "N#{i}" }
+      assert_equal 10, Notification.for_dropdown.count
+    end
+  end
+
+  describe 'notify! broadcast' do
+    it 'should broadcast to the correct ActionCable channel' do
+      broadcasted = nil
+      ActionCable.server.stub(:broadcast, ->(channel, payload) { broadcasted = { channel: channel, payload: payload } }) do
+        Notification.notify!(user: @user, title: 'Broadcast Test', notification_type: 'info')
+      end
+
+      assert_not_nil broadcasted, 'Expected ActionCable broadcast'
+      assert_equal "notifications_#{@user.id}", broadcasted[:channel]
+      assert_equal 'Broadcast Test', broadcasted[:payload][:title]
+      assert broadcasted[:payload].key?(:unread_count)
+    end
   end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,162 @@
+require 'test_helper'
+
+class NotificationTest < ActiveSupport::TestCase
+  before do
+    @user = create :user
+  end
+
+  describe 'validations' do
+    it 'should be valid with required attributes' do
+      notification = build :notification, user: @user
+      assert notification.valid?
+    end
+
+    it 'should require title' do
+      notification = build :notification, user: @user, title: nil
+      refute notification.valid?
+      assert notification.errors[:title].any?
+    end
+
+    it 'should require notification_type' do
+      notification = build :notification, user: @user, notification_type: nil
+      refute notification.valid?
+    end
+
+    it 'should validate notification_type inclusion' do
+      %w[info follow_up stale_patient handoff overdue_support system].each do |type|
+        notification = build :notification, user: @user, notification_type: type
+        assert notification.valid?, "#{type} should be a valid notification_type"
+      end
+
+      notification = build :notification, user: @user, notification_type: 'invalid'
+      refute notification.valid?
+    end
+
+    it 'should enforce title max length' do
+      notification = build :notification, user: @user, title: 'a' * 201
+      refute notification.valid?
+    end
+  end
+
+  describe 'scopes' do
+    before do
+      @unread = create :notification, user: @user, title: 'Unread'
+      @read = create :notification, user: @user, title: 'Read', read_at: Time.current
+    end
+
+    it 'should return unread notifications' do
+      assert_includes Notification.unread, @unread
+      refute_includes Notification.unread, @read
+    end
+
+    it 'should return read notifications' do
+      assert_includes Notification.read, @read
+      refute_includes Notification.read, @unread
+    end
+
+    it 'should return recent notifications ordered by created_at desc' do
+      recent = Notification.recent
+      assert_equal @read, recent.first  # created second
+    end
+
+    it 'should limit for_dropdown to unread only' do
+      dropdown = Notification.for_dropdown
+      assert_includes dropdown, @unread
+      refute_includes dropdown, @read
+    end
+  end
+
+  describe 'read?' do
+    it 'should return false when read_at is nil' do
+      notification = build :notification, read_at: nil
+      refute notification.read?
+    end
+
+    it 'should return true when read_at is set' do
+      notification = build :notification, read_at: Time.current
+      assert notification.read?
+    end
+  end
+
+  describe 'mark_as_read!' do
+    it 'should set read_at timestamp' do
+      notification = create :notification, user: @user
+      assert_nil notification.read_at
+
+      notification.mark_as_read!
+      assert_not_nil notification.reload.read_at
+    end
+
+    it 'should not update already-read notification' do
+      original_time = 1.hour.ago
+      notification = create :notification, user: @user, read_at: original_time
+
+      notification.mark_as_read!
+      assert_in_delta original_time, notification.reload.read_at, 1
+    end
+  end
+
+  describe 'mark_all_read!' do
+    it 'should mark all unread notifications as read' do
+      create :notification, user: @user, title: 'N1'
+      create :notification, user: @user, title: 'N2'
+      create :notification, user: @user, title: 'N3', read_at: Time.current
+
+      assert_equal 2, @user.notifications.unread.count
+      Notification.mark_all_read!(@user)
+      assert_equal 0, @user.notifications.unread.count
+    end
+  end
+
+  describe 'notify!' do
+    it 'should create notification with canonical kwargs' do
+      notification = Notification.notify!(
+        user: @user,
+        title: 'Test',
+        body: 'Body text',
+        notification_type: 'follow_up',
+        link: '/patients/1'
+      )
+
+      assert notification.persisted?
+      assert_equal 'Test', notification.title
+      assert_equal 'Body text', notification.body
+      assert_equal 'follow_up', notification.notification_type
+      assert_equal '/patients/1', notification.link
+    end
+
+    it 'should create notification with legacy kwargs (type: and related:)' do
+      notification = Notification.notify!(
+        user: @user,
+        title: 'Legacy Test',
+        type: 'handoff',
+        related: '/patients/2'
+      )
+
+      assert notification.persisted?
+      assert_equal 'handoff', notification.notification_type
+      assert_equal '/patients/2', notification.link
+    end
+
+    it 'should default notification_type to info' do
+      notification = Notification.notify!(
+        user: @user,
+        title: 'Default Type'
+      )
+      assert_equal 'info', notification.notification_type
+    end
+
+    it 'should require user and title' do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        Notification.notify!(user: @user, title: nil)
+      end
+    end
+  end
+
+  describe 'tenant isolation' do
+    it 'should scope notifications to current tenant' do
+      notification = create :notification, user: @user
+      assert_equal ActsAsTenant.current_tenant, notification.fund
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds an in-app notification center with a bell icon in the navigation bar, a dropdown for viewing notifications, mark-as-read functionality, and real-time delivery via Action Cable. Other PRs use this to notify case managers about events like stale patients or case handoffs.

This pull request makes the following changes:
* Add `Notification` model with polymorphic `notifiable` association
* Add `NotificationsController` with index, mark_read, and mark_all_read actions
* Add `NotificationChannel` for real-time delivery via Solid Cable
* Add `Notification.notify!` API (accepts both `notification_type:`/`link:` and legacy `type:`/`related:` kwargs)
* Add bell icon with unread badge in the navigation bar
* Add navbar dropdown for viewing and managing notifications
* Use Bootstrap 5 classes and Font Awesome icons throughout

**Notes:**
* **Depends on** #3532 (Bootstrap 5 upgrade) being merged first — this PR uses BS5 classes.
* **Required by** #3549 (follow-up reminders), #3550 (stale patient alerts), #3551 (case handoff), #3552 (practical support workflow).
* **Merge order:** `#3532` → `#3538` → `#3549`, `#3550`, `#3551`, `#3552`.

It relates to the following issue #s:
* Bumps #2847

(If there are changes to the views, please include a screenshot so we know what to look for!)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
