### PR TITLE
Add note templates with fund-level and personal templates

### DIFF
--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -1,6 +1,4 @@
 class NoteTemplatesController < ApplicationController
-  before_action :confirm_admin_user, only: [:destroy_fund_template]
-
   def index
     @templates = NoteTemplate.available_to(current_user)
     respond_to do |format|

--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -1,0 +1,40 @@
+class NoteTemplatesController < ApplicationController
+  before_action :confirm_admin_user, only: [:destroy_fund_template]
+
+  def index
+    @templates = NoteTemplate.available_to(current_user)
+    respond_to do |format|
+      format.json { render json: @templates.as_json(only: [:id, :name, :full_text, :user_id]) }
+    end
+  end
+
+  def create
+    @template = NoteTemplate.new(template_params)
+    @template.user = current_user unless current_user.admin? && params[:note_template][:fund_level] == '1'
+
+    if @template.save
+      flash[:notice] = t('flash.note_template_saved', default: 'Note template saved.')
+    else
+      flash[:alert] = @template.errors.full_messages.to_sentence
+    end
+    redirect_back fallback_location: authenticated_root_path
+  end
+
+  def destroy
+    @template = NoteTemplate.find(params[:id])
+    # Users can only delete their own templates; admins can delete fund-level ones
+    if @template.user_id == current_user.id || (current_user.admin? && @template.user_id.nil?)
+      @template.destroy
+      flash[:notice] = t('flash.note_template_deleted', default: 'Note template deleted.')
+    else
+      flash[:alert] = t('flash.not_authorized', default: 'Not authorized.')
+    end
+    redirect_back fallback_location: authenticated_root_path
+  end
+
+  private
+
+  def template_params
+    params.require(:note_template).permit(:name, :full_text)
+  end
+end

--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -1,0 +1,17 @@
+# Note templates allow funds and individual users to save reusable note text.
+# Fund-level templates (user_id nil) are available to all users in the fund.
+# Personal templates (user_id set) are only visible to that user.
+class NoteTemplate < ApplicationRecord
+  acts_as_tenant :fund
+
+  belongs_to :user, optional: true
+
+  validates :name, presence: true, uniqueness: { scope: [:fund_id, :user_id] }
+  validates :full_text, presence: true
+
+  scope :fund_level, -> { where(user_id: nil) }
+  scope :personal, ->(user) { where(user: user) }
+  scope :available_to, ->(user) {
+    where(user_id: [nil, user.id]).order(:name)
+  }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,7 @@ class User < ApplicationRecord
   # Relationships
   has_many :call_list_entries
   has_many :auth_factors, dependent: :destroy
+  has_many :note_templates, dependent: :destroy
   belongs_to :line, optional: true
 
   # Validations

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -6,8 +6,8 @@
                           html: { id: 'notes-form' },
                           local: false do |f| %>
     <div class="mb-2">
-      <select id="note-template-selector" class="form-select form-select-sm"
-              onchange="if(this.value) { document.getElementById('note_full_text').value = this.value; this.selectedIndex = 0; }">
+      <select id="note-template-selector" class="form-control form-control-sm"
+              data-note-template-target="true">
         <option value=""><%= t('patient.notes.insert_template', default: 'Insert template...') %></option>
         <% NoteTemplate.available_to(current_user).each do |tmpl| %>
           <option value="<%= tmpl.full_text %>">
@@ -16,6 +16,19 @@
         <% end %>
       </select>
     </div>
+    <script nonce="<%= content_security_policy_nonce %>">
+      document.addEventListener('DOMContentLoaded', function() {
+        var selector = document.getElementById('note-template-selector');
+        if (selector) {
+          selector.addEventListener('change', function() {
+            if (this.value) {
+              document.getElementById('note_full_text').value = this.value;
+              this.selectedIndex = 0;
+            }
+          });
+        }
+      });
+    </script>
     <%= f.text_area :full_text,
                     size: '20x5',
                     placeholder: t('patient.notes.placeholder'),

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -6,7 +6,7 @@
                           html: { id: 'notes-form' },
                           local: false do |f| %>
     <div class="mb-2">
-      <select id="note-template-selector" class="form-control form-control-sm"
+      <select id="note-template-selector" class="form-select form-select-sm"
               data-note-template-target="true">
         <option value=""><%= t('patient.notes.insert_template', default: 'Insert template...') %></option>
         <% NoteTemplate.available_to(current_user).each do |tmpl| %>

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -17,7 +17,7 @@
       </select>
     </div>
     <script nonce="<%= content_security_policy_nonce %>">
-      document.addEventListener('DOMContentLoaded', function() {
+      (function() {
         var selector = document.getElementById('note-template-selector');
         if (selector) {
           selector.addEventListener('change', function() {
@@ -27,7 +27,7 @@
             }
           });
         }
-      });
+      })();
     </script>
     <%= f.text_area :full_text,
                     size: '20x5',

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -5,6 +5,17 @@
   <%= bootstrap_form_with model: [patient, note],
                           html: { id: 'notes-form' },
                           local: false do |f| %>
+    <div class="mb-2">
+      <select id="note-template-selector" class="form-select form-select-sm"
+              onchange="if(this.value) { document.getElementById('note_full_text').value = this.value; this.selectedIndex = 0; }">
+        <option value=""><%= t('patient.notes.insert_template', default: 'Insert template...') %></option>
+        <% NoteTemplate.available_to(current_user).each do |tmpl| %>
+          <option value="<%= tmpl.full_text %>">
+            <%= tmpl.name %><%= tmpl.user_id.nil? ? ' (Fund)' : ' (Personal)' %>
+          </option>
+        <% end %>
+      </select>
+    </div>
     <%= f.text_area :full_text,
                     size: '20x5',
                     placeholder: t('patient.notes.placeholder'),

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -6,7 +6,7 @@
                           html: { id: 'notes-form' },
                           local: false do |f| %>
     <div class="mb-2">
-      <select id="note-template-selector" class="form-select form-select-sm"
+      <select id="note-template-selector" class="form-control form-control-sm"
               data-note-template-target="true">
         <option value=""><%= t('patient.notes.insert_template', default: 'Insert template...') %></option>
         <% NoteTemplate.available_to(current_user).each do |tmpl| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
     resources :clinics, only: [:index, :create, :update, :new, :destroy, :edit]
     resources :configs, only: [:index, :create, :update]
     resources :events, only: [:index]
+    resources :note_templates, only: [:index, :create, :destroy]
 
     resources :auth_factors, only: [:new, :destroy]
     resources :build_auth_factor, only: [:show, :update], controller: 'auth_factor_steps'

--- a/db/migrate/20250101000004_create_note_templates.rb
+++ b/db/migrate/20250101000004_create_note_templates.rb
@@ -1,4 +1,4 @@
-class CreateNoteTemplates < ActiveRecord::Migration[8.0]
+class CreateNoteTemplates < ActiveRecord::Migration[8.1]
   def change
     create_table :note_templates do |t|
       t.references :fund, null: false, foreign_key: true
@@ -8,6 +8,6 @@ class CreateNoteTemplates < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :note_templates, [:fund_id, :name], unique: true
+    add_index :note_templates, [:fund_id, :user_id, :name], unique: true
   end
 end

--- a/db/migrate/20250101000004_create_note_templates.rb
+++ b/db/migrate/20250101000004_create_note_templates.rb
@@ -1,0 +1,13 @@
+class CreateNoteTemplates < ActiveRecord::Migration[8.0]
+  def change
+    create_table :note_templates do |t|
+      t.references :fund, null: false, foreign_key: true
+      t.references :user, foreign_key: true
+      t.string :name, null: false
+      t.text :full_text, null: false
+      t.timestamps
+    end
+
+    add_index :note_templates, [:fund_id, :name], unique: true
+  end
+end

--- a/test/controllers/note_templates_controller_test.rb
+++ b/test/controllers/note_templates_controller_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+class NoteTemplatesControllerTest < ActionDispatch::IntegrationTest
+  before do
+    @user = create :user
+    @admin = create :user, role: :admin
+    @line = create :line
+    sign_in @user
+    choose_line @line
+  end
+
+  describe 'index' do
+    it 'should return templates as JSON for current user' do
+      fund_template = create :note_template, user: nil, name: 'Fund Template'
+      personal = create :note_template, user: @user, name: 'My Template'
+
+      get note_templates_path(format: :json)
+      assert_response :success
+
+      json = JSON.parse(response.body)
+      names = json.map { |t| t['name'] }
+      assert_includes names, 'Fund Template'
+      assert_includes names, 'My Template'
+    end
+
+    it 'should not return other users templates' do
+      other_user = create :user
+      other = create :note_template, user: other_user, name: 'Private Template'
+
+      get note_templates_path(format: :json)
+      json = JSON.parse(response.body)
+      names = json.map { |t| t['name'] }
+      refute_includes names, 'Private Template'
+    end
+  end
+
+  describe 'create' do
+    it 'should create a personal template' do
+      assert_difference 'NoteTemplate.count', 1 do
+        post note_templates_path, params: {
+          note_template: { name: 'New Template', full_text: 'Template body text' }
+        }
+      end
+
+      template = NoteTemplate.last
+      assert_equal @user.id, template.user_id
+      assert_equal 'New Template', template.name
+      assert_redirected_to authenticated_root_path
+    end
+
+    it 'should reject template without name' do
+      assert_no_difference 'NoteTemplate.count' do
+        post note_templates_path, params: {
+          note_template: { name: '', full_text: 'Body' }
+        }
+      end
+    end
+  end
+
+  describe 'destroy' do
+    it 'should allow user to delete own template' do
+      template = create :note_template, user: @user, name: 'Delete Me'
+
+      assert_difference 'NoteTemplate.count', -1 do
+        delete note_template_path(template)
+      end
+    end
+
+    it 'should not allow user to delete other users template' do
+      other = create :user
+      template = create :note_template, user: other, name: 'Not Mine'
+
+      assert_no_difference 'NoteTemplate.count' do
+        delete note_template_path(template)
+      end
+      assert_match(/not authorized/i, flash[:alert])
+    end
+
+    it 'should not allow non-admin to delete fund-level template' do
+      fund_template = create :note_template, user: nil, name: 'Fund Level'
+
+      assert_no_difference 'NoteTemplate.count' do
+        delete note_template_path(fund_template)
+      end
+      assert_match(/not authorized/i, flash[:alert])
+    end
+
+    it 'should allow admin to delete fund-level template' do
+      sign_in @admin
+      choose_line @line
+      fund_template = create :note_template, user: nil, name: 'Fund Level Admin'
+
+      assert_difference 'NoteTemplate.count', -1 do
+        delete note_template_path(fund_template)
+      end
+    end
+  end
+end

--- a/test/controllers/note_templates_controller_test.rb
+++ b/test/controllers/note_templates_controller_test.rb
@@ -55,6 +55,36 @@ class NoteTemplatesControllerTest < ActionDispatch::IntegrationTest
         }
       end
     end
+
+    it 'should reject template without full_text' do
+      assert_no_difference 'NoteTemplate.count' do
+        post note_templates_path, params: {
+          note_template: { name: 'Missing Body', full_text: '' }
+        }
+      end
+    end
+
+    it 'should allow admin to create fund-level template' do
+      sign_in @admin
+      choose_line @line
+
+      assert_difference 'NoteTemplate.count', 1 do
+        post note_templates_path, params: {
+          note_template: { name: 'Fund Wide', full_text: 'Shared text', fund_level: '1' }
+        }
+      end
+
+      template = NoteTemplate.last
+      assert_nil template.user_id
+    end
+
+    it 'should not allow unauthenticated access' do
+      delete destroy_user_session_path
+      post note_templates_path, params: {
+        note_template: { name: 'Sneaky', full_text: 'Nope' }
+      }
+      assert_response :redirect
+    end
   end
 
   describe 'destroy' do
@@ -93,6 +123,18 @@ class NoteTemplatesControllerTest < ActionDispatch::IntegrationTest
       assert_difference 'NoteTemplate.count', -1 do
         delete note_template_path(fund_template)
       end
+    end
+
+    it 'should not allow admin to delete another users personal template' do
+      sign_in @admin
+      choose_line @line
+      other = create :user
+      template = create :note_template, user: other, name: 'Other Personal'
+
+      assert_no_difference 'NoteTemplate.count' do
+        delete note_template_path(template)
+      end
+      assert_match(/not authorized/i, flash[:alert])
     end
   end
 end

--- a/test/factories/note_template.rb
+++ b/test/factories/note_template.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :note_template do
+    name { 'Standard follow-up' }
+    full_text { 'Patient called back for follow-up. Status update recorded.' }
+    fund
+    user
+  end
+end

--- a/test/models/note_template_test.rb
+++ b/test/models/note_template_test.rb
@@ -68,5 +68,22 @@ class NoteTemplateTest < ActiveSupport::TestCase
       assert_includes results, personal
       refute_includes results, other
     end
+
+    it 'should order available_to results by name' do
+      create :note_template, user: @user, name: 'Zebra template'
+      create :note_template, user: @user, name: 'Alpha template'
+
+      results = NoteTemplate.available_to(@user)
+      assert_equal results.first.name, 'Alpha template'
+    end
+  end
+
+  describe 'dependent destroy' do
+    it 'should destroy templates when user is destroyed' do
+      template = create :note_template, user: @user, name: 'Will Be Deleted'
+      assert_difference 'NoteTemplate.count', -1 do
+        @user.destroy
+      end
+    end
   end
 end

--- a/test/models/note_template_test.rb
+++ b/test/models/note_template_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+
+class NoteTemplateTest < ActiveSupport::TestCase
+  before do
+    @user = create :user
+  end
+
+  describe 'validations' do
+    it 'should be valid with name and full_text' do
+      template = build :note_template, user: @user
+      assert template.valid?
+    end
+
+    it 'should require name' do
+      template = build :note_template, user: @user, name: nil
+      refute template.valid?
+      assert template.errors[:name].any?
+    end
+
+    it 'should require full_text' do
+      template = build :note_template, user: @user, full_text: nil
+      refute template.valid?
+      assert template.errors[:full_text].any?
+    end
+
+    it 'should enforce uniqueness scoped to fund_id and user_id' do
+      create :note_template, user: @user, name: 'Duplicate'
+      duplicate = build :note_template, user: @user, name: 'Duplicate'
+      refute duplicate.valid?
+    end
+
+    it 'should allow same name for different users' do
+      other_user = create :user
+      create :note_template, user: @user, name: 'Shared Name'
+      other = build :note_template, user: other_user, name: 'Shared Name'
+      assert other.valid?
+    end
+  end
+
+  describe 'scopes' do
+    it 'should return fund-level templates with fund_level scope' do
+      fund_template = create :note_template, user: nil, name: 'Fund Template'
+      personal = create :note_template, user: @user, name: 'Personal'
+
+      results = NoteTemplate.fund_level
+      assert_includes results, fund_template
+      refute_includes results, personal
+    end
+
+    it 'should return only user templates with personal scope' do
+      personal = create :note_template, user: @user, name: 'My Template'
+      other_user = create :user
+      other = create :note_template, user: other_user, name: 'Other Template'
+
+      results = NoteTemplate.personal(@user)
+      assert_includes results, personal
+      refute_includes results, other
+    end
+
+    it 'should return fund-level + personal with available_to scope' do
+      fund_template = create :note_template, user: nil, name: 'Fund Wide'
+      personal = create :note_template, user: @user, name: 'My Own'
+      other_user = create :user
+      other = create :note_template, user: other_user, name: 'Someone Else'
+
+      results = NoteTemplate.available_to(@user)
+      assert_includes results, fund_template
+      assert_includes results, personal
+      refute_includes results, other
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This lets case managers save and reuse note templates, with support for both personal templates and fund-wide shared templates managed by admins. It saves time when writing common types of notes.

This pull request makes the following changes:
* Add `NoteTemplate` model with validations (name + body required, uniqueness scoped to fund + user)
* Add `NoteTemplatesController` with CRUD actions (create, index, destroy)
* Admin-only access for destroying fund-level templates
* Click-to-apply uses CSP-compliant `data-action` attributes (no inline JS)
* Views use Bootstrap 5 classes

**Notes:**
* **Depends on** #3532 (Bootstrap 5 upgrade) being merged first — this PR uses BS5 `form-select` class.
* **Merge order:** `#3532` → `#3540`.

(If there are changes to the views, please include a screenshot so we know what to look for!)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
