### PR TITLE
Fix Sass deprecation warnings: map-merge() to map.merge() (#3312, #3313)

### DIFF
--- a/app/assets/stylesheets/styles/bootstrap.scss
+++ b/app/assets/stylesheets/styles/bootstrap.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use 'bootstrap/scss/bootstrap';
 // @import "rails_bootstrap_forms";
 
@@ -5,7 +6,7 @@ $spacer: .5rem !default;
 
 $spacers: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
-$spacers: map-merge(
+$spacers: map.merge(
   (
     0: 0,
     1: ($spacer * .25), //.125 rem


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This fixes Sass deprecation warnings that generate noisy build output, giving developers a cleaner console when building stylesheets.

This pull request makes the following changes:
* Configure Sass options to suppress known Bootstrap 4 deprecation warnings
* No functional changes — this is a warning suppression for cleaner build output

**Notes:**
* **Recommended:** merge BEFORE #3532 (Bootstrap 5 upgrade). If #3532 has already merged, verify whether these suppressions are still needed — BS5 may not trigger the same warnings.

It relates to the following issue #s:
* Fixes #3312
* Fixes #3313

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
