### PR TITLE
Add Office 365-style auto-save for patient forms

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -23,3 +23,4 @@
 @use './styles/flash';
 @use './styles/forms';
 @use './styles/buttons';
+@use './styles/autosave';

--- a/app/assets/stylesheets/styles/autosave.scss
+++ b/app/assets/stylesheets/styles/autosave.scss
@@ -1,0 +1,9 @@
+.autosave-indicator {
+  font-size: 0.85rem;
+  padding: 2px 8px;
+  transition: opacity 0.5s ease-out;
+}
+
+.autosave-fade {
+  opacity: 0;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,7 +12,6 @@ import './src/vendor/jquery-bootstrap-modal-steps.min';
 import './controllers/index';
 
 // Custom
-import './src/autosave';
 import './src/call_list_drag_and_drop';
 import './src/clinic_finder';
 import './src/clinics';

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -8,6 +8,9 @@ import * as bootstrap from "bootstrap";
 // Vendor
 import './src/vendor/jquery-bootstrap-modal-steps.min';
 
+// Stimulus controllers (requires @hotwired/stimulus from #3544)
+import './controllers/index';
+
 // Custom
 import './src/autosave';
 import './src/call_list_drag_and_drop';

--- a/app/javascript/controllers/__tests__/autosave_controller.test.js
+++ b/app/javascript/controllers/__tests__/autosave_controller.test.js
@@ -1,0 +1,262 @@
+import { Application } from "@hotwired/stimulus"
+import AutosaveController from "../autosave_controller"
+
+describe("AutosaveController", () => {
+  let application
+  let container
+
+  function createDOM(attrs = {}) {
+    const url = attrs.url || "/patients/123"
+    const debounce = attrs.debounce || 200 // short for tests
+    const maxInterval = attrs.maxInterval || 1000
+
+    container = document.createElement("div")
+    container.innerHTML = `
+      <form data-controller="autosave"
+            data-autosave-url-value="${url}"
+            data-autosave-debounce-value="${debounce}"
+            data-autosave-max-interval-value="${maxInterval}"
+            data-action="input->autosave#changed">
+        <input type="text" name="patient[name]" value="Alice" />
+        <span data-autosave-target="indicator" class="autosave-indicator d-none"></span>
+      </form>
+    `
+    document.body.appendChild(container)
+  }
+
+  beforeEach(() => {
+    // CSRF meta tag
+    const meta = document.createElement("meta")
+    meta.name = "csrf-token"
+    meta.content = "test-csrf-token"
+    document.head.appendChild(meta)
+
+    application = Application.start()
+    application.register("autosave", AutosaveController)
+
+    jest.useFakeTimers()
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    )
+    global.navigator.sendBeacon = jest.fn(() => true)
+  })
+
+  afterEach(() => {
+    application.stop()
+    if (container) container.remove()
+    document.head.querySelector('meta[name="csrf-token"]')?.remove()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  describe("connect", () => {
+    it("initializes state on connect", async () => {
+      createDOM()
+      await new Promise(r => setTimeout(r, 0))
+      // Controller connects without errors — indicator is hidden
+      const indicator = container.querySelector('[data-autosave-target="indicator"]')
+      expect(indicator.classList.contains("d-none")).toBe(true)
+    })
+  })
+
+  describe("debounce behavior", () => {
+    it("fires save after debounce delay", async () => {
+      createDOM({ debounce: 200 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const input = container.querySelector("input")
+      input.value = "Bob"
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+
+      // Before debounce - no fetch
+      expect(fetch).not.toHaveBeenCalled()
+
+      // After debounce
+      jest.advanceTimersByTime(250)
+      await Promise.resolve() // flush microtasks
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it("resets debounce on subsequent changes", async () => {
+      createDOM({ debounce: 200 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const input = container.querySelector("input")
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+
+      jest.advanceTimersByTime(150) // not yet
+      input.dispatchEvent(new Event("input", { bubbles: true })) // reset
+
+      jest.advanceTimersByTime(150) // 150ms since last change, not 200
+      await Promise.resolve()
+      expect(fetch).not.toHaveBeenCalled()
+
+      jest.advanceTimersByTime(100) // now 250ms since last change
+      await Promise.resolve()
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("max interval", () => {
+    it("forces save at max interval even with continuous changes", async () => {
+      createDOM({ debounce: 200, maxInterval: 500 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const input = container.querySelector("input")
+
+      // Simulate rapid typing that keeps resetting debounce
+      for (let i = 0; i < 5; i++) {
+        input.dispatchEvent(new Event("input", { bubbles: true }))
+        jest.advanceTimersByTime(100) // 100ms between each input
+      }
+      // At 500ms total, max interval should trigger
+      jest.advanceTimersByTime(50)
+      await Promise.resolve()
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("save request", () => {
+    it("sends PATCH with FormData and CSRF token", async () => {
+      createDOM({ debounce: 100 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const input = container.querySelector("input")
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+      jest.advanceTimersByTime(150)
+      await Promise.resolve()
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/patients/123",
+        expect.objectContaining({
+          method: "PATCH",
+          headers: expect.objectContaining({
+            "Accept": "application/json",
+            "X-CSRF-Token": "test-csrf-token"
+          })
+        })
+      )
+    })
+  })
+
+  describe("indicator states", () => {
+    it("shows 'Saving...' then '✓ Saved' on success", async () => {
+      let resolvePromise
+      fetch.mockImplementation(() => new Promise(r => { resolvePromise = r }))
+
+      createDOM({ debounce: 100 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const indicator = container.querySelector('[data-autosave-target="indicator"]')
+      const input = container.querySelector("input")
+
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+      jest.advanceTimersByTime(150)
+      await Promise.resolve()
+
+      // During save
+      expect(indicator.textContent).toBe("Saving...")
+      expect(indicator.classList.contains("text-muted")).toBe(true)
+
+      // Resolve fetch
+      resolvePromise({ ok: true })
+      await Promise.resolve()
+      await Promise.resolve() // extra tick for async
+
+      expect(indicator.textContent).toBe("✓ Saved")
+      expect(indicator.classList.contains("text-success")).toBe(true)
+    })
+
+    it("shows error indicator on fetch failure", async () => {
+      fetch.mockImplementation(() => Promise.resolve({ ok: false, status: 500 }))
+
+      createDOM({ debounce: 100 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const indicator = container.querySelector('[data-autosave-target="indicator"]')
+      const input = container.querySelector("input")
+
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+      jest.advanceTimersByTime(150)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(indicator.textContent).toBe("⚠ Save failed")
+      expect(indicator.classList.contains("text-danger")).toBe(true)
+    })
+
+    it("shows error indicator on network error", async () => {
+      fetch.mockImplementation(() => Promise.reject(new Error("Network error")))
+
+      createDOM({ debounce: 100 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const indicator = container.querySelector('[data-autosave-target="indicator"]')
+      const input = container.querySelector("input")
+
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+      jest.advanceTimersByTime(150)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(indicator.textContent).toBe("⚠ Save failed")
+    })
+  })
+
+  describe("error recovery", () => {
+    it("re-marks dirty on failed save and schedules retry", async () => {
+      fetch
+        .mockImplementationOnce(() => Promise.resolve({ ok: false }))
+        .mockImplementationOnce(() => Promise.resolve({ ok: true }))
+
+      createDOM({ debounce: 100 })
+      await new Promise(r => setTimeout(r, 0))
+
+      const input = container.querySelector("input")
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+
+      // First save (fails)
+      jest.advanceTimersByTime(150)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+
+      // Retry after debounce
+      jest.advanceTimersByTime(150)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe("disconnect", () => {
+    it("uses sendBeacon when dirty on disconnect", async () => {
+      createDOM({ debounce: 5000 }) // long debounce, won't fire
+      await new Promise(r => setTimeout(r, 0))
+
+      const input = container.querySelector("input")
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+
+      // Disconnect before debounce fires
+      application.stop()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledWith(
+        "/patients/123",
+        expect.any(FormData)
+      )
+    })
+
+    it("does not sendBeacon when not dirty", async () => {
+      createDOM()
+      await new Promise(r => setTimeout(r, 0))
+
+      application.stop()
+
+      expect(navigator.sendBeacon).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/javascript/controllers/autosave_controller.js
+++ b/app/javascript/controllers/autosave_controller.js
@@ -31,6 +31,8 @@ export default class extends Controller {
     // Use sendBeacon for reliable delivery during page unload
     if (this.dirty && !this.saving) {
       const formData = new FormData(this.element)
+      const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+      if (csrfToken) formData.append('authenticity_token', csrfToken)
       const url = this.urlValue || this.element.action
       navigator.sendBeacon(url, formData)
       this.dirty = false
@@ -53,7 +55,6 @@ export default class extends Controller {
   async save() {
     if (!this.dirty || this.saving) return
 
-    this.dirty = false
     this.saving = true
     this.clearTimers()
     this.showIndicator("saving")
@@ -73,6 +74,7 @@ export default class extends Controller {
       })
 
       if (response.ok) {
+        this.dirty = false
         this.showIndicator("saved")
       } else {
         this.showIndicator("error")

--- a/app/javascript/controllers/autosave_controller.js
+++ b/app/javascript/controllers/autosave_controller.js
@@ -56,6 +56,8 @@ export default class extends Controller {
     if (!this.dirty || this.saving) return
 
     this.saving = true
+    this.dirty = false
+    const dirtyAtStart = true
     this.clearTimers()
     this.showIndicator("saving")
 
@@ -74,18 +76,20 @@ export default class extends Controller {
       })
 
       if (response.ok) {
-        this.dirty = false
         this.showIndicator("saved")
       } else {
+        // Re-mark dirty so retry picks up the failed save
+        this.dirty = true
         this.showIndicator("error")
       }
     } catch (error) {
+      this.dirty = true
       this.showIndicator("error")
     } finally {
       this.saving = false
     }
 
-    // If more changes came in while saving, schedule another save
+    // If new changes came in during save, or save failed, schedule retry
     if (this.dirty) {
       this.debounceTimer = setTimeout(() => this.save(), this.debounceValue)
     }

--- a/app/javascript/controllers/autosave_controller.js
+++ b/app/javascript/controllers/autosave_controller.js
@@ -1,0 +1,121 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Office 365-style auto-save controller.
+// Debounces saves: 2s after last change, forced save at 15s max interval.
+// Visual feedback: "Saving..." → "✓ Saved" → fades after 3s.
+//
+// Usage:
+//   <form data-controller="autosave"
+//         data-autosave-url-value="/patients/123"
+//         data-action="input->autosave#changed select->autosave#changed">
+//     <div data-autosave-target="indicator" class="autosave-indicator"></div>
+//     ...
+//   </form>
+export default class extends Controller {
+  static targets = ["indicator"]
+  static values = {
+    url: String,
+    debounce: { type: Number, default: 2000 },
+    maxInterval: { type: Number, default: 15000 }
+  }
+
+  connect() {
+    this.debounceTimer = null
+    this.maxTimer = null
+    this.dirty = false
+    this.saving = false
+  }
+
+  disconnect() {
+    this.clearTimers()
+    // Save any pending changes before teardown
+    if (this.dirty && !this.saving) {
+      this.save()
+    }
+  }
+
+  changed() {
+    this.dirty = true
+
+    // Reset debounce timer on every change
+    clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => this.save(), this.debounceValue)
+
+    // Start max interval timer if not already running
+    if (!this.maxTimer) {
+      this.maxTimer = setTimeout(() => this.save(), this.maxIntervalValue)
+    }
+  }
+
+  async save() {
+    if (!this.dirty || this.saving) return
+
+    this.dirty = false
+    this.saving = true
+    this.clearTimers()
+    this.showIndicator("saving")
+
+    try {
+      const formData = new FormData(this.element)
+      const token = document.querySelector('meta[name="csrf-token"]')?.content
+
+      const response = await fetch(this.urlValue || this.element.action, {
+        method: "PATCH",
+        headers: {
+          "X-CSRF-Token": token,
+          "Accept": "application/json"
+        },
+        body: formData
+      })
+
+      if (response.ok) {
+        this.showIndicator("saved")
+      } else {
+        this.showIndicator("error")
+      }
+    } catch (error) {
+      this.showIndicator("error")
+    } finally {
+      this.saving = false
+    }
+
+    // If more changes came in while saving, schedule another save
+    if (this.dirty) {
+      this.debounceTimer = setTimeout(() => this.save(), this.debounceValue)
+    }
+  }
+
+  showIndicator(state) {
+    if (!this.hasIndicatorTarget) return
+
+    const el = this.indicatorTarget
+    el.classList.remove("d-none")
+
+    switch (state) {
+      case "saving":
+        el.textContent = "Saving..."
+        el.className = "autosave-indicator text-muted"
+        break
+      case "saved":
+        el.textContent = "✓ Saved"
+        el.className = "autosave-indicator text-success"
+        // Fade out after 3 seconds
+        setTimeout(() => {
+          el.classList.add("autosave-fade")
+          setTimeout(() => el.classList.add("d-none"), 500)
+        }, 3000)
+        break
+      case "error":
+        el.textContent = "⚠ Save failed"
+        el.className = "autosave-indicator text-danger"
+        break
+    }
+  }
+
+  clearTimers() {
+    clearTimeout(this.debounceTimer)
+    clearTimeout(this.maxTimer)
+    this.debounceTimer = null
+    this.maxTimer = null
+  }
+}

--- a/app/javascript/controllers/autosave_controller.js
+++ b/app/javascript/controllers/autosave_controller.js
@@ -28,9 +28,12 @@ export default class extends Controller {
 
   disconnect() {
     this.clearTimers()
-    // Save any pending changes before teardown
+    // Use sendBeacon for reliable delivery during page unload
     if (this.dirty && !this.saving) {
-      this.save()
+      const formData = new FormData(this.element)
+      const url = this.urlValue || this.element.action
+      navigator.sendBeacon(url, formData)
+      this.dirty = false
     }
   }
 
@@ -57,14 +60,15 @@ export default class extends Controller {
 
     try {
       const formData = new FormData(this.element)
-      const token = document.querySelector('meta[name="csrf-token"]')?.content
+      const csrfMeta = document.querySelector('meta[name="csrf-token"]')
+      const token = csrfMeta ? csrfMeta.content : null
+
+      const headers = { "Accept": "application/json" }
+      if (token) headers["X-CSRF-Token"] = token
 
       const response = await fetch(this.urlValue || this.element.action, {
         method: "PATCH",
-        headers: {
-          "X-CSRF-Token": token,
-          "Accept": "application/json"
-        },
+        headers: headers,
         body: formData
       })
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,8 @@
+// Stimulus controller registration for auto-save feature.
+// Requires @hotwired/stimulus from #3544 (stimulus-dashboard).
+import { Application } from "@hotwired/stimulus"
+import AutosaveController from "./autosave_controller"
+
+// Use existing Stimulus instance from window (set by #3544) or start a new one
+const application = window.Stimulus || Application.start()
+application.register("autosave", AutosaveController)

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -1,9 +1,17 @@
 <div id="patient_dashboard_content">
   <%= bootstrap_form_with model: patient,
-                         html: { id: 'patient_dashboard_form' },
+                         html: { id: 'patient_dashboard_form',
+                                 'data-controller': 'autosave',
+                                 'data-autosave-url-value': patient_path(patient),
+                                 'data-action': 'input->autosave#changed change->autosave#changed' },
                          local: false,
                          method: 'patch',
                          class: 'edit_patient' do |f| %>
+    <div class="row">
+      <div class="col-12">
+        <span data-autosave-target="indicator" class="autosave-indicator d-none"></span>
+      </div>
+    </div>
     <div class="row">
 
       <div class="col-4">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.7.2",
+    "@hotwired/stimulus": "^3.2.2",
     "@popperjs/core": "2.11.8",
     "bootstrap": "4.6.2",
     "esbuild": "0.25.8",

--- a/test/controllers/auto_save_patient_test.rb
+++ b/test/controllers/auto_save_patient_test.rb
@@ -56,5 +56,31 @@ class AutoSavePatientTest < ActionDispatch::IntegrationTest
         }
       end
     end
+
+    it 'should respond to JSON format requests' do
+      patch patient_path(@patient, format: :json), params: {
+        patient: { name: 'JSON Save' }
+      }
+      assert_response :success
+      @patient.reload
+      assert_equal 'JSON Save', @patient.name
+    end
+
+    it 'should render autosave data attributes on the form' do
+      get edit_patient_path(@patient)
+      assert_response :success
+      assert_select 'form[data-controller="autosave"]'
+      assert_select 'form[data-autosave-url-value]'
+      assert_select '[data-autosave-target="indicator"]'
+    end
+
+    it 'should not change updated_at when no fields actually change' do
+      original_updated_at = @patient.updated_at
+      patch patient_path(@patient), params: {
+        patient: { name: @patient.name }
+      }
+      @patient.reload
+      assert_equal original_updated_at.to_i, @patient.updated_at.to_i
+    end
   end
 end

--- a/test/controllers/auto_save_patient_test.rb
+++ b/test/controllers/auto_save_patient_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class AutoSavePatientTest < ActionDispatch::IntegrationTest
+  before do
+    @user = create :user
+    @line = create :line
+    @patient = create :patient, name: 'Original Name'
+    sign_in @user
+    choose_line @line
+  end
+
+  describe 'PATCH patient (autosave)' do
+    it 'should update patient via PATCH' do
+      patch patient_path(@patient), params: {
+        patient: { name: 'Auto-Saved Name' }
+      }
+      assert_response :redirect
+      @patient.reload
+      assert_equal 'Auto-Saved Name', @patient.name
+    end
+
+    it 'should reject update without authentication' do
+      delete destroy_user_session_path
+      patch patient_path(@patient), params: {
+        patient: { name: 'Unauthorized' }
+      }
+      assert_response :redirect
+      @patient.reload
+      refute_equal 'Unauthorized', @patient.name
+    end
+
+    it 'should render edit page with patient form' do
+      get edit_patient_path(@patient)
+      assert_response :success
+      assert_select '#patient_dashboard_form'
+    end
+  end
+end

--- a/test/controllers/auto_save_patient_test.rb
+++ b/test/controllers/auto_save_patient_test.rb
@@ -34,5 +34,27 @@ class AutoSavePatientTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_select '#patient_dashboard_form'
     end
+
+    it 'should update multiple fields in a single PATCH' do
+      patch patient_path(@patient), params: {
+        patient: { name: 'Updated Name', city: 'New City' }
+      }
+      @patient.reload
+      assert_equal 'Updated Name', @patient.name
+      assert_equal 'New City', @patient.city
+    end
+
+    it 'should not update patient from a different tenant' do
+      other_fund = create :fund
+      other_patient = nil
+      ActsAsTenant.with_tenant(other_fund) do
+        other_patient = create :patient, name: 'Other Tenant'
+      end
+      assert_raises(ActiveRecord::RecordNotFound) do
+        patch patient_path(other_patient), params: {
+          patient: { name: 'Cross Tenant' }
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds auto-save to patient intake forms so that data is automatically saved as the user types, preventing data loss if the browser crashes, the session times out, or the user navigates away.

This pull request makes the following changes:
* Add `autosave_controller.js` Stimulus controller with debounced auto-save via PATCH
* Register controller in Stimulus application.js
* Add CSRF token validation with null check for graceful fallback
* Use `navigator.sendBeacon()` on disconnect for reliable save-on-navigate
* Add `@hotwired/stimulus` npm dependency

**Notes:**
* **Depends on** #3544 (Stimulus dashboard) for the Stimulus foundation.
* **Merge order:** `#3544` → `#3545`.

(If there are changes to the views, please include a screenshot so we know what to look for!)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
