### PR TITLE
Add touch: true to child associations for Russian doll caching

### DIFF
--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -14,7 +14,7 @@ class Call < ApplicationRecord
   }
 
   # Relationships
-  belongs_to :can_call, polymorphic: true
+  belongs_to :can_call, polymorphic: true, touch: true
 
   # Validations
   validates :status,  presence: true

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -14,6 +14,9 @@ class Call < ApplicationRecord
   }
 
   # Relationships
+  # touch: true enables russian-doll caching — parent updated_at bumps when
+  # children change, busting the outer cache fragment. Trade-off: PaperTrail
+  # records an extra version on the parent for each child update.
   belongs_to :can_call, polymorphic: true, touch: true
 
   # Validations

--- a/app/models/external_pledge.rb
+++ b/app/models/external_pledge.rb
@@ -7,7 +7,7 @@ class ExternalPledge < ApplicationRecord
   include PaperTrailable
 
   # Relationships
-  belongs_to :can_pledge, polymorphic: true
+  belongs_to :can_pledge, polymorphic: true, touch: true
 
   default_scope -> { where(active: true) }
   scope :active, -> { where(active: true) }

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -7,7 +7,7 @@ class Fulfillment < ApplicationRecord
   include PaperTrailable
 
   # Relationships
-  belongs_to :can_fulfill, polymorphic: true
+  belongs_to :can_fulfill, polymorphic: true, touch: true
 
   # Validations
   validates :fund_payout, :gestation_at_procedure, numericality: { only_integer: true,

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -7,7 +7,7 @@ class Note < ApplicationRecord
   include PaperTrailable
 
   # Relationships
-  belongs_to :can_note, polymorphic: true
+  belongs_to :can_note, polymorphic: true, touch: true
 
   # Validations
   validates :full_text, presence: true, length: { maximum: 4000 }

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -9,7 +9,7 @@ class PracticalSupport < ApplicationRecord
   include Notetakeable
 
   # Relationships
-  belongs_to :can_support, polymorphic: true
+  belongs_to :can_support, polymorphic: true, touch: true
   has_many :notes, as: :can_note
 
   # Validations

--- a/test/models/call_test.rb
+++ b/test/models/call_test.rb
@@ -59,5 +59,20 @@ class CallTest < ActiveSupport::TestCase
       assert patient.updated_at > original_updated_at,
              'Patient updated_at should be bumped when a call is created'
     end
+
+    it 'should update parent updated_at when call is destroyed' do
+      patient = create :patient
+      call = create :call, can_call: patient
+      patient.reload
+      original_updated_at = patient.updated_at
+
+      travel 1.second do
+        call.destroy!
+      end
+
+      patient.reload
+      assert patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when a call is destroyed'
+    end
   end
 end

--- a/test/models/call_test.rb
+++ b/test/models/call_test.rb
@@ -44,4 +44,20 @@ class CallTest < ActiveSupport::TestCase
       assert @call.respond_to? :created_by_id
     end
   end
+
+  describe 'russian-doll caching (touch: true)' do
+    it 'should update parent updated_at when call is created' do
+      patient = create :patient
+      original_updated_at = patient.updated_at
+
+      # Small sleep to ensure timestamp differs
+      travel 1.second do
+        create :call, can_call: patient
+      end
+
+      patient.reload
+      assert patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when a call is created'
+    end
+  end
 end

--- a/test/models/external_pledge_test.rb
+++ b/test/models/external_pledge_test.rb
@@ -51,4 +51,31 @@ class ExternalPledgeTest < ActiveSupport::TestCase
       assert_equal 2, @patient.external_pledges.unscoped.count
     end
   end
+
+  describe 'russian-doll caching (touch: true)' do
+    it 'should touch parent patient when pledge is created' do
+      original_updated_at = @patient.updated_at
+
+      travel 1.second do
+        @patient.external_pledges.create amount: 50, source: 'New Source'
+      end
+
+      @patient.reload
+      assert @patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when a pledge is created'
+    end
+
+    it 'should touch parent patient when pledge is updated' do
+      @patient.reload
+      original_updated_at = @patient.updated_at
+
+      travel 1.second do
+        @pledge.update!(amount: 999)
+      end
+
+      @patient.reload
+      assert @patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when a pledge is updated'
+    end
+  end
 end

--- a/test/models/fulfillment_test.rb
+++ b/test/models/fulfillment_test.rb
@@ -24,4 +24,18 @@ class FulfillmentTest < ActiveSupport::TestCase
       assert_equal '7 weeks', @fulfillment.gestation_at_procedure_display
     end
   end
+
+  describe 'russian-doll caching (touch: true)' do
+    it 'should touch parent patient when fulfillment is updated' do
+      original_updated_at = @pt_1.updated_at
+
+      travel 1.second do
+        @fulfillment.update!(fulfilled: true)
+      end
+
+      @pt_1.reload
+      assert @pt_1.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when fulfillment is updated'
+    end
+  end
 end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -37,4 +37,35 @@ class NoteTest < ActiveSupport::TestCase
       assert @note.respond_to? :created_by_id
     end
   end
+
+  describe 'russian-doll caching (touch: true)' do
+    it 'should touch parent patient when note is created' do
+      original_updated_at = @patient.updated_at
+
+      travel 1.second do
+        with_versioning(@user) do
+          @patient.notes.create!(full_text: 'New note for caching test')
+        end
+      end
+
+      @patient.reload
+      assert @patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when a note is created'
+    end
+
+    it 'should touch parent patient when note is updated' do
+      @patient.reload
+      original_updated_at = @patient.updated_at
+
+      travel 1.second do
+        with_versioning(@user) do
+          @note.update!(full_text: 'Updated note text')
+        end
+      end
+
+      @patient.reload
+      assert @patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when a note is updated'
+    end
+  end
 end

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -46,4 +46,34 @@ class PracticalSupportTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'russian-doll caching (touch: true)' do
+    it 'should touch parent patient when practical support is created' do
+      original_updated_at = @patient.updated_at
+
+      travel 1.second do
+        @patient.practical_supports.create!(
+          support_type: 'Bus Fare',
+          source: 'Test Fund'
+        )
+      end
+
+      @patient.reload
+      assert @patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when practical support is created'
+    end
+
+    it 'should touch parent patient when practical support is updated' do
+      @patient.reload
+      original_updated_at = @patient.updated_at
+
+      travel 1.second do
+        @psupport1.update!(source: 'Updated Source')
+      end
+
+      @patient.reload
+      assert @patient.updated_at > original_updated_at,
+             'Patient updated_at should be bumped when practical support is updated'
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds `touch: true` to child model associations so that when a note, call, or other child record is updated, the parent patient's timestamp is automatically bumped. This enables Russian doll caching to work correctly.

This pull request makes the following changes:
* Add `touch: true` to `belongs_to` in Note, Call, Event, ExternalPledge, PracticalSupport, and Fulfillment
* Patient `updated_at` automatically bumps when any associated record changes

**Notes:**
* This adds PaperTrail version entries for touch updates — documented as an acceptable tradeoff for cache correctness.
* **Required by** #3546 (fragment caching), which depends on these touch associations.
* **Merge order:** `#3547` → `#3546`.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
