### PR TITLE
Add post-quantum hybrid key wrapping for Active Record encryption (ML-KEM-1024)

### DIFF
--- a/app/javascript/locales.json
+++ b/app/javascript/locales.json
@@ -6178,6 +6178,7 @@
       "email": "Email",
       "for": "for",
       "from": "from",
+      "language_speaker": "%{language} speaker",
       "medicaid": "Medicaid",
       "naf": "NAF",
       "name": "Name",
@@ -6705,6 +6706,8 @@
           "add_missing": "add missing keys to locale data, optionally match a pattern",
           "check_consistent_interpolations": "verify that all translations use correct interpolation variables",
           "check_normalized": "verify that all translation data is normalized",
+          "check_prism": "verify that Prism-scanner produces the same (or better) results as the default parser",
+          "check_reserved_interpolations": "verify that all translations avoid reserved interpolation variables",
           "config": "display i18n-tasks configuration",
           "cp": "copy the keys in locale data that match the given pattern",
           "data": "show locale data",
@@ -6801,6 +6804,10 @@
         },
         "noop": "No unused keys to remove",
         "removed": "Removed %{count} keys"
+      },
+      "reserved_interpolations": {
+        "details_title": "Reserved interpolation keys",
+        "none": "No reserved interpolations found."
       },
       "translate_missing": {
         "translated": "Translated %{count} keys"
@@ -10629,6 +10636,7 @@
       "email": "Email",
       "for": "por",
       "from": "de",
+      "language_speaker": "Hablante de %{language}",
       "medicaid": "Medicaid",
       "naf": "NAF",
       "name": "Nombre",
@@ -30214,6 +30222,8 @@
           "add_missing": "добавить недостающие ключи к переводам",
           "check_consistent_interpolations": "убедитесь, что во всех переводах используются правильные интерполяционные переменные",
           "check_normalized": "проверить, что все файлы переводов нормализованы",
+          "check_prism": "убедитесь, что Prism-scanner выдает те же (или лучшие) результаты, что и анализатор по умолчанию",
+          "check_reserved_interpolations": "проверьте, что все переводы обходятся без зарезервированных интерполяционных переменных",
           "config": "показать конфигурацию",
           "cp": "скопируйте ключи в данных локали, соответствующие заданному шаблону",
           "data": "показать данные переводов",
@@ -30314,6 +30324,10 @@
         },
         "noop": "Нет неиспользуемых ключей",
         "removed": "Удалены ключи (%{count})"
+      },
+      "reserved_interpolations": {
+        "details_title": "Зарезервированные ключи интерполяции",
+        "none": "NЗарезервированных интерполяций не обнаружено."
       },
       "translate_missing": {
         "translated": "Переведены ключи (%{count})"

--- a/app/services/pqc_key_manager.rb
+++ b/app/services/pqc_key_manager.rb
@@ -41,7 +41,7 @@ class PqcKeyManager
   end
 
   # Returns the primary encryption key, unwrapping via PQC if configured.
-  # Production: raises if keys are missing. Dev/test: generates fallback.
+  # Production/staging: raises if keys are missing. Dev/test only: generates fallback.
   def self.primary_key
     if pqc_enabled?
       unwrap_primary_key
@@ -49,7 +49,7 @@ class PqcKeyManager
       require_env_key("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "primary encryption key")
     end
   rescue PqcError => e
-    raise if Rails.env.production?
+    raise unless Rails.env.in?(%w[development test])
     warn "[PQC] #{e.message} — using development fallback. DO NOT use in production."
     dev_fallback_key("primary")
   end
@@ -60,8 +60,8 @@ class PqcKeyManager
     value = ENV[env_var]
     return value if value.present?
 
-    if Rails.env.production?
-      raise PqcError, "#{env_var} is required in production. Configure the #{description} environment variable."
+    unless Rails.env.in?(%w[development test])
+      raise PqcError, "#{env_var} is required in #{Rails.env}. Configure the #{description} environment variable."
     end
 
     warn "[PQC] #{env_var} not set — using development fallback for #{description}. DO NOT use in production."

--- a/app/services/pqc_key_manager.rb
+++ b/app/services/pqc_key_manager.rb
@@ -1,16 +1,18 @@
 # Post-Quantum Cryptography hybrid key manager.
 #
 # Wraps Rails Active Record encryption keys using ML-KEM-1024 (FIPS 203)
-# combined with AES-256-KW (RFC 3394) for quantum-resistant key protection.
+# combined with AES-256-GCM for quantum-resistant key protection.
 #
-# Hybrid approach: Even if ML-KEM is broken, AES-256-KW still protects the key.
-# Even if AES-256 is broken, ML-KEM still protects the key.
+# Hybrid approach: Even if ML-KEM is broken, the AES layer still protects
+# the key. Even if AES is broken, ML-KEM still protects the key.
+#
+# Requires OpenSSL 3.5+ with ML-KEM support (provided by upgrade/openssl-3.5.5).
 #
 # Environment variables:
 #   PQC_ENABLED          - Set to "true" to enable PQC key unwrapping
-#   PQC_PRIVATE_KEY      - Base64-encoded ML-KEM-1024 private key
-#   PQC_WRAPPED_KEY      - Base64-encoded AES-256-KW wrapped primary key
-#   PQC_KEM_CIPHERTEXT   - Base64-encoded ML-KEM ciphertext (shared secret)
+#   PQC_PRIVATE_KEY_PATH - Path to ML-KEM-1024 private key PEM file
+#   PQC_WRAPPED_KEY      - Base64-encoded AES-256-GCM encrypted primary key
+#   PQC_KEM_CIPHERTEXT   - Base64-encoded ML-KEM ciphertext (encapsulated shared secret)
 #
 # Dual-read: If PQC env vars are set, unwraps the key. Otherwise falls back
 # to the raw ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY env var.
@@ -19,6 +21,24 @@ class PqcKeyManager
 
   class PqcError < StandardError; end
   class KeyUnwrapError < PqcError; end
+  class PqcUnavailableError < PqcError; end
+
+  # Check if ML-KEM-1024 is available in the current OpenSSL installation
+  def self.pqc_available?
+    return @pqc_available unless @pqc_available.nil?
+
+    @pqc_available = begin
+      key = OpenSSL::PKey.generate_key(PQC_ALGORITHM)
+      key.respond_to?(:encapsulate) && key.respond_to?(:decapsulate)
+    rescue => _e
+      false
+    end
+  end
+
+  # Reset cached availability (for testing)
+  def self.reset_availability_cache!
+    @pqc_available = nil
+  end
 
   # Returns the primary encryption key, unwrapping via PQC if configured
   def self.primary_key
@@ -29,88 +49,109 @@ class PqcKeyManager
     end
   end
 
-  # Check if PQC key wrapping is enabled
+  # Check if PQC key wrapping is enabled and configured
   def self.pqc_enabled?
     ENV["PQC_ENABLED"] == "true" &&
-      ENV["PQC_PRIVATE_KEY"].present? &&
+      ENV["PQC_PRIVATE_KEY_PATH"].present? &&
       ENV["PQC_WRAPPED_KEY"].present? &&
       ENV["PQC_KEM_CIPHERTEXT"].present?
   end
 
-  # Generate a new ML-KEM-1024 keypair for initial setup
-  # Returns { public_key: base64, private_key: base64 }
+  # Generate a new ML-KEM-1024 keypair.
+  # Returns the key object. Caller is responsible for secure storage.
   def self.generate_keypair
-    require "openssl"
-    kem = OpenSSL::KEM.new(PQC_ALGORITHM)
-    keypair = kem.generate_key
+    raise PqcUnavailableError, "ML-KEM-1024 not available. Requires OpenSSL 3.5+" unless pqc_available?
 
-    {
-      public_key: Base64.strict_encode64(keypair.public_to_der),
-      private_key: Base64.strict_encode64(keypair.private_to_der)
-    }
+    OpenSSL::PKey.generate_key(PQC_ALGORITHM)
   end
 
-  # Wrap an existing primary key with PQC hybrid encryption
+  # Write keypair to files with restricted permissions.
+  # private_key_path gets mode 0600 (owner read/write only).
+  def self.save_keypair(key, private_key_path:, public_key_path:)
+    File.write(private_key_path, key.private_to_pem)
+    File.chmod(0o600, private_key_path)
+
+    File.write(public_key_path, key.public_to_pem)
+    File.chmod(0o644, public_key_path)
+  end
+
+  # Wrap an existing primary key with PQC hybrid encryption.
+  # Uses ML-KEM encapsulation to derive a shared secret, then
+  # AES-256-GCM to encrypt the primary key.
+  #
   # Returns { wrapped_key: base64, kem_ciphertext: base64 }
-  def self.wrap_key(primary_key, public_key_base64)
-    require "openssl"
+  def self.wrap_key(primary_key, public_key_pem)
+    raise PqcUnavailableError, "ML-KEM-1024 not available" unless pqc_available?
 
-    # Decapsulate: use ML-KEM public key to get shared secret + ciphertext
-    pub_der = Base64.strict_decode64(public_key_base64)
-    pub_key = OpenSSL::PKey.read(pub_der)
-    kem = OpenSSL::KEM.new(PQC_ALGORITHM)
-    ciphertext, shared_secret = kem.encapsulate(pub_key)
+    pub_key = OpenSSL::PKey.read(public_key_pem)
+    ciphertext, shared_secret = pub_key.encapsulate
 
-    # Derive a 256-bit wrapping key from the shared secret
+    # Derive a 256-bit wrapping key from the shared secret via SHA-256
     wrapping_key = OpenSSL::Digest::SHA256.digest(shared_secret)
 
-    # AES-256-KW wrap the primary key
-    wrapped = aes_key_wrap(wrapping_key, primary_key.b)
+    # AES-256-GCM encrypt the primary key
+    encrypted = aes_gcm_encrypt(wrapping_key, primary_key.b)
 
     {
-      wrapped_key: Base64.strict_encode64(wrapped),
+      wrapped_key: Base64.strict_encode64(encrypted),
       kem_ciphertext: Base64.strict_encode64(ciphertext)
     }
   end
 
   private
 
-  # Unwrap the primary key using ML-KEM decapsulation + AES-256-KW
+  # Unwrap the primary key using ML-KEM decapsulation + AES-256-GCM
   def self.unwrap_primary_key
-    require "openssl"
+    raise PqcUnavailableError, "ML-KEM-1024 not available" unless pqc_available?
 
-    priv_der = Base64.strict_decode64(ENV["PQC_PRIVATE_KEY"])
-    priv_key = OpenSSL::PKey.read(priv_der)
+    private_key_path = ENV.fetch("PQC_PRIVATE_KEY_PATH")
+    raise KeyUnwrapError, "Private key file not found: #{private_key_path}" unless File.exist?(private_key_path)
 
-    ciphertext = Base64.strict_decode64(ENV["PQC_KEM_CIPHERTEXT"])
-    wrapped_key = Base64.strict_decode64(ENV["PQC_WRAPPED_KEY"])
+    priv_pem = File.read(private_key_path)
+    priv_key = OpenSSL::PKey.read(priv_pem)
+
+    ciphertext = Base64.strict_decode64(ENV.fetch("PQC_KEM_CIPHERTEXT"))
+    wrapped_key = Base64.strict_decode64(ENV.fetch("PQC_WRAPPED_KEY"))
 
     # Decapsulate to recover the shared secret
-    kem = OpenSSL::KEM.new(PQC_ALGORITHM)
-    shared_secret = kem.decapsulate(priv_key, ciphertext)
+    shared_secret = priv_key.decapsulate(ciphertext)
 
     # Derive the wrapping key
     wrapping_key = OpenSSL::Digest::SHA256.digest(shared_secret)
 
-    # AES-256-KW unwrap
-    aes_key_unwrap(wrapping_key, wrapped_key)
+    # AES-256-GCM decrypt
+    aes_gcm_decrypt(wrapping_key, wrapped_key)
+  rescue PqcError
+    raise
   rescue => e
     raise KeyUnwrapError, "Failed to unwrap primary key via PQC: #{e.message}"
   end
 
-  # AES-256 Key Wrap (RFC 3394)
-  def self.aes_key_wrap(kek, plaintext)
-    cipher = OpenSSL::Cipher.new("aes-256-wrap")
+  # AES-256-GCM encrypt: returns iv + auth_tag + ciphertext
+  def self.aes_gcm_encrypt(key, plaintext)
+    cipher = OpenSSL::Cipher.new("aes-256-gcm")
     cipher.encrypt
-    cipher.key = kek
-    cipher.update(plaintext) + cipher.final
+    cipher.key = key
+    iv = cipher.random_iv
+
+    ciphertext = cipher.update(plaintext) + cipher.final
+    auth_tag = cipher.auth_tag
+
+    iv + auth_tag + ciphertext
   end
 
-  # AES-256 Key Unwrap (RFC 3394)
-  def self.aes_key_unwrap(kek, ciphertext)
-    cipher = OpenSSL::Cipher.new("aes-256-wrap")
+  # AES-256-GCM decrypt: expects iv (12 bytes) + auth_tag (16 bytes) + ciphertext
+  def self.aes_gcm_decrypt(key, data)
+    iv = data[0, 12]
+    auth_tag = data[12, 16]
+    ciphertext = data[28..]
+
+    cipher = OpenSSL::Cipher.new("aes-256-gcm")
     cipher.decrypt
-    cipher.key = kek
+    cipher.key = key
+    cipher.iv = iv
+    cipher.auth_tag = auth_tag
+
     cipher.update(ciphertext) + cipher.final
   end
 end

--- a/app/services/pqc_key_manager.rb
+++ b/app/services/pqc_key_manager.rb
@@ -1,0 +1,116 @@
+# Post-Quantum Cryptography hybrid key manager.
+#
+# Wraps Rails Active Record encryption keys using ML-KEM-1024 (FIPS 203)
+# combined with AES-256-KW (RFC 3394) for quantum-resistant key protection.
+#
+# Hybrid approach: Even if ML-KEM is broken, AES-256-KW still protects the key.
+# Even if AES-256 is broken, ML-KEM still protects the key.
+#
+# Environment variables:
+#   PQC_ENABLED          - Set to "true" to enable PQC key unwrapping
+#   PQC_PRIVATE_KEY      - Base64-encoded ML-KEM-1024 private key
+#   PQC_WRAPPED_KEY      - Base64-encoded AES-256-KW wrapped primary key
+#   PQC_KEM_CIPHERTEXT   - Base64-encoded ML-KEM ciphertext (shared secret)
+#
+# Dual-read: If PQC env vars are set, unwraps the key. Otherwise falls back
+# to the raw ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY env var.
+class PqcKeyManager
+  PQC_ALGORITHM = "ML-KEM-1024".freeze
+
+  class PqcError < StandardError; end
+  class KeyUnwrapError < PqcError; end
+
+  # Returns the primary encryption key, unwrapping via PQC if configured
+  def self.primary_key
+    if pqc_enabled?
+      unwrap_primary_key
+    else
+      ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "default_primary_key")
+    end
+  end
+
+  # Check if PQC key wrapping is enabled
+  def self.pqc_enabled?
+    ENV["PQC_ENABLED"] == "true" &&
+      ENV["PQC_PRIVATE_KEY"].present? &&
+      ENV["PQC_WRAPPED_KEY"].present? &&
+      ENV["PQC_KEM_CIPHERTEXT"].present?
+  end
+
+  # Generate a new ML-KEM-1024 keypair for initial setup
+  # Returns { public_key: base64, private_key: base64 }
+  def self.generate_keypair
+    require "openssl"
+    kem = OpenSSL::KEM.new(PQC_ALGORITHM)
+    keypair = kem.generate_key
+
+    {
+      public_key: Base64.strict_encode64(keypair.public_to_der),
+      private_key: Base64.strict_encode64(keypair.private_to_der)
+    }
+  end
+
+  # Wrap an existing primary key with PQC hybrid encryption
+  # Returns { wrapped_key: base64, kem_ciphertext: base64 }
+  def self.wrap_key(primary_key, public_key_base64)
+    require "openssl"
+
+    # Decapsulate: use ML-KEM public key to get shared secret + ciphertext
+    pub_der = Base64.strict_decode64(public_key_base64)
+    pub_key = OpenSSL::PKey.read(pub_der)
+    kem = OpenSSL::KEM.new(PQC_ALGORITHM)
+    ciphertext, shared_secret = kem.encapsulate(pub_key)
+
+    # Derive a 256-bit wrapping key from the shared secret
+    wrapping_key = OpenSSL::Digest::SHA256.digest(shared_secret)
+
+    # AES-256-KW wrap the primary key
+    wrapped = aes_key_wrap(wrapping_key, primary_key.b)
+
+    {
+      wrapped_key: Base64.strict_encode64(wrapped),
+      kem_ciphertext: Base64.strict_encode64(ciphertext)
+    }
+  end
+
+  private
+
+  # Unwrap the primary key using ML-KEM decapsulation + AES-256-KW
+  def self.unwrap_primary_key
+    require "openssl"
+
+    priv_der = Base64.strict_decode64(ENV["PQC_PRIVATE_KEY"])
+    priv_key = OpenSSL::PKey.read(priv_der)
+
+    ciphertext = Base64.strict_decode64(ENV["PQC_KEM_CIPHERTEXT"])
+    wrapped_key = Base64.strict_decode64(ENV["PQC_WRAPPED_KEY"])
+
+    # Decapsulate to recover the shared secret
+    kem = OpenSSL::KEM.new(PQC_ALGORITHM)
+    shared_secret = kem.decapsulate(priv_key, ciphertext)
+
+    # Derive the wrapping key
+    wrapping_key = OpenSSL::Digest::SHA256.digest(shared_secret)
+
+    # AES-256-KW unwrap
+    aes_key_unwrap(wrapping_key, wrapped_key)
+  rescue => e
+    raise KeyUnwrapError, "Failed to unwrap primary key via PQC: #{e.message}"
+  end
+
+  # AES-256 Key Wrap (RFC 3394)
+  def self.aes_key_wrap(kek, plaintext)
+    cipher = OpenSSL::Cipher.new("aes-256-wrap")
+    cipher.encrypt
+    cipher.key = kek
+    cipher.update(plaintext) + cipher.final
+  end
+
+  # AES-256 Key Unwrap (RFC 3394)
+  def self.aes_key_unwrap(kek, ciphertext)
+    cipher = OpenSSL::Cipher.new("aes-256-wrap")
+    cipher.decrypt
+    cipher.key = kek
+    cipher.update(ciphertext) + cipher.final
+  end
+end

--- a/app/services/pqc_key_manager.rb
+++ b/app/services/pqc_key_manager.rb
@@ -40,13 +40,32 @@ class PqcKeyManager
     @pqc_available = nil
   end
 
-  # Returns the primary encryption key, unwrapping via PQC if configured
+  # Returns the primary encryption key, unwrapping via PQC if configured.
+  # Production: raises if keys are missing. Dev/test: generates fallback.
   def self.primary_key
     if pqc_enabled?
       unwrap_primary_key
     else
-      ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "default_primary_key")
+      require_env_key("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "primary encryption key")
     end
+  rescue PqcError => e
+    raise if Rails.env.production?
+    warn "[PQC] #{e.message} — using development fallback. DO NOT use in production."
+    dev_fallback_key("primary")
+  end
+
+  # Load a required encryption key from ENV with environment-aware guard.
+  # Production: raises if missing. Dev/test: generates deterministic fallback.
+  def self.require_env_key(env_var, description)
+    value = ENV[env_var]
+    return value if value.present?
+
+    if Rails.env.production?
+      raise PqcError, "#{env_var} is required in production. Configure the #{description} environment variable."
+    end
+
+    warn "[PQC] #{env_var} not set — using development fallback for #{description}. DO NOT use in production."
+    dev_fallback_key(env_var)
   end
 
   # Check if PQC key wrapping is enabled and configured
@@ -99,6 +118,13 @@ class PqcKeyManager
   end
 
   private
+
+  # Generate a deterministic dev-only fallback key. NOT cryptographically
+  # meaningful — exists solely to unblock local development without real
+  # key material. Never called in production.
+  def self.dev_fallback_key(scope)
+    OpenSSL::HMAC.hexdigest("SHA256", "daria-dev-only-not-for-production", scope)
+  end
 
   # Unwrap the primary key using ML-KEM decapsulation + AES-256-GCM
   def self.unwrap_primary_key

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,15 @@ module Daria2
     # temporary, can be removed in separate release once data migration for encrypted data is complete
     config.active_record.encryption.support_unencrypted_data = true
     # the first key in the list is the active key to perform encryptions, the rest of the list is decryption keys (to support key rotation)
-    config.active_record.encryption.primary_key = [ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "default_primary_key")]
+    # PQC dual-read: If PQC env vars are set, unwraps key via ML-KEM-1024 + AES-256-KW.
+    # Otherwise falls back to raw ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY env var.
+    primary_key = if ENV["PQC_ENABLED"] == "true"
+                    require_relative "../app/services/pqc_key_manager"
+                    PqcKeyManager.primary_key
+                  else
+                    ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "default_primary_key")
+                  end
+    config.active_record.encryption.primary_key = [primary_key]
     config.active_record.encryption.key_derivation_salt = ENV.fetch("ACTIVE_RECORD_KEY_DERIVATION_SALT", "default_salt")
     config.active_record.encryption.deterministic_key = [ENV.fetch("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY", "default_deterministic_key")]
     # for backwards compatibility's sake

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,15 +36,12 @@ module Daria2
     # the first key in the list is the active key to perform encryptions, the rest of the list is decryption keys (to support key rotation)
     # PQC dual-read: If PQC env vars are set, unwraps key via ML-KEM-1024 + AES-256-GCM.
     # Otherwise falls back to raw ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY env var.
-    primary_key = if ENV["PQC_ENABLED"] == "true"
-                    require_relative "../app/services/pqc_key_manager"
-                    PqcKeyManager.primary_key
-                  else
-                    ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "default_primary_key")
-                  end
-    config.active_record.encryption.primary_key = [primary_key]
-    config.active_record.encryption.key_derivation_salt = ENV.fetch("ACTIVE_RECORD_KEY_DERIVATION_SALT", "default_salt")
-    config.active_record.encryption.deterministic_key = [ENV.fetch("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY", "default_deterministic_key")]
+    # All key loading is environment-aware: production raises on missing keys,
+    # dev/test generates deterministic fallbacks.
+    require_relative "../app/services/pqc_key_manager"
+    config.active_record.encryption.primary_key = [PqcKeyManager.primary_key]
+    config.active_record.encryption.key_derivation_salt = PqcKeyManager.require_env_key("ACTIVE_RECORD_KEY_DERIVATION_SALT", "key derivation salt")
+    config.active_record.encryption.deterministic_key = [PqcKeyManager.require_env_key("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY", "deterministic encryption key")]
     # for backwards compatibility's sake
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1 # New data uses SHA256, but old rails had this as a default
     config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true # Allows decryption of old SHA1 data

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module Daria2
     # temporary, can be removed in separate release once data migration for encrypted data is complete
     config.active_record.encryption.support_unencrypted_data = true
     # the first key in the list is the active key to perform encryptions, the rest of the list is decryption keys (to support key rotation)
-    # PQC dual-read: If PQC env vars are set, unwraps key via ML-KEM-1024 + AES-256-KW.
+    # PQC dual-read: If PQC env vars are set, unwraps key via ML-KEM-1024 + AES-256-GCM.
     # Otherwise falls back to raw ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY env var.
     primary_key = if ENV["PQC_ENABLED"] == "true"
                     require_relative "../app/services/pqc_key_manager"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_21_192950) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_181616) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/lib/tasks/pqc.rake
+++ b/lib/tasks/pqc.rake
@@ -2,34 +2,55 @@ desc 'PQC key management tasks'
 namespace :pqc do
   desc 'Generate a new ML-KEM-1024 keypair for PQC hybrid key wrapping'
   task generate_keypair: :environment do
-    keypair = PqcKeyManager.generate_keypair
+    unless PqcKeyManager.pqc_available?
+      abort "ERROR: ML-KEM-1024 not available. Requires OpenSSL 3.5+ " \
+            "(see PR #3531 upgrade/openssl-3.5.5)."
+    end
+
+    key = PqcKeyManager.generate_keypair
+
+    priv_path = ENV.fetch("PQC_PRIVATE_KEY_PATH", "config/credentials/pqc_private.pem")
+    pub_path = ENV.fetch("PQC_PUBLIC_KEY_PATH", "config/credentials/pqc_public.pem")
+
+    FileUtils.mkdir_p(File.dirname(priv_path))
+    PqcKeyManager.save_keypair(key, private_key_path: priv_path, public_key_path: pub_path)
+
     puts "ML-KEM-1024 Keypair Generated"
     puts "=============================="
     puts ""
-    puts "Add these to your environment (e.g., Heroku config vars):"
+    puts "Private key: #{priv_path} (mode 0600)"
+    puts "Public key:  #{pub_path}"
     puts ""
-    puts "PQC_PRIVATE_KEY=#{keypair[:private_key]}"
+    puts "Set the environment variable:"
+    puts "  PQC_PRIVATE_KEY_PATH=#{priv_path}"
     puts ""
-    puts "Store the public key securely for wrapping operations:"
-    puts "PQC_PUBLIC_KEY=#{keypair[:public_key]}"
-    puts ""
-    puts "IMPORTANT: Back up the private key securely. If lost, encrypted data"
-    puts "cannot be recovered (unless you still have the raw primary key)."
+    puts "IMPORTANT: Back up the private key securely and add it to .gitignore."
+    puts "If lost, PQC-wrapped keys cannot be recovered."
   end
 
   desc 'Wrap the current primary encryption key with PQC hybrid encryption'
   task wrap_key: :environment do
-    public_key = ENV.fetch("PQC_PUBLIC_KEY") do
-      abort "ERROR: Set PQC_PUBLIC_KEY env var first. Run `rake pqc:generate_keypair` to create one."
+    unless PqcKeyManager.pqc_available?
+      abort "ERROR: ML-KEM-1024 not available. Requires OpenSSL 3.5+."
+    end
+
+    pub_path = ENV.fetch("PQC_PUBLIC_KEY_PATH") do
+      abort "ERROR: Set PQC_PUBLIC_KEY_PATH env var. Run `rake pqc:generate_keypair` first."
+    end
+
+    unless File.exist?(pub_path)
+      abort "ERROR: Public key file not found: #{pub_path}"
     end
 
     primary_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY") do
       abort "ERROR: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY not set."
     end
 
-    result = PqcKeyManager.wrap_key(primary_key, public_key)
-    puts "Primary Key Wrapped with ML-KEM-1024 + AES-256-KW"
-    puts "==================================================="
+    public_key_pem = File.read(pub_path)
+    result = PqcKeyManager.wrap_key(primary_key, public_key_pem)
+
+    puts "Primary Key Wrapped with ML-KEM-1024 + AES-256-GCM"
+    puts "===================================================="
     puts ""
     puts "Add these to your environment:"
     puts ""
@@ -39,6 +60,6 @@ namespace :pqc do
     puts ""
     puts "You can now remove ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY from your"
     puts "environment (keep a backup). The key will be unwrapped at boot time"
-    puts "using PQC_PRIVATE_KEY + PQC_WRAPPED_KEY + PQC_KEM_CIPHERTEXT."
+    puts "using PQC_PRIVATE_KEY_PATH + PQC_WRAPPED_KEY + PQC_KEM_CIPHERTEXT."
   end
 end

--- a/lib/tasks/pqc.rake
+++ b/lib/tasks/pqc.rake
@@ -1,0 +1,44 @@
+desc 'PQC key management tasks'
+namespace :pqc do
+  desc 'Generate a new ML-KEM-1024 keypair for PQC hybrid key wrapping'
+  task generate_keypair: :environment do
+    keypair = PqcKeyManager.generate_keypair
+    puts "ML-KEM-1024 Keypair Generated"
+    puts "=============================="
+    puts ""
+    puts "Add these to your environment (e.g., Heroku config vars):"
+    puts ""
+    puts "PQC_PRIVATE_KEY=#{keypair[:private_key]}"
+    puts ""
+    puts "Store the public key securely for wrapping operations:"
+    puts "PQC_PUBLIC_KEY=#{keypair[:public_key]}"
+    puts ""
+    puts "IMPORTANT: Back up the private key securely. If lost, encrypted data"
+    puts "cannot be recovered (unless you still have the raw primary key)."
+  end
+
+  desc 'Wrap the current primary encryption key with PQC hybrid encryption'
+  task wrap_key: :environment do
+    public_key = ENV.fetch("PQC_PUBLIC_KEY") do
+      abort "ERROR: Set PQC_PUBLIC_KEY env var first. Run `rake pqc:generate_keypair` to create one."
+    end
+
+    primary_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY") do
+      abort "ERROR: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY not set."
+    end
+
+    result = PqcKeyManager.wrap_key(primary_key, public_key)
+    puts "Primary Key Wrapped with ML-KEM-1024 + AES-256-KW"
+    puts "==================================================="
+    puts ""
+    puts "Add these to your environment:"
+    puts ""
+    puts "PQC_ENABLED=true"
+    puts "PQC_WRAPPED_KEY=#{result[:wrapped_key]}"
+    puts "PQC_KEM_CIPHERTEXT=#{result[:kem_ciphertext]}"
+    puts ""
+    puts "You can now remove ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY from your"
+    puts "environment (keep a backup). The key will be unwrapped at boot time"
+    puts "using PQC_PRIVATE_KEY + PQC_WRAPPED_KEY + PQC_KEM_CIPHERTEXT."
+  end
+end

--- a/test/services/pqc_key_manager_test.rb
+++ b/test/services/pqc_key_manager_test.rb
@@ -1,0 +1,179 @@
+require 'test_helper'
+
+class PqcKeyManagerTest < ActiveSupport::TestCase
+  before do
+    PqcKeyManager.reset_availability_cache!
+    # Stash original env vars to restore after tests
+    @original_env = {}
+    %w[PQC_ENABLED PQC_PRIVATE_KEY_PATH PQC_WRAPPED_KEY PQC_KEM_CIPHERTEXT
+       PQC_PUBLIC_KEY_PATH ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY].each do |key|
+      @original_env[key] = ENV[key]
+    end
+  end
+
+  after do
+    # Restore environment
+    @original_env.each { |key, val| val.nil? ? ENV.delete(key) : ENV[key] = val }
+    PqcKeyManager.reset_availability_cache!
+  end
+
+  describe 'pqc_available?' do
+    it 'should return a boolean' do
+      result = PqcKeyManager.pqc_available?
+      assert [true, false].include?(result)
+    end
+
+    it 'should cache the result' do
+      first = PqcKeyManager.pqc_available?
+      second = PqcKeyManager.pqc_available?
+      assert_equal first, second
+    end
+
+    it 'should reset cache when reset_availability_cache! is called' do
+      PqcKeyManager.pqc_available?
+      PqcKeyManager.reset_availability_cache!
+      # After reset, calling again should re-evaluate
+      assert [true, false].include?(PqcKeyManager.pqc_available?)
+    end
+  end
+
+  describe 'pqc_enabled?' do
+    it 'should return false when PQC_ENABLED is not set' do
+      ENV.delete('PQC_ENABLED')
+      refute PqcKeyManager.pqc_enabled?
+    end
+
+    it 'should return false when PQC_ENABLED is not "true"' do
+      ENV['PQC_ENABLED'] = 'false'
+      refute PqcKeyManager.pqc_enabled?
+    end
+
+    it 'should return false when required env vars are missing' do
+      ENV['PQC_ENABLED'] = 'true'
+      ENV.delete('PQC_PRIVATE_KEY_PATH')
+      ENV.delete('PQC_WRAPPED_KEY')
+      ENV.delete('PQC_KEM_CIPHERTEXT')
+      refute PqcKeyManager.pqc_enabled?
+    end
+
+    it 'should return true when all env vars are set' do
+      ENV['PQC_ENABLED'] = 'true'
+      ENV['PQC_PRIVATE_KEY_PATH'] = '/tmp/test_key.pem'
+      ENV['PQC_WRAPPED_KEY'] = 'somebase64data'
+      ENV['PQC_KEM_CIPHERTEXT'] = 'somebase64data'
+      assert PqcKeyManager.pqc_enabled?
+    end
+  end
+
+  describe 'primary_key' do
+    it 'should fall back to env var when PQC is not enabled' do
+      ENV.delete('PQC_ENABLED')
+      ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY'] = 'test-primary-key'
+      assert_equal 'test-primary-key', PqcKeyManager.primary_key
+    end
+
+    it 'should return default when no env var and PQC disabled' do
+      ENV.delete('PQC_ENABLED')
+      ENV.delete('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY')
+      assert_equal 'default_primary_key', PqcKeyManager.primary_key
+    end
+  end
+
+  describe 'AES-256-GCM round trip' do
+    it 'should encrypt and decrypt correctly' do
+      key = OpenSSL::Random.random_bytes(32)
+      plaintext = "my-secret-primary-key"
+
+      encrypted = PqcKeyManager.send(:aes_gcm_encrypt, key, plaintext.b)
+      decrypted = PqcKeyManager.send(:aes_gcm_decrypt, key, encrypted)
+
+      assert_equal plaintext.b, decrypted
+    end
+
+    it 'should fail with wrong key' do
+      key = OpenSSL::Random.random_bytes(32)
+      wrong_key = OpenSSL::Random.random_bytes(32)
+      plaintext = "my-secret-primary-key"
+
+      encrypted = PqcKeyManager.send(:aes_gcm_encrypt, key, plaintext.b)
+
+      assert_raises(OpenSSL::Cipher::CipherError) do
+        PqcKeyManager.send(:aes_gcm_decrypt, wrong_key, encrypted)
+      end
+    end
+
+    it 'should fail with tampered ciphertext' do
+      key = OpenSSL::Random.random_bytes(32)
+      plaintext = "my-secret-primary-key"
+
+      encrypted = PqcKeyManager.send(:aes_gcm_encrypt, key, plaintext.b)
+      # Tamper with last byte
+      tampered = encrypted.dup
+      tampered[-1] = (tampered[-1].ord ^ 0xFF).chr
+
+      assert_raises(OpenSSL::Cipher::CipherError) do
+        PqcKeyManager.send(:aes_gcm_decrypt, key, tampered)
+      end
+    end
+  end
+
+  describe 'generate_keypair' do
+    it 'should raise PqcUnavailableError when ML-KEM not available' do
+      # Stub pqc_available? to return false
+      PqcKeyManager.stub(:pqc_available?, false) do
+        assert_raises(PqcKeyManager::PqcUnavailableError) do
+          PqcKeyManager.generate_keypair
+        end
+      end
+    end
+  end
+
+  describe 'save_keypair' do
+    it 'should write files with correct permissions' do
+      skip 'File permissions not reliable on Windows' if Gem.win_platform?
+
+      # Create a mock PEM key object
+      key = OpenSSL::PKey::RSA.generate(2048) # RSA for testing file write
+      Dir.mktmpdir do |dir|
+        priv_path = File.join(dir, 'test_private.pem')
+        pub_path = File.join(dir, 'test_public.pem')
+
+        PqcKeyManager.save_keypair(key, private_key_path: priv_path, public_key_path: pub_path)
+
+        assert File.exist?(priv_path)
+        assert File.exist?(pub_path)
+        assert_equal 0o600, File.stat(priv_path).mode & 0o777
+      end
+    end
+  end
+
+  describe 'unwrap_primary_key error handling' do
+    it 'should raise KeyUnwrapError when private key file missing' do
+      PqcKeyManager.stub(:pqc_available?, true) do
+        ENV['PQC_ENABLED'] = 'true'
+        ENV['PQC_PRIVATE_KEY_PATH'] = '/nonexistent/path/key.pem'
+        ENV['PQC_WRAPPED_KEY'] = Base64.strict_encode64('fake')
+        ENV['PQC_KEM_CIPHERTEXT'] = Base64.strict_encode64('fake')
+
+        assert_raises(PqcKeyManager::KeyUnwrapError) do
+          PqcKeyManager.primary_key
+        end
+      end
+    end
+  end
+
+  describe 'private key never exposed' do
+    it 'should not include private key material in any public method return value' do
+      # Verify that generate_keypair returns a key object, not a hash with raw key material
+      PqcKeyManager.stub(:pqc_available?, true) do
+        # Mock generate_key to return a real key type for testing
+        mock_key = OpenSSL::PKey::RSA.generate(2048)
+        OpenSSL::PKey.stub(:generate_key, mock_key) do
+          result = PqcKeyManager.generate_keypair
+          # Should return an OpenSSL::PKey object, not a hash with base64 key material
+          assert_kind_of OpenSSL::PKey::PKey, result
+        end
+      end
+    end
+  end
+end

--- a/test/services/pqc_key_manager_test.rb
+++ b/test/services/pqc_key_manager_test.rb
@@ -219,4 +219,107 @@ class PqcKeyManagerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'pqc_available? thread safety' do
+    it 'should return consistent results across concurrent threads' do
+      PqcKeyManager.reset_availability_cache!
+
+      results = []
+      threads = 10.times.map do
+        Thread.new { results << PqcKeyManager.pqc_available? }
+      end
+      threads.each(&:join)
+
+      assert_equal 1, results.uniq.size,
+        'All threads should observe the same cached pqc_available? value'
+    end
+  end
+
+  describe 'wrap_key with invalid public key' do
+    it 'should raise when given corrupted PEM data' do
+      PqcKeyManager.stub(:pqc_available?, true) do
+        assert_raises(OpenSSL::PKey::PKeyError) do
+          PqcKeyManager.wrap_key('my-secret-key', 'NOT-A-VALID-PEM')
+        end
+      end
+    end
+
+    it 'should raise when given an empty string as public key' do
+      PqcKeyManager.stub(:pqc_available?, true) do
+        assert_raises(OpenSSL::PKey::PKeyError) do
+          PqcKeyManager.wrap_key('my-secret-key', '')
+        end
+      end
+    end
+  end
+
+  describe 'unwrap_primary_key with tampered ciphertext' do
+    it 'should raise KeyUnwrapError when kem_ciphertext is tampered' do
+      PqcKeyManager.stub(:pqc_available?, true) do
+        # Set up env with tampered ciphertext that will fail decapsulation
+        Dir.mktmpdir do |dir|
+          # Use an RSA key as a stand-in private key file (will fail at decapsulate)
+          rsa_key = OpenSSL::PKey::RSA.generate(2048)
+          priv_path = File.join(dir, 'private.pem')
+          File.write(priv_path, rsa_key.to_pem)
+
+          ENV['PQC_ENABLED'] = 'true'
+          ENV['PQC_PRIVATE_KEY_PATH'] = priv_path
+          ENV['PQC_WRAPPED_KEY'] = Base64.strict_encode64('fake-wrapped')
+          ENV['PQC_KEM_CIPHERTEXT'] = Base64.strict_encode64('tampered-ciphertext')
+
+          Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
+            assert_raises(PqcKeyManager::KeyUnwrapError) do
+              PqcKeyManager.primary_key
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'rake tasks' do
+    it 'should define pqc:generate_keypair task' do
+      Rake::Task.task_defined?('pqc:generate_keypair') ||
+        Rake.application.load_rakefile
+      assert Rake::Task.task_defined?('pqc:generate_keypair'),
+        'pqc:generate_keypair rake task should be defined'
+    end
+
+    it 'should define pqc:wrap_key task' do
+      Rake::Task.task_defined?('pqc:wrap_key') ||
+        Rake.application.load_rakefile
+      assert Rake::Task.task_defined?('pqc:wrap_key'),
+        'pqc:wrap_key rake task should be defined'
+    end
+
+    it 'should have descriptive comments on rake tasks' do
+      task = Rake::Task['pqc:generate_keypair']
+      assert_match(/ML-KEM/, task.comment, 'generate_keypair should mention ML-KEM in description')
+
+      task = Rake::Task['pqc:wrap_key']
+      assert_match(/[Ww]rap/, task.comment, 'wrap_key should mention wrapping in description')
+    end
+  end
+
+  describe 'dev_fallback_key determinism' do
+    it 'should return the same key for the same scope' do
+      key1 = PqcKeyManager.send(:dev_fallback_key, 'primary')
+      key2 = PqcKeyManager.send(:dev_fallback_key, 'primary')
+      assert_equal key1, key2
+    end
+
+    it 'should return different keys for different scopes' do
+      key_primary = PqcKeyManager.send(:dev_fallback_key, 'primary')
+      key_deterministic = PqcKeyManager.send(:dev_fallback_key, 'deterministic')
+      refute_equal key_primary, key_deterministic
+    end
+
+    it 'should return a hex string of expected length' do
+      key = PqcKeyManager.send(:dev_fallback_key, 'test-scope')
+      # SHA256 HMAC hex digest is 64 characters
+      assert_equal 64, key.length
+      assert_match(/\A[0-9a-f]{64}\z/, key)
+    end
+  end
 end

--- a/test/services/pqc_key_manager_test.rb
+++ b/test/services/pqc_key_manager_test.rb
@@ -72,10 +72,15 @@ class PqcKeyManagerTest < ActiveSupport::TestCase
       assert_equal 'test-primary-key', PqcKeyManager.primary_key
     end
 
-    it 'should return default when no env var and PQC disabled' do
+    it 'should return deterministic dev fallback when no env var and PQC disabled' do
       ENV.delete('PQC_ENABLED')
       ENV.delete('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY')
-      assert_equal 'default_primary_key', PqcKeyManager.primary_key
+      key = PqcKeyManager.primary_key
+      assert key.present?
+      # Dev fallback is deterministic — same input yields same output
+      assert_equal key, PqcKeyManager.primary_key
+      # Must not be the old hardcoded value
+      refute_equal 'default_primary_key', key
     end
   end
 
@@ -148,15 +153,53 @@ class PqcKeyManagerTest < ActiveSupport::TestCase
   end
 
   describe 'unwrap_primary_key error handling' do
-    it 'should raise KeyUnwrapError when private key file missing' do
+    it 'should fall back gracefully when private key file missing in non-production' do
       PqcKeyManager.stub(:pqc_available?, true) do
         ENV['PQC_ENABLED'] = 'true'
         ENV['PQC_PRIVATE_KEY_PATH'] = '/nonexistent/path/key.pem'
         ENV['PQC_WRAPPED_KEY'] = Base64.strict_encode64('fake')
         ENV['PQC_KEM_CIPHERTEXT'] = Base64.strict_encode64('fake')
 
-        assert_raises(PqcKeyManager::KeyUnwrapError) do
-          PqcKeyManager.primary_key
+        key = PqcKeyManager.primary_key
+        assert key.present?
+        refute_equal 'default_primary_key', key
+      end
+    end
+
+    it 'should raise KeyUnwrapError in production when private key file missing' do
+      PqcKeyManager.stub(:pqc_available?, true) do
+        ENV['PQC_ENABLED'] = 'true'
+        ENV['PQC_PRIVATE_KEY_PATH'] = '/nonexistent/path/key.pem'
+        ENV['PQC_WRAPPED_KEY'] = Base64.strict_encode64('fake')
+        ENV['PQC_KEM_CIPHERTEXT'] = Base64.strict_encode64('fake')
+
+        Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
+          assert_raises(PqcKeyManager::KeyUnwrapError) do
+            PqcKeyManager.primary_key
+          end
+        end
+      end
+    end
+  end
+
+  describe 'require_env_key' do
+    it 'should return env var value when present' do
+      ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY'] = 'my-real-key'
+      assert_equal 'my-real-key', PqcKeyManager.require_env_key('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY', 'test')
+    end
+
+    it 'should return dev fallback in non-production when env var missing' do
+      ENV.delete('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY')
+      key = PqcKeyManager.require_env_key('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY', 'test')
+      assert key.present?
+      refute_equal 'default_primary_key', key
+    end
+
+    it 'should raise PqcError in production when env var missing' do
+      ENV.delete('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY')
+      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
+        assert_raises(PqcKeyManager::PqcError) do
+          PqcKeyManager.require_env_key('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY', 'test')
         end
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds post-quantum hybrid key wrapping for the encryption system, combining a quantum-resistant algorithm with traditional AES-256 encryption. This future-proofs patient data encryption against advances in quantum computing.

This pull request makes the following changes:
* Add `PqcKeyManager` service with key generation, key wrapping (encapsulate), and key unwrapping (decapsulate)
* Use ML-KEM-1024 (post-quantum) combined with AES-256-GCM (symmetric) for hybrid encryption
* Add rake task `pqc:generate_keypair` for generating key pairs (writes PEM files, never prints keys to stdout)
* Private keys stored as PEM files with restricted (0600) permissions
* Add runtime capability check (`pqc_available?`) with caching

**Notes:**
* **Depends on** #3531 (OpenSSL 3.5.5 upgrade) — ML-KEM-1024 is only available in OpenSSL 3.5+.
* **Merge order:** `#3531` → `#3548`.
* **Environment variable:** `PQC_PRIVATE_KEY_PATH` must point to the generated private key PEM file.
* **After merging:** Admin must run `rake pqc:generate_keypair` to create the key pair, then set `PQC_PRIVATE_KEY_PATH` in the environment.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
