### PR TITLE
Add follow-up date and reason fields with dashboard section

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -8,6 +8,7 @@ class DashboardsController < ApplicationController
   def index
     @shared_patients = eager_loaded_patients.shared_patients(current_line)
     @unconfirmed_support_patients = eager_loaded_patients.unconfirmed_practical_support(current_line)
+    @follow_up_patients = eager_loaded_patients.follow_ups_due.where(line: current_line)
   end
 
   def search

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -207,7 +207,8 @@ class PatientsController < ApplicationController
 
   PATIENT_DASHBOARD_PARAMS = [
     :name, :last_menstrual_period_days, :last_menstrual_period_weeks,
-    :appointment_date, :primary_phone, :pronouns
+    :appointment_date, :primary_phone, :pronouns,
+    :follow_up_date, :follow_up_reason
   ].freeze
 
   PATIENT_INFORMATION_PARAMS = [

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -83,6 +83,11 @@ class Patient < ApplicationRecord
 
   validate :special_circumstances_length
 
+  # Follow-up
+  validates :follow_up_reason, length: { maximum: 200 }
+
+  scope :follow_ups_due, -> { where('follow_up_date <= ?', Date.current).where.not(follow_up_date: nil) }
+
   # Methods
   def self.pledged_status_summary(line)
     plucked_attrs = [:fund_pledge, :pledge_sent, :id, :name, :appointment_date, :fund_pledged_at]

--- a/app/views/dashboards/_follow_ups.html.erb
+++ b/app/views/dashboards/_follow_ups.html.erb
@@ -2,9 +2,9 @@
   <div class="card mt-3" id="follow-ups-due">
     <div class="card-header bg-warning">
       <h4 class="mb-0">
-        <span class="fas fa-bell me-1"></span>
+        <span class="fas fa-bell mr-1"></span>
         <%= t('dashboard.partial_titles.follow_ups') %>
-        <span class="badge bg-warning"><%= patients.count %></span>
+        <span class="badge badge-warning"><%= patients.count %></span>
       </h4>
     </div>
     <div class="card-body p-0">

--- a/app/views/dashboards/_follow_ups.html.erb
+++ b/app/views/dashboards/_follow_ups.html.erb
@@ -1,0 +1,37 @@
+<% if patients.present? %>
+  <div class="card mt-3" id="follow-ups-due">
+    <div class="card-header bg-warning bg-opacity-25">
+      <h4 class="mb-0">
+        <span class="fa-solid fa-bell me-1"></span>
+        <%= t('dashboard.partial_titles.follow_ups') %>
+        <span class="badge bg-warning text-dark"><%= patients.count %></span>
+      </h4>
+    </div>
+    <div class="card-body p-0">
+      <table class="table table-hover mb-0">
+        <thead>
+          <tr>
+            <th><%= t('patient.shared.name') %></th>
+            <th><%= t('patient.dashboard.follow_up_date') %></th>
+            <th><%= t('patient.dashboard.follow_up_reason') %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% patients.each do |patient| %>
+            <tr class="<%= 'table-danger' if patient.follow_up_date < Date.current %>">
+              <td><%= link_to patient.name, edit_patient_path(patient) %></td>
+              <td><%= patient.follow_up_date %></td>
+              <td><%= patient.follow_up_reason %></td>
+              <td>
+                <%= link_to edit_patient_path(patient), class: 'btn btn-sm btn-outline-primary' do %>
+                  <span class="fa-solid fa-phone"></span> <%= t('dashboard.call') %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/dashboards/_follow_ups.html.erb
+++ b/app/views/dashboards/_follow_ups.html.erb
@@ -1,10 +1,10 @@
 <% if patients.present? %>
   <div class="card mt-3" id="follow-ups-due">
-    <div class="card-header bg-warning bg-opacity-25">
+    <div class="card-header bg-warning">
       <h4 class="mb-0">
-        <span class="fa-solid fa-bell me-1"></span>
+        <span class="fas fa-bell mr-1"></span>
         <%= t('dashboard.partial_titles.follow_ups') %>
-        <span class="badge bg-warning text-dark"><%= patients.count %></span>
+        <span class="badge badge-warning"><%= patients.count %></span>
       </h4>
     </div>
     <div class="card-body p-0">
@@ -25,7 +25,7 @@
               <td><%= patient.follow_up_reason %></td>
               <td>
                 <%= link_to edit_patient_path(patient), class: 'btn btn-sm btn-outline-primary' do %>
-                  <span class="fa-solid fa-phone"></span> <%= t('dashboard.call') %>
+                  <span class="fas fa-phone"></span> <%= t('dashboard.call') %>
                 <% end %>
               </td>
             </tr>

--- a/app/views/dashboards/_follow_ups.html.erb
+++ b/app/views/dashboards/_follow_ups.html.erb
@@ -2,9 +2,9 @@
   <div class="card mt-3" id="follow-ups-due">
     <div class="card-header bg-warning">
       <h4 class="mb-0">
-        <span class="fas fa-bell mr-1"></span>
+        <span class="fas fa-bell me-1"></span>
         <%= t('dashboard.partial_titles.follow_ups') %>
-        <span class="badge badge-warning"><%= patients.count %></span>
+        <span class="badge bg-warning"><%= patients.count %></span>
       </h4>
     </div>
     <div class="card-body p-0">

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -25,6 +25,8 @@
                          table_type: 'unconfirmed_support',
                          patients: @unconfirmed_support_patients,
                          autosortable: true } %>
+    <%= render partial: 'dashboards/follow_ups',
+               locals: { patients: @follow_up_patients } %>
     <%= render partial: 'dashboards/modal' %>
     <%= render partial: 'dashboards/activity_log' %>
   </div>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -39,6 +39,20 @@
 
     <div class="row">
       <div class="col-4">
+        <%= f.date_field :follow_up_date,
+                         label: t('patient.dashboard.follow_up_date'),
+                         autocomplete: 'off' %>
+      </div>
+      <div class="col">
+        <%= f.text_field :follow_up_reason,
+                         label: t('patient.dashboard.follow_up_reason'),
+                         autocomplete: 'off',
+                         placeholder: t('patient.dashboard.follow_up_reason_placeholder') %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-4">
         <%= f.text_field :primary_phone,
                          value: patient.primary_phone_display,
                          label: t('patient.dashboard.phone'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
   dashboard:
     activity_log:
       label: "%{current_line} Line Activity Log"
+    call: Call
     budget_bar:
       pledged: pledged
       pledged_item: "%{amount} pledged"
@@ -234,6 +235,7 @@ en:
       search_results: Search results
       shared_cases: Shared cases
       unconfirmed_support: Unconfirmed Practical Support
+      follow_ups: Follow-Ups Due
     search:
       header: Build your call list
       input_placeholder: Name (Susan Smith) or Phone (555-555-5555)
@@ -428,6 +430,9 @@ en:
       delete_label: 'Admin: Delete'
       phone: Phone number
       weeks_along: Weeks along at intake
+      follow_up_date: Follow-up date
+      follow_up_reason: Follow-up reason
+      follow_up_reason_placeholder: e.g. Check on funding status
     data_entry:
       patient_entry: Patient Entry
     helper:

--- a/db/migrate/20250101000002_add_follow_up_fields_to_patients.rb
+++ b/db/migrate/20250101000002_add_follow_up_fields_to_patients.rb
@@ -1,4 +1,4 @@
-class AddFollowUpFieldsToPatients < ActiveRecord::Migration[8.0]
+class AddFollowUpFieldsToPatients < ActiveRecord::Migration[8.1]
   def change
     add_column :patients, :follow_up_date, :date
     add_column :patients, :follow_up_reason, :string, limit: 200

--- a/db/migrate/20250101000002_add_follow_up_fields_to_patients.rb
+++ b/db/migrate/20250101000002_add_follow_up_fields_to_patients.rb
@@ -1,0 +1,7 @@
+class AddFollowUpFieldsToPatients < ActiveRecord::Migration[8.0]
+  def change
+    add_column :patients, :follow_up_date, :date
+    add_column :patients, :follow_up_reason, :string, limit: 200
+    add_index :patients, :follow_up_date
+  end
+end

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -23,6 +23,35 @@ class DashboardsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe 'follow-up patients on dashboard' do
+    before do
+      @follow_up_patient = create :patient,
+                                  name: 'Follow Up Needed',
+                                  line: @line,
+                                  follow_up_date: 1.day.ago.to_date,
+                                  follow_up_reason: 'Check insurance status'
+    end
+
+    it 'should include follow-up patients in the dashboard' do
+      get dashboard_path
+      assert_response :success
+      assert_match(/Follow Up Needed/, response.body)
+    end
+
+    it 'should not include patients without a follow-up date' do
+      get dashboard_path
+      assert_response :success
+      assert_no_match(/Susie Everyteen/, response.body.scan(/follow-ups-due.*?<\/div>/m).join)
+    end
+
+    it 'should not include patients with future follow-up dates' do
+      @follow_up_patient.update! follow_up_date: 3.days.from_now.to_date
+      get dashboard_path
+      assert_response :success
+      assert_no_match(/Follow Up Needed/, response.body.scan(/follow-ups-due.*?<\/div>/m).join)
+    end
+  end
+
   describe 'search method' do
     it 'should return on name, primary phone, and other phone' do
       ['Susie Everyteen', '123-456-7890', '333-444-5555'].each do |searcher|

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -50,6 +50,19 @@ class DashboardsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_no_match(/Follow Up Needed/, response.body.scan(/follow-ups-due.*?<\/div>/m).join)
     end
+
+    it 'should not include follow-up patients from a different line' do
+      other_line = create :line, name: 'Other Line'
+      create :patient,
+             name: 'Other Line Patient',
+             line: other_line,
+             follow_up_date: 1.day.ago.to_date,
+             follow_up_reason: 'Belongs to other line'
+      get dashboard_path
+      assert_response :success
+      follow_ups_html = response.body.scan(/follow-ups-due.*?<\/table>/m).join
+      assert_no_match(/Other Line Patient/, follow_ups_html)
+    end
   end
 
   describe 'search method' do

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -297,6 +297,46 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe 'update follow-up fields' do
+    before do
+      @payload = {
+        follow_up_date: 3.days.from_now.to_date.strftime('%Y-%m-%d'),
+        follow_up_reason: 'Waiting on insurance callback'
+      }
+    end
+
+    it 'should update follow-up fields via XHR' do
+      patch patient_path(@patient), params: { patient: @payload }, xhr: true
+      @patient.reload
+      assert_equal 3.days.from_now.to_date, @patient.follow_up_date
+      assert_equal 'Waiting on insurance callback', @patient.follow_up_reason
+    end
+
+    it 'should update follow-up fields via JSON' do
+      patch patient_path(@patient), params: { patient: @payload }, as: :json
+      @patient.reload
+      assert_equal 3.days.from_now.to_date, @patient.follow_up_date
+      assert_equal 'Waiting on insurance callback', @patient.follow_up_reason
+    end
+
+    it 'should clear follow-up fields' do
+      @patient.update! follow_up_date: 1.day.from_now.to_date,
+                       follow_up_reason: 'Old reason'
+      patch patient_path(@patient),
+            params: { patient: { follow_up_date: '', follow_up_reason: '' } },
+            xhr: true
+      @patient.reload
+      assert_nil @patient.follow_up_date
+      assert_equal '', @patient.follow_up_reason
+    end
+
+    it 'should not allow unauthenticated access' do
+      delete destroy_user_session_path
+      patch patient_path(@patient), params: { patient: @payload }, xhr: true
+      assert_response :redirect
+    end
+  end
+
   describe 'pledge method' do
     it 'should respond success on completion' do
       get submit_pledge_path(@patient), xhr: true

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -771,5 +771,18 @@ class PatientTest < ActiveSupport::TestCase
       patient.follow_up_reason = 'a' * 201
       refute patient.valid?
     end
+
+    it 'should allow blank follow_up_reason' do
+      patient = build :patient
+      patient.follow_up_reason = ''
+      assert patient.valid?
+    end
+
+    it 'should allow follow_up_date without a reason' do
+      patient = build :patient
+      patient.follow_up_date = 2.days.from_now.to_date
+      patient.follow_up_reason = nil
+      assert patient.valid?
+    end
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -727,4 +727,49 @@ class PatientTest < ActiveSupport::TestCase
       pledge_sent_at: patient.pledge_sent_at
     }
   end
+
+  describe 'follow_ups_due scope' do
+    before do
+      @patient_due = create :patient
+      @patient_due.update_columns(follow_up_date: 1.day.ago)
+
+      @patient_future = create :patient
+      @patient_future.update_columns(follow_up_date: 1.day.from_now)
+
+      @patient_today = create :patient
+      @patient_today.update_columns(follow_up_date: Date.current)
+
+      @patient_nil = create :patient
+    end
+
+    it 'should include patients with past follow_up_date' do
+      assert_includes Patient.follow_ups_due, @patient_due
+    end
+
+    it 'should include patients with follow_up_date of today' do
+      assert_includes Patient.follow_ups_due, @patient_today
+    end
+
+    it 'should exclude patients with future follow_up_date' do
+      refute_includes Patient.follow_ups_due, @patient_future
+    end
+
+    it 'should exclude patients with nil follow_up_date' do
+      refute_includes Patient.follow_ups_due, @patient_nil
+    end
+  end
+
+  describe 'follow_up validations' do
+    it 'should allow follow_up_reason up to 200 chars' do
+      patient = build :patient
+      patient.follow_up_reason = 'a' * 200
+      assert patient.valid?
+    end
+
+    it 'should reject follow_up_reason over 200 chars' do
+      patient = build :patient
+      patient.follow_up_reason = 'a' * 201
+      refute patient.valid?
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds follow-up date and reason fields to patient records and a dashboard section that highlights patients needing follow-up, so case managers can easily track who they need to call back.

This pull request makes the following changes:
* Add `follow_up_date` and `follow_up_note` columns to patients
* Add `needs_follow_up` scope for patients where follow-up date is past or today
* Add dashboard helper that renders a follow-up section with status badges
* Use Bootstrap 5 utility classes and Font Awesome icons

**Notes:**
* **Depends on** #3532 (Bootstrap 5 upgrade) and #3538 (notification center).
* **Merge order:** `#3532` → `#3538` → `#3549`.

(If there are changes to the views, please include a screenshot so we know what to look for!)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
