### PR TITLE
Add configurable stale patient alerts with nightly notifications

### DIFF
--- a/app/jobs/stale_patient_alert_job.rb
+++ b/app/jobs/stale_patient_alert_job.rb
@@ -2,6 +2,11 @@ class StalePatientAlertJob < ApplicationJob
   queue_as :default
 
   def perform
+    unless defined?(Notification)
+      Rails.logger.info('StalePatientAlertJob skipped: Notification model not available')
+      return
+    end
+
     Fund.all.each do |fund|
       ActsAsTenant.with_tenant(fund) do
         days = Config.stale_patient_days

--- a/app/jobs/stale_patient_alert_job.rb
+++ b/app/jobs/stale_patient_alert_job.rb
@@ -13,21 +13,22 @@ class StalePatientAlertJob < ApplicationJob
           users = user_ids.any? ? User.where(id: user_ids) : User.where(role: [:admin])
 
           users.each do |user|
+            patient_link = "/patients/#{patient.id}/edit"
+
             # Skip if there's already an unread stale notification for this patient
             next if Notification.where(
               user: user,
-              notification_type: :stale_patient,
-              related_type: 'Patient',
-              related_id: patient.id,
+              notification_type: "stale_patient",
+              link: patient_link,
               read_at: nil
             ).exists?
 
             Notification.notify!(
               user: user,
-              type: :stale_patient,
+              notification_type: "stale_patient",
               title: "Stale patient: #{patient.name}",
               body: "No activity in #{days} days (last updated #{patient.updated_at.strftime('%b %d')})",
-              related: patient
+              link: patient_link
             )
           end
         end

--- a/app/jobs/stale_patient_alert_job.rb
+++ b/app/jobs/stale_patient_alert_job.rb
@@ -1,0 +1,37 @@
+class StalePatientAlertJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Fund.all.each do |fund|
+      ActsAsTenant.with_tenant(fund) do
+        days = Config.stale_patient_days
+        stale_patients = Patient.stale(days)
+
+        stale_patients.find_each do |patient|
+          # Notify users who have this patient on their call list
+          user_ids = CallListEntry.where(patient: patient).pluck(:user_id).uniq
+          users = user_ids.any? ? User.where(id: user_ids) : User.where(role: [:admin])
+
+          users.each do |user|
+            # Skip if there's already an unread stale notification for this patient
+            next if Notification.where(
+              user: user,
+              notification_type: :stale_patient,
+              related_type: 'Patient',
+              related_id: patient.id,
+              read_at: nil
+            ).exists?
+
+            Notification.notify!(
+              user: user,
+              type: :stale_patient,
+              title: "Stale patient: #{patient.name}",
+              body: "No activity in #{days} days (last updated #{patient.updated_at.strftime('%b %d')})",
+              related: patient
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -27,7 +27,8 @@ class Config < ApplicationRecord
     show_patient_identifier: 'Enter "yes" to show the patient\' Daria Identifier on the patient information tab.',
     display_practical_support_attachment_url: 'CAUTION: Whether or not to allow people to enter attachment URLs for practical support entries; for example, a link to a file in Google Drive. Please ensure that any system storing these is properly secured by your fund!',
     display_practical_support_waiver: 'For funds that use waivers for practical support recipients. Enables the display of a checkbox for indicating if a patient has signed a practical support waiver. ',
-    display_consent_to_survey: 'For funds that do followup surveys, this displays a Consent to Survey checkbox under the Patient Information tab.'
+    display_consent_to_survey: 'For funds that do followup surveys, this displays a Consent to Survey checkbox under the Patient Information tab.',
+    stale_patient_days: 'Number of days with no activity before a patient is considered stale. Options: 2, 3, 5 (default), 7, 14, 30.'
   }.freeze
 
   # Whether a config should show a current options dropdown to the right
@@ -65,7 +66,8 @@ class Config < ApplicationRecord
     aggregate_statistics: false,
     hide_standard_dropdown_values: false,
     county: nil,
-    time_zone: "Eastern"
+    time_zone: "Eastern",
+    stale_patient_days: 5
   }.freeze
 
   enum :config_key, {
@@ -94,7 +96,8 @@ class Config < ApplicationRecord
     show_patient_identifier: 22,
     display_practical_support_attachment_url: 23,
     display_practical_support_waiver: 24,
-    display_consent_to_survey: 25
+    display_consent_to_survey: 25,
+    stale_patient_days: 28
   }
 
   # which fields are URLs (run special validation only on those)
@@ -165,6 +168,8 @@ class Config < ApplicationRecord
       [:validate_singleton, :validate_yes_or_no],
     display_consent_to_survey:
       [:validate_singleton, :validate_yes_or_no],
+    stale_patient_days:
+      [:validate_singleton, :validate_stale_patient_days],
   }.freeze
 
   before_validation :clean_config_value
@@ -266,6 +271,15 @@ class Config < ApplicationRecord
 
   def self.display_consent_to_survey
     config_to_bool('display_consent_to_survey')
+  end
+
+  STALE_PATIENT_DAY_OPTIONS = [2, 3, 5, 7, 14, 30].freeze
+
+  def self.stale_patient_days
+    days = Config.find_or_create_by(config_key: 'stale_patient_days').options.try :last
+    days = days.to_i if days.present?
+    days = DEFAULTS[:stale_patient_days] unless STALE_PATIENT_DAY_OPTIONS.include?(days)
+    days
   end
 
   private
@@ -419,5 +433,13 @@ class Config < ApplicationRecord
         total_length += option.length
       end
       "Length of provided values is too long (over 4000 characters)" if total_length > 4000
+    end
+
+    ### Stale patient days
+
+    def validate_stale_patient_days
+      unless STALE_PATIENT_DAY_OPTIONS.include?(options.last.to_i)
+        "Must be one of: #{STALE_PATIENT_DAY_OPTIONS.join(', ')} days"
+      end
     end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -97,7 +97,7 @@ class Config < ApplicationRecord
     display_practical_support_attachment_url: 23,
     display_practical_support_waiver: 24,
     display_consent_to_survey: 25,
-    stale_patient_days: 28
+    stale_patient_days: 27
   }
 
   # which fields are URLs (run special validation only on those)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -83,6 +83,12 @@ class Patient < ApplicationRecord
 
   validate :special_circumstances_length
 
+  scope :stale, ->(days) {
+    where('updated_at < ?', days.days.ago)
+      .where(resolved_without_fund: [false, nil])
+      .where(pledge_sent: [false, nil])
+  }
+
   # Methods
   def self.pledged_status_summary(line)
     plucked_attrs = [:fund_pledge, :pledge_sent, :id, :name, :appointment_date, :fund_pledged_at]

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -89,6 +89,13 @@ class Patient < ApplicationRecord
       .where(pledge_sent: [false, nil])
   }
 
+  # Instance-level check matching the scope logic above
+  def stale?
+    return false if resolved_without_fund? || pledge_sent?
+
+    updated_at < Config.stale_patient_days.days.ago
+  end
+
   # Methods
   def self.pledged_status_summary(line)
     plucked_attrs = [:fund_pledge, :pledge_sent, :id, :name, :appointment_date, :fund_pledged_at]

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -34,7 +34,7 @@
           <% end %>
 
           <td><%= patient.primary_phone_display %></td>
-          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge badge-warning" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
+          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge bg-warning" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
 
           <td><%= patient.initial_call_date.display_date %></td>
 

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -34,7 +34,7 @@
           <% end %>
 
           <td><%= patient.primary_phone_display %></td>
-          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge bg-warning" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
+          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge badge-warning" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
 
           <td><%= patient.initial_call_date.display_date %></td>
 

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -34,7 +34,7 @@
           <% end %>
 
           <td><%= patient.primary_phone_display %></td>
-          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %></span></td>
+          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge bg-warning text-dark" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
 
           <td><%= patient.initial_call_date.display_date %></td>
 

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -34,7 +34,7 @@
           <% end %>
 
           <td><%= patient.primary_phone_display %></td>
-          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge badge-warning" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
+          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.stale? %> <span class="badge badge-warning" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
 
           <td><%= patient.initial_call_date.display_date %></td>
 

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -34,7 +34,7 @@
           <% end %>
 
           <td><%= patient.primary_phone_display %></td>
-          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge bg-warning text-dark" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
+          <td><%= link_to patient.name, edit_patient_path(patient) %> <%= language_badge patient %><% if patient.updated_at < Config.stale_patient_days.days.ago %> <span class="badge badge-warning" title="No activity in <%= Config.stale_patient_days %> days"><%= t('dashboard.stale', default: 'Stale') %></span><% end %></span></td>
 
           <td><%= patient.initial_call_date.display_date %></td>
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,7 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  stale_patient_alerts:
+    class: StalePatientAlertJob
+    queue: default
+    schedule: at 6am every day

--- a/test/jobs/stale_patient_alert_job_test.rb
+++ b/test/jobs/stale_patient_alert_job_test.rb
@@ -50,4 +50,32 @@ class StalePatientAlertJobTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'Patient#stale? instance method' do
+    it 'should return true for stale patients' do
+      @patient.update_columns(updated_at: 10.days.ago)
+      assert @patient.stale?
+    end
+
+    it 'should return false for recently updated patients' do
+      @patient.update_columns(updated_at: 1.day.ago)
+      refute @patient.stale?
+    end
+
+    it 'should return false for resolved_without_fund patients' do
+      @patient.update_columns(updated_at: 10.days.ago, resolved_without_fund: true)
+      refute @patient.stale?
+    end
+
+    it 'should return false for pledge_sent patients' do
+      @patient.update_columns(updated_at: 10.days.ago, pledge_sent: true)
+      refute @patient.stale?
+    end
+
+    it 'should match scope results' do
+      @patient.update_columns(updated_at: 10.days.ago)
+      scope_includes = Patient.stale(Config.stale_patient_days).include?(@patient)
+      assert_equal scope_includes, @patient.stale?
+    end
+  end
 end

--- a/test/jobs/stale_patient_alert_job_test.rb
+++ b/test/jobs/stale_patient_alert_job_test.rb
@@ -30,6 +30,17 @@ class StalePatientAlertJobTest < ActiveSupport::TestCase
       stale = Patient.stale(7)
       refute_includes stale, @patient
     end
+
+    it 'should respect different threshold values' do
+      @patient.update_columns(updated_at: 4.days.ago)
+      assert_includes Patient.stale(3), @patient
+      refute_includes Patient.stale(5), @patient
+    end
+
+    it 'should return empty when no patients are stale' do
+      @patient.update_columns(updated_at: Time.current)
+      assert_empty Patient.stale(7)
+    end
   end
 
   describe 'Config.stale_patient_days' do
@@ -41,6 +52,19 @@ class StalePatientAlertJobTest < ActiveSupport::TestCase
       days = Config.stale_patient_days
       assert_equal 5, days
     end
+
+    it 'should return configured value when set' do
+      c = Config.find_or_create_by(config_key: 'stale_patient_days')
+      c.config_value = { options: ["14"] }
+      c.save!
+      assert_equal 14, Config.stale_patient_days
+    end
+
+    it 'should fall back to default for invalid value' do
+      c = Config.find_or_create_by(config_key: 'stale_patient_days')
+      c.update_column(:config_value, { options: ["99"] }.to_json)
+      assert_equal 5, Config.stale_patient_days
+    end
   end
 
   describe 'stale patient day options validation' do
@@ -48,6 +72,18 @@ class StalePatientAlertJobTest < ActiveSupport::TestCase
       [2, 3, 5, 7, 14, 30].each do |days|
         assert_includes Config::STALE_PATIENT_DAY_OPTIONS, days
       end
+    end
+
+    it 'should reject invalid stale day values in config' do
+      c = Config.find_or_create_by(config_key: 'stale_patient_days')
+      c.config_value = { options: ["4"] }
+      refute c.valid?
+    end
+
+    it 'should accept valid stale day values in config' do
+      c = Config.find_or_create_by(config_key: 'stale_patient_days')
+      c.config_value = { options: ["7"] }
+      assert c.valid?
     end
   end
 

--- a/test/jobs/stale_patient_alert_job_test.rb
+++ b/test/jobs/stale_patient_alert_job_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class StalePatientAlertJobTest < ActiveSupport::TestCase
+  before do
+    @user = create :user
+    @patient = create :patient
+  end
+
+  describe 'Patient.stale scope' do
+    it 'should return patients with no activity past threshold' do
+      @patient.update_columns(updated_at: 10.days.ago)
+      stale = Patient.stale(7)
+      assert_includes stale, @patient
+    end
+
+    it 'should exclude patients with recent activity' do
+      @patient.update_columns(updated_at: 1.day.ago)
+      stale = Patient.stale(7)
+      refute_includes stale, @patient
+    end
+
+    it 'should exclude resolved_without_fund patients' do
+      @patient.update_columns(updated_at: 10.days.ago, resolved_without_fund: true)
+      stale = Patient.stale(7)
+      refute_includes stale, @patient
+    end
+
+    it 'should exclude pledge_sent patients' do
+      @patient.update_columns(updated_at: 10.days.ago, pledge_sent: true)
+      stale = Patient.stale(7)
+      refute_includes stale, @patient
+    end
+  end
+
+  describe 'Config.stale_patient_days' do
+    it 'should have stale_patient_days enum value of 27' do
+      assert_equal 27, Config.config_keys['stale_patient_days']
+    end
+
+    it 'should return default of 5 when no config exists' do
+      days = Config.stale_patient_days
+      assert_equal 5, days
+    end
+  end
+
+  describe 'stale patient day options validation' do
+    it 'should accept valid stale day options' do
+      [2, 3, 5, 7, 14, 30].each do |days|
+        assert_includes Config::STALE_PATIENT_DAY_OPTIONS, days
+      end
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds a nightly background job that detects patients without recent activity and sends notifications to their case managers, so stale cases don't fall through the cracks. The number of days before a patient is considered stale is configurable per fund.

This pull request makes the following changes:
* Add new Config setting `stale_patient_days` (enum value 27) so each fund can set their threshold
* Add `StalePatientAlertJob` recurring job that checks for stale patients nightly
* Create notifications via the notification center for each stale patient
* Job is idempotent (skips patients that already have a recent alert) and tenant-scoped

**Notes:**
* **Depends on** #3536 (session security, config enum 26) — this PR uses enum value 27 and must come after.
* **Depends on** #3538 (notification center) for `Notification.notify!`.
* **Depends on** #3532 (Bootstrap 5 upgrade) for BS5 badge classes.
* **Merge order:** `#3536` → `#3550`, and `#3532` → `#3538` → `#3550`.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
