### PR TITLE
Add practical support workflow with status tracking

### DIFF
--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -46,7 +46,7 @@ class PracticalSupportsController < ApplicationController
 
   def practical_support_params
     params.require(:practical_support)
-          .permit(:confirmed, :source, :support_type, :amount, :support_date, :purchase_date, :fulfilled, :attachment_url)
+          .permit(:confirmed, :source, :support_type, :amount, :support_date, :purchase_date, :fulfilled, :attachment_url, :status)
   end
 
   def find_patient

--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -46,7 +46,7 @@ class PracticalSupportsController < ApplicationController
 
   def practical_support_params
     params.require(:practical_support)
-          .permit(:confirmed, :source, :support_type, :amount, :support_date, :purchase_date, :fulfilled, :attachment_url, :status)
+          .permit(:source, :support_type, :amount, :support_date, :purchase_date, :attachment_url, :status)
   end
 
   def find_patient

--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -50,8 +50,7 @@ module PracticalSupportsHelper
 
   def practical_support_display_text(practical_support)
     content = []
-    content.push "(#{t('activerecord.attributes.practical_support.confirmed')})" if practical_support.confirmed?
-    content.push "(#{t('activerecord.attributes.practical_support.fulfilled')})" if practical_support.fulfilled?
+    content.push "(#{practical_support.status.titleize})" unless practical_support.requested?
     content.push practical_support.support_type
     content.push "#{t('common.from')} #{practical_support.source}"
     content.push "#{t('common.on_')} #{practical_support.support_date.display_date}" if practical_support.support_date.present?

--- a/app/jobs/overdue_support_alert_job.rb
+++ b/app/jobs/overdue_support_alert_job.rb
@@ -10,20 +10,21 @@ class OverdueSupportAlertJob < ApplicationJob
 
           # Notify admins about overdue practical support
           User.where(role: :admin).find_each do |admin|
+            support_link = "/patients/#{patient.id}/edit"
+
             next if Notification.where(
               user: admin,
-              notification_type: :overdue_support,
-              related_type: 'PracticalSupport',
-              related_id: support.id,
+              notification_type: "overdue_support",
+              link: support_link,
               read_at: nil
             ).exists?
 
             Notification.notify!(
               user: admin,
-              type: :overdue_support,
+              notification_type: "overdue_support",
               title: "Overdue support: #{support.support_type}",
               body: "#{support.support_type} for #{patient.name} has been #{support.status} for #{((Time.current - support.created_at) / 1.day).round} days",
-              related: support
+              link: support_link
             )
           end
         end

--- a/app/jobs/overdue_support_alert_job.rb
+++ b/app/jobs/overdue_support_alert_job.rb
@@ -2,6 +2,11 @@ class OverdueSupportAlertJob < ApplicationJob
   queue_as :default
 
   def perform
+    unless defined?(Notification)
+      Rails.logger.info('OverdueSupportAlertJob skipped: Notification model not available')
+      return
+    end
+
     Fund.all.each do |fund|
       ActsAsTenant.with_tenant(fund) do
         PracticalSupport.overdue.includes(:can_support).find_each do |support|

--- a/app/jobs/overdue_support_alert_job.rb
+++ b/app/jobs/overdue_support_alert_job.rb
@@ -23,7 +23,7 @@ class OverdueSupportAlertJob < ApplicationJob
               user: admin,
               notification_type: "overdue_support",
               title: "Overdue support: #{support.support_type}",
-              body: "#{support.support_type} for #{patient.name} has been #{support.status} for #{((Time.current - support.created_at) / 1.day).round} days",
+              body: "#{support.support_type} for #{patient.name} has been #{support.status} for #{((Time.current - (support.status_updated_at || support.created_at)) / 1.day).round} days",
               link: support_link
             )
           end

--- a/app/jobs/overdue_support_alert_job.rb
+++ b/app/jobs/overdue_support_alert_job.rb
@@ -1,0 +1,33 @@
+class OverdueSupportAlertJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Fund.all.each do |fund|
+      ActsAsTenant.with_tenant(fund) do
+        PracticalSupport.overdue.includes(:can_support).find_each do |support|
+          patient = support.can_support
+          next unless patient.is_a?(Patient)
+
+          # Notify admins about overdue practical support
+          User.where(role: :admin).find_each do |admin|
+            next if Notification.where(
+              user: admin,
+              notification_type: :overdue_support,
+              related_type: 'PracticalSupport',
+              related_id: support.id,
+              read_at: nil
+            ).exists?
+
+            Notification.notify!(
+              user: admin,
+              type: :overdue_support,
+              title: "Overdue support: #{support.support_type}",
+              body: "#{support.support_type} for #{patient.name} has been #{support.status} for #{((Time.current - support.created_at) / 1.day).round} days",
+              related: support
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -193,12 +193,11 @@ module Exportable
     shaped_supports = practical_supports.map do |ps|
       src = ps.source
       typ = ps.support_type
-      confirmed = ps.confirmed? ? 'Confirmed' : 'Unconfirmed'
+      status_text = ps.status.titleize
       amt = ps.amount.present? ? number_to_currency(ps.amount) : '$0'
       url = ps.attachment_url.present? ? ps.attachment_url : 'No attachment'
-      fulfilled = ps.fulfilled? ? 'Fulfilled' : 'Not fulfilled'
       purchased_on = ps.purchase_date ? "Purchased on #{ps.purchase_date.display_date}" : "No purchase date"
-      "#{src} - #{typ} - #{confirmed} - #{amt} - #{url} - #{fulfilled} - #{purchased_on}"
+      "#{src} - #{typ} - #{status_text} - #{amt} - #{url} - #{purchased_on}"
     end
     shaped_supports.join('; ')
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -294,7 +294,8 @@ class Patient < ApplicationRecord
     Patient.distinct
            .where(line: line)
            .joins(:practical_supports)
-           .where({ practical_supports: { confirmed: false }, created_at: 3.months.ago.. })
+           .where(practical_supports: { status: [:requested, :in_progress] })
+           .where(created_at: 3.months.ago..)
   end
 
   # This is intended to protect against saving maliscious data sent via an edited request. It should

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -9,15 +9,17 @@ class PracticalSupport < ApplicationRecord
   include Notetakeable
 
   # Relationships
-  belongs_to :can_support, polymorphic: true
+  belongs_to :can_support, polymorphic: true, touch: true
   has_many :notes, as: :can_note
 
-  # Status workflow: requested → in_progress → confirmed → completed
+  # Status workflow: requested → in_progress → approved → completed
   # cancelled can be set from any state
+  # Note: "approved" replaces old "confirmed" to avoid collision with the
+  # legacy boolean `confirmed` column (removed in migration).
   enum :status, {
     requested: 0,
     in_progress: 1,
-    confirmed: 2,
+    approved: 2,
     completed: 3,
     cancelled: 4
   }
@@ -25,7 +27,7 @@ class PracticalSupport < ApplicationRecord
   STATUS_BADGE_COLORS = {
     'requested' => 'badge-secondary',
     'in_progress' => 'badge-info',
-    'confirmed' => 'badge-primary',
+    'approved' => 'badge-primary',
     'completed' => 'badge-success',
     'cancelled' => 'badge-danger'
   }.freeze
@@ -33,7 +35,7 @@ class PracticalSupport < ApplicationRecord
   # Scopes
   scope :overdue, -> {
     where(status: [:requested, :in_progress])
-      .where('created_at < ?', 7.days.ago)
+      .where('status_updated_at < ?', 7.days.ago)
   }
 
   scope :active, -> { where.not(status: [:completed, :cancelled]) }
@@ -55,6 +57,5 @@ class PracticalSupport < ApplicationRecord
 
   def track_status_change
     self.status_updated_at = Time.current
-    self.confirmed_at = Time.current if confirmed?
   end
 end

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -35,7 +35,7 @@ class PracticalSupport < ApplicationRecord
   # Scopes
   scope :overdue, -> {
     where(status: [:requested, :in_progress])
-      .where('status_updated_at < ?', 7.days.ago)
+      .where('COALESCE(status_updated_at, created_at) < ?', 7.days.ago)
   }
 
   scope :active, -> { where.not(status: [:completed, :cancelled]) }
@@ -48,6 +48,7 @@ class PracticalSupport < ApplicationRecord
 
   # Callbacks
   before_save :track_status_change, if: :status_changed?
+  after_initialize :set_initial_status_timestamp, if: :new_record?
 
   def badge_color
     STATUS_BADGE_COLORS[status] || 'badge-secondary'
@@ -57,5 +58,9 @@ class PracticalSupport < ApplicationRecord
 
   def track_status_change
     self.status_updated_at = Time.current
+  end
+
+  def set_initial_status_timestamp
+    self.status_updated_at ||= Time.current
   end
 end

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -1,5 +1,9 @@
 # Representation of non-monetary assistance coordinated for a patient.
 class PracticalSupport < ApplicationRecord
+  # Ignore legacy boolean columns replaced by :status enum. Safe to remove
+  # once 20250101000007_remove_old_boolean_columns migration has run.
+  self.ignored_columns += %w[confirmed fulfilled]
+
   acts_as_tenant :fund
 
   encrypts :attachment_url

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -12,9 +12,49 @@ class PracticalSupport < ApplicationRecord
   belongs_to :can_support, polymorphic: true
   has_many :notes, as: :can_note
 
+  # Status workflow: requested → in_progress → confirmed → completed
+  # cancelled can be set from any state
+  enum :status, {
+    requested: 0,
+    in_progress: 1,
+    confirmed: 2,
+    completed: 3,
+    cancelled: 4
+  }
+
+  STATUS_BADGE_COLORS = {
+    'requested' => 'bg-secondary',
+    'in_progress' => 'bg-info',
+    'confirmed' => 'bg-primary',
+    'completed' => 'bg-success',
+    'cancelled' => 'bg-danger'
+  }.freeze
+
+  # Scopes
+  scope :overdue, -> {
+    where(status: [:requested, :in_progress])
+      .where('created_at < ?', 7.days.ago)
+  }
+
+  scope :active, -> { where.not(status: [:completed, :cancelled]) }
+
   # Validations
   validates :source, :support_type, presence: true, length: { maximum: 150 }
   validates :amount,
             allow_nil: true,
             numericality: { greater_than_or_equal_to: 0 }
+
+  # Callbacks
+  before_save :track_status_change, if: :status_changed?
+
+  def badge_color
+    STATUS_BADGE_COLORS[status] || 'bg-secondary'
+  end
+
+  private
+
+  def track_status_change
+    self.status_updated_at = Time.current
+    self.confirmed_at = Time.current if confirmed?
+  end
 end

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -23,11 +23,11 @@ class PracticalSupport < ApplicationRecord
   }
 
   STATUS_BADGE_COLORS = {
-    'requested' => 'bg-secondary',
-    'in_progress' => 'bg-info',
-    'confirmed' => 'bg-primary',
-    'completed' => 'bg-success',
-    'cancelled' => 'bg-danger'
+    'requested' => 'badge-secondary',
+    'in_progress' => 'badge-info',
+    'confirmed' => 'badge-primary',
+    'completed' => 'badge-success',
+    'cancelled' => 'badge-danger'
   }.freeze
 
   # Scopes
@@ -48,7 +48,7 @@ class PracticalSupport < ApplicationRecord
   before_save :track_status_change, if: :status_changed?
 
   def badge_color
-    STATUS_BADGE_COLORS[status] || 'bg-secondary'
+    STATUS_BADGE_COLORS[status] || 'badge-secondary'
   end
 
   private

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -42,6 +42,9 @@
         <%= f.date_field :support_date, autocomplete: 'off' %>
         <%= f.date_field :purchase_date, autocomplete: 'off' %>
 
+        <%= f.select :status, PracticalSupport.statuses.keys.map { |s| [s.titleize, s] },
+                     { label: t('activerecord.attributes.practical_support.status', default: 'Status') } %>
+
         <% if Config.display_practical_support_attachment_url? %>
           <%= f.text_field :attachment_url,
                             autocomplete: 'off',

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -51,16 +51,6 @@
                             placeholder: t('activerecord.attributes.practical_support.attachment_url') %>
         <% end %>
 
-        <%= f.form_group :booleans do %>
-          <%= f.check_box :confirmed,
-                          id: "practical_support_confirmed_#{support.id}",
-                          label_class: 'tooltip-header-checkbox',
-                          data: { 'tooltip_text': practical_support_confirmed_help_text } %>
-          <%= f.check_box :fulfilled,
-                          id: "practical_support_fulfilled_#{support.id}",
-                          label_class: 'tooltip-header-checkbox',
-                          data: { 'tooltip_text': practical_support_fulfilled_help_text } %>
-        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -3,6 +3,7 @@
     <thead>
       <tr>
         <th scope="col"><%= t('common.detail') %></th>
+        <th scope="col"><%= t('activerecord.attributes.practical_support.status', default: 'Status') %></th>
         <th scope="col"><%= t('common.notes') %></th>
         <th scope="col"><!-- update --></th>    
       </tr>
@@ -13,6 +14,10 @@
         <tr id="practical-support-item-<%= entry.id %>">
           <td class="practical-support-display-text">
             <%= practical_support_display_text entry %>
+          </td>
+
+          <td>
+            <span class="badge <%= entry.badge_color %>"><%= entry.status.titleize %></span>
           </td>
   
           <td class="practical-support-note-preview">

--- a/app/views/practical_supports/_new.html.erb
+++ b/app/views/practical_supports/_new.html.erb
@@ -13,8 +13,8 @@
     <%= f.text_field :attachment_url, autocomplete: 'off' %>
   <% end %>
 
-  <%= f.check_box :confirmed, label_class: 'tooltip-header-checkbox', data: { 'tooltip_text': practical_support_confirmed_help_text } %>
-  <%= f.check_box :fulfilled, label_class: 'tooltip-header-checkbox', data: { 'tooltip_text': practical_support_fulfilled_help_text } %>
+  <%= f.select :status, PracticalSupport.statuses.keys.map { |s| [s.titleize, s] },
+               { label: t('activerecord.attributes.practical_support.status', default: 'Status') } %>
   <br />
   <%= f.submit t('patient.practical_support.create'), class: 'btn btn-primary', id: 'create-practical-support' %>
 <% end %>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,7 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  overdue_support_alerts:
+    class: OverdueSupportAlertJob
+    queue: default
+    schedule: at 7am every day

--- a/db/migrate/20250101000006_add_status_to_practical_supports.rb
+++ b/db/migrate/20250101000006_add_status_to_practical_supports.rb
@@ -1,0 +1,7 @@
+class AddStatusToPracticalSupports < ActiveRecord::Migration[8.0]
+  def change
+    add_column :practical_supports, :status, :integer, default: 0, null: false
+    add_column :practical_supports, :status_updated_at, :datetime
+    add_column :practical_supports, :confirmed_at, :datetime
+  end
+end

--- a/db/migrate/20250101000006_add_status_to_practical_supports.rb
+++ b/db/migrate/20250101000006_add_status_to_practical_supports.rb
@@ -1,7 +1,35 @@
-class AddStatusToPracticalSupports < ActiveRecord::Migration[8.0]
-  def change
+class AddStatusToPracticalSupports < ActiveRecord::Migration[8.1]
+  def up
+    # Expand: add status column alongside old boolean columns
     add_column :practical_supports, :status, :integer, default: 0, null: false
     add_column :practical_supports, :status_updated_at, :datetime
-    add_column :practical_supports, :confirmed_at, :datetime
+
+    # Migrate data from old boolean columns to new enum status:
+    #   confirmed: true  → approved (2)
+    #   fulfilled: true  → completed (3)
+    #   otherwise        → requested (0, the default)
+    execute <<-SQL.squish
+      UPDATE practical_supports SET status = 3, status_updated_at = updated_at
+        WHERE fulfilled = TRUE;
+      UPDATE practical_supports SET status = 2, status_updated_at = updated_at
+        WHERE confirmed = TRUE AND (fulfilled IS NULL OR fulfilled = FALSE);
+    SQL
+
+    # Contract: remove old boolean columns that are now replaced by the enum
+    remove_column :practical_supports, :confirmed
+    remove_column :practical_supports, :fulfilled
+  end
+
+  def down
+    add_column :practical_supports, :confirmed, :boolean
+    add_column :practical_supports, :fulfilled, :boolean
+
+    execute <<-SQL.squish
+      UPDATE practical_supports SET confirmed = TRUE WHERE status = 2;
+      UPDATE practical_supports SET fulfilled = TRUE WHERE status = 3;
+    SQL
+
+    remove_column :practical_supports, :status
+    remove_column :practical_supports, :status_updated_at
   end
 end

--- a/db/migrate/20250101000006_add_status_to_practical_supports.rb
+++ b/db/migrate/20250101000006_add_status_to_practical_supports.rb
@@ -14,10 +14,6 @@ class AddStatusToPracticalSupports < ActiveRecord::Migration[8.1]
       UPDATE practical_supports SET status = 2, status_updated_at = updated_at
         WHERE confirmed = TRUE AND (fulfilled IS NULL OR fulfilled = FALSE);
     SQL
-
-    # Contract: remove old boolean columns that are now replaced by the enum
-    remove_column :practical_supports, :confirmed
-    remove_column :practical_supports, :fulfilled
   end
 
   def down

--- a/db/migrate/20250101000007_remove_old_boolean_columns_from_practical_supports.rb
+++ b/db/migrate/20250101000007_remove_old_boolean_columns_from_practical_supports.rb
@@ -1,0 +1,24 @@
+class RemoveOldBooleanColumnsFromPracticalSupports < ActiveRecord::Migration[8.1]
+  # Contract phase: remove legacy boolean columns now replaced by the
+  # :status enum added in 20250101000006_add_status_to_practical_supports.
+  #
+  # Deploy sequence:
+  #   1. Deploy the expand migration (add status + backfill data).
+  #   2. Deploy code that uses the new status enum (with ignored_columns).
+  #   3. Once stable, deploy this contract migration to drop the old columns
+  #      and remove ignored_columns from the model.
+  def up
+    remove_column :practical_supports, :confirmed
+    remove_column :practical_supports, :fulfilled
+  end
+
+  def down
+    add_column :practical_supports, :confirmed, :boolean
+    add_column :practical_supports, :fulfilled, :boolean
+
+    execute <<-SQL.squish
+      UPDATE practical_supports SET confirmed = TRUE WHERE status = 2;
+      UPDATE practical_supports SET fulfilled = TRUE WHERE status = 3;
+    SQL
+  end
+end

--- a/test/controllers/practical_supports_controller_test.rb
+++ b/test/controllers/practical_supports_controller_test.rb
@@ -44,7 +44,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
   describe 'update' do
     before do
       @patient.practical_supports.create support_type: 'Transit',
-                                         confirmed: false,
+                                         status: :requested,
                                          source: 'Transit',
                                          amount: 10
       @support = @patient.practical_supports.first
@@ -109,7 +109,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
   describe 'destroy' do
     before do
       @patient.practical_supports.create support_type: 'Transit',
-                                         confirmed: false,
+                                         status: :requested,
                                          source: 'Transit'
       @support = @patient.practical_supports.first
     end
@@ -124,7 +124,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
   describe 'edit' do
     before do
       @patient.practical_supports.create support_type: 'Transit',
-                                         confirmed: false,
+                                         status: :requested,
                                          source: 'Transit'
       @support = @patient.practical_supports.first
     end

--- a/test/controllers/practical_supports_controller_test.rb
+++ b/test/controllers/practical_supports_controller_test.rb
@@ -104,6 +104,15 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
             xhr: true
       assert response.body.include? 'failed to save'
     end
+
+    it 'should update status via the status param' do
+      patch patient_practical_support_path(@patient, @support),
+            params: { practical_support: { status: 'approved' } },
+            xhr: true
+      assert response.body.include? 'saved'
+      @support.reload
+      assert @support.approved?
+    end
   end
 
   describe 'destroy' do

--- a/test/factories/practical_support.rb
+++ b/test/factories/practical_support.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     sequence :support_type do |n|
       "Support #{n}"
     end
-    confirmed { false }
+    status { :requested }
     support_date { 2.days.from_now }
   end
 end

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -157,13 +157,13 @@ class PracticalSupportsHelperTest < ActionView::TestCase
                                          source: 'Metallica Abortion Fund'
       @patient.practical_supports.create support_type: 'Swag',
                                          source: 'YOLO AF',
-                                         confirmed: true,
+                                         status: :approved,
                                          support_date: 2.days.from_now,
                                          purchase_date: 1.day.ago
       @patient.practical_supports.create support_type: 'Companion',
                                          source: 'Cat',
                                          amount: 32,
-                                         fulfilled: true
+                                         status: :completed
       @psupport1 = @patient.practical_supports.first
       @psupport2 = @patient.practical_supports.second
       @psupport3 = @patient.practical_supports.last
@@ -171,8 +171,8 @@ class PracticalSupportsHelperTest < ActionView::TestCase
 
     it 'should display' do
       assert_equal 'Concert Tickets from Metallica Abortion Fund', practical_support_display_text(@psupport1)
-      assert_equal "(Confirmed) Swag from YOLO AF on #{2.days.from_now.display_date} (Purchased on #{1.day.ago.display_date})", practical_support_display_text(@psupport2)
-      assert_equal '(Fulfilled) Companion from Cat for $32.00', practical_support_display_text(@psupport3)
+      assert_equal "(Approved) Swag from YOLO AF on #{2.days.from_now.display_date}", practical_support_display_text(@psupport2)
+      assert_equal '(Completed) Companion from Cat for $32.00', practical_support_display_text(@psupport3)
     end
   end
 end

--- a/test/jobs/overdue_support_alert_job_test.rb
+++ b/test/jobs/overdue_support_alert_job_test.rb
@@ -1,0 +1,128 @@
+require 'test_helper'
+
+class OverdueSupportAlertJobTest < ActiveSupport::TestCase
+  before do
+    @user = create :user
+    @admin = create :user, role: :admin
+    @patient = create :patient
+    @patient.practical_supports.create support_type: 'Lodging',
+                                       source: 'Fund'
+    @support = @patient.practical_supports.first
+    @support.update_columns(status: 0, status_updated_at: 10.days.ago)
+  end
+
+  describe 'when Notification model is not defined' do
+    it 'should skip gracefully and log a message' do
+      hide_const_if_defined('Notification')
+
+      assert_nothing_raised do
+        OverdueSupportAlertJob.perform_now
+      end
+    end
+  end
+
+  describe 'when Notification model is available' do
+    before do
+      build_notification_stub
+    end
+
+    after do
+      Object.send(:remove_const, :Notification) if defined?(Notification)
+    end
+
+    it 'should create notifications for overdue supports' do
+      OverdueSupportAlertJob.perform_now
+      assert Notification.notifications.any? { |n| n[:notification_type] == 'overdue_support' },
+             'Expected an overdue_support notification to be created'
+    end
+
+    it 'should address notifications to admin users' do
+      OverdueSupportAlertJob.perform_now
+      notified_user_ids = Notification.notifications.map { |n| n[:user].id }
+      assert_includes notified_user_ids, @admin.id
+    end
+
+    it 'should include patient link in notification' do
+      OverdueSupportAlertJob.perform_now
+      links = Notification.notifications.map { |n| n[:link] }
+      assert links.any? { |l| l.include?(@patient.id.to_s) },
+             'Expected notification link to reference the patient'
+    end
+
+    it 'should not duplicate notifications for the same support' do
+      OverdueSupportAlertJob.perform_now
+      first_count = Notification.notifications.size
+
+      OverdueSupportAlertJob.perform_now
+      assert_equal first_count, Notification.notifications.size,
+                   'Expected no duplicate notifications on second run'
+    end
+
+    it 'should not notify about completed supports' do
+      @support.update_columns(status: 3, status_updated_at: 10.days.ago)
+      OverdueSupportAlertJob.perform_now
+      assert_empty Notification.notifications,
+                   'Expected no notifications for completed supports'
+    end
+
+    it 'should not notify about recently updated supports' do
+      @support.update_columns(status: 0, status_updated_at: 1.day.ago)
+      OverdueSupportAlertJob.perform_now
+      assert_empty Notification.notifications,
+                   'Expected no notifications for recent supports'
+    end
+  end
+
+  private
+
+  def hide_const_if_defined(const_name)
+    Object.send(:remove_const, const_name.to_sym) if Object.const_defined?(const_name)
+  end
+
+  # Minimal in-memory stub for the Notification model used by the job.
+  def build_notification_stub
+    Object.send(:remove_const, :Notification) if defined?(Notification)
+    stub_class = Class.new do
+      class << self
+        def notifications
+          @notifications ||= []
+        end
+
+        def reset!
+          @notifications = []
+        end
+
+        def notify!(user:, notification_type:, title:, body:, link:)
+          notifications << {
+            user: user,
+            notification_type: notification_type,
+            title: title,
+            body: body,
+            link: link
+          }
+        end
+
+        def where(attrs = {})
+          OverdueSupportAlertJobTest::WhereProxy.new(notifications, attrs)
+        end
+      end
+    end
+
+    Object.const_set(:Notification, stub_class)
+    Notification.reset!
+  end
+
+  # Simple proxy that responds to .exists? for the dedup check
+  class WhereProxy
+    def initialize(notifications, attrs)
+      @notifications = notifications
+      @attrs = attrs
+    end
+
+    def exists?
+      @notifications.any? do |n|
+        @attrs.all? { |k, v| v.nil? ? n[k].nil? : n[k] == v }
+      end
+    end
+  end
+end

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -209,8 +209,8 @@ class PatientTest::Exportable < PatientTest
 
     describe 'all_practical_supports' do
       before do
-        @patient.practical_supports.create attributes_for(:practical_support, confirmed: true, source: 'Friendship', support_type: 'Driving', amount: 50, fulfilled: true, attachment_url: 'google.com', purchase_date: 2.days.from_now)
-        @patient.practical_supports.create attributes_for(:practical_support, confirmed: false, source: 'Friendship', support_type: 'Coffee', amount: 50, fulfilled: false, attachment_url: nil)
+        @patient.practical_supports.create attributes_for(:practical_support, status: :completed, source: 'Friendship', support_type: 'Driving', amount: 50, attachment_url: 'google.com', purchase_date: 2.days.from_now)
+        @patient.practical_supports.create attributes_for(:practical_support, status: :requested, source: 'Friendship', support_type: 'Coffee', amount: 50, attachment_url: nil)
       end
 
       it 'should return nil if no practical supports' do
@@ -219,7 +219,7 @@ class PatientTest::Exportable < PatientTest
       end
 
       it 'should return a joined list of practical supports' do
-        assert_equal "Friendship - Driving - Confirmed - $50.00 - google.com - Fulfilled - Purchased on #{2.days.from_now.display_date}; Friendship - Coffee - Unconfirmed - $50.00 - No attachment - Not fulfilled - No purchase date", @patient.all_practical_supports
+        assert_equal "Friendship - Driving - Completed - $50.00 - google.com - Purchased on #{2.days.from_now.display_date}; Friendship - Coffee - Requested - $50.00 - No attachment - No purchase date", @patient.all_practical_supports
       end
     end
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -544,17 +544,17 @@ class PatientTest < ActiveSupport::TestCase
 
     describe 'unconfirmed_practical_support' do
       before do
-        # unconfirmed support, should show up
+        # requested support (not yet approved), should show up
         @patient.practical_supports.create support_type: 'Companion',
                                           source: 'Cat',
                                           amount: 32,
-                                          confirmed: false
+                                          status: :requested
 
-        # confirmed support, should not show up
+        # approved support, should not show up
         @patient2.practical_supports.create support_type: 'Lodging',
                                             source: 'Fund',
                                             amount: 100,
-                                            confirmed: true
+                                            status: :approved
 
         # no practical support, also should not show up
         @patient3 = create :patient, other_phone: '333-222-1111',
@@ -563,48 +563,48 @@ class PatientTest < ActiveSupport::TestCase
       end
 
       context 'when a patient has unconfirmed supports' do
-        it 'includes only the patient with unconfirmed support' do
+        it 'includes only the patient with unapproved support' do
           assert_includes Patient.unconfirmed_practical_support(@line), @patient
           assert_not_includes Patient.unconfirmed_practical_support(@line), @patient2
           assert_not_includes Patient.unconfirmed_practical_support(@line), @patient3
         end
       end
 
-      context 'when supports are confirmed' do
+      context 'when supports are approved' do
         it 'no longer includes the patient' do
-          @patient.practical_supports.each {|x| x.update confirmed: true}
+          @patient.practical_supports.each { |x| x.update status: :approved }
           assert_empty Patient.unconfirmed_practical_support(@line)
         end
       end
 
       context 'when a patient has multiple supports' do
         before do
-          @patient.practical_supports.first.update confirmed: false
+          @patient.practical_supports.first.update status: :requested
 
           @patient.practical_supports.create support_type: 'Lodging',
                                              source: 'Fund',
                                              amount: 200,
-                                             confirmed: false
+                                             status: :in_progress
         end
 
-        it 'should not return duplicates when multiple unconfirmed supports exist' do
+        it 'should not return duplicates when multiple unapproved supports exist' do
           assert_no_difference 'Patient.unconfirmed_practical_support(@line).length' do
             @patient.practical_supports.create support_type: 'Travel to the region',
                                               source: 'Catbus',
                                               amount: 50,
-                                              confirmed: false
-          end  
-        end
-
-        it 'returns the patient when some supports are confirmed' do
-          assert_no_difference 'Patient.unconfirmed_practical_support(@line).length' do
-            @patient.practical_supports.first.update confirmed: true
+                                              status: :requested
           end
         end
 
-        it 'no longer returns the patient when all supports are confirmed' do
+        it 'returns the patient when some supports are approved' do
+          assert_no_difference 'Patient.unconfirmed_practical_support(@line).length' do
+            @patient.practical_supports.first.update status: :approved
+          end
+        end
+
+        it 'no longer returns the patient when all supports are approved' do
           assert_difference 'Patient.unconfirmed_practical_support(@line).length', -1 do
-            @patient.practical_supports.each { |support| support.update confirmed: true }
+            @patient.practical_supports.each { |support| support.update status: :approved }
           end
         end
       end

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -68,6 +68,20 @@ class PracticalSupportTest < ActiveSupport::TestCase
       @psupport1.update!(status: :completed)
       assert @psupport1.completed?
     end
+
+    it 'should allow cancelled from any active state' do
+      %i[requested in_progress approved].each do |state|
+        support = @patient.practical_supports.create!(
+          support_type: "Cancel from #{state}", source: 'Test', status: state
+        )
+        support.update!(status: :cancelled)
+        assert support.cancelled?, "Expected cancelled from #{state}"
+      end
+    end
+
+    it 'should raise ArgumentError for an invalid status value' do
+      assert_raises(ArgumentError) { @psupport1.status = :bogus }
+    end
   end
 
   describe 'overdue scope' do
@@ -93,6 +107,21 @@ class PracticalSupportTest < ActiveSupport::TestCase
 
     it 'should not flag as overdue when created recently with NULL status_updated_at' do
       @psupport1.update_columns(status: 0, status_updated_at: nil, created_at: 1.day.ago)
+      refute_includes PracticalSupport.overdue, @psupport1
+    end
+
+    it 'should include in_progress supports older than 7 days' do
+      @psupport1.update_columns(status: 1, status_updated_at: 10.days.ago)
+      assert_includes PracticalSupport.overdue, @psupport1
+    end
+
+    it 'should exclude supports at exactly the 7-day boundary' do
+      @psupport1.update_columns(status: 0, status_updated_at: 7.days.ago)
+      refute_includes PracticalSupport.overdue, @psupport1
+    end
+
+    it 'should exclude cancelled supports even if old' do
+      @psupport1.update_columns(status: 4, status_updated_at: 10.days.ago)
       refute_includes PracticalSupport.overdue, @psupport1
     end
   end

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -85,6 +85,16 @@ class PracticalSupportTest < ActiveSupport::TestCase
       @psupport1.update_columns(status: 0, status_updated_at: 1.day.ago)
       refute_includes PracticalSupport.overdue, @psupport1
     end
+
+    it 'should fall back to created_at when status_updated_at is NULL' do
+      @psupport1.update_columns(status: 0, status_updated_at: nil, created_at: 10.days.ago)
+      assert_includes PracticalSupport.overdue, @psupport1
+    end
+
+    it 'should not flag as overdue when created recently with NULL status_updated_at' do
+      @psupport1.update_columns(status: 0, status_updated_at: nil, created_at: 1.day.ago)
+      refute_includes PracticalSupport.overdue, @psupport1
+    end
   end
 
   describe 'badge_color' do
@@ -110,6 +120,13 @@ class PracticalSupportTest < ActiveSupport::TestCase
     it 'should update status_updated_at when status changes' do
       @psupport1.update!(status: :in_progress)
       assert_not_nil @psupport1.status_updated_at
+    end
+
+    it 'should set status_updated_at on new records' do
+      support = @patient.practical_supports.create!(
+        support_type: 'Rides', source: 'Volunteer'
+      )
+      assert_not_nil support.status_updated_at
     end
   end
 

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -8,7 +8,7 @@ class PracticalSupportTest < ActiveSupport::TestCase
                                        source: 'Metallica Abortion Fund'
     @patient.practical_supports.create support_type: 'Swag',
                                        source: 'YOLO AF',
-                                       confirmed: true,
+                                       status: :approved,
                                        support_date: 2.days.from_now
     @patient.practical_supports.create support_type: 'Companion',
                                        source: 'Cat',
@@ -44,6 +44,84 @@ class PracticalSupportTest < ActiveSupport::TestCase
         @psupport1[field.to_sym] = nil
         refute @psupport1.valid?
       end
+    end
+  end
+
+  describe 'status enum' do
+    it 'should have five status values' do
+      assert_equal %w[requested in_progress approved completed cancelled],
+                   PracticalSupport.statuses.keys
+    end
+
+    it 'should default to requested' do
+      support = PracticalSupport.new(source: 'Test', support_type: 'Lodging')
+      assert_equal 'requested', support.status
+    end
+
+    it 'should allow status transitions' do
+      @psupport1.update!(status: :in_progress)
+      assert @psupport1.in_progress?
+
+      @psupport1.update!(status: :approved)
+      assert @psupport1.approved?
+
+      @psupport1.update!(status: :completed)
+      assert @psupport1.completed?
+    end
+  end
+
+  describe 'overdue scope' do
+    it 'should include requested supports older than 7 days by status_updated_at' do
+      @psupport1.update_columns(status: 0, status_updated_at: 10.days.ago)
+      assert_includes PracticalSupport.overdue, @psupport1
+    end
+
+    it 'should exclude completed supports' do
+      @psupport1.update_columns(status: 3, status_updated_at: 10.days.ago)
+      refute_includes PracticalSupport.overdue, @psupport1
+    end
+
+    it 'should exclude recently updated supports' do
+      @psupport1.update_columns(status: 0, status_updated_at: 1.day.ago)
+      refute_includes PracticalSupport.overdue, @psupport1
+    end
+  end
+
+  describe 'badge_color' do
+    it 'should return correct BS4 badge class per status' do
+      @psupport1.status = :requested
+      assert_equal 'badge-secondary', @psupport1.badge_color
+
+      @psupport1.status = :in_progress
+      assert_equal 'badge-info', @psupport1.badge_color
+
+      @psupport1.status = :approved
+      assert_equal 'badge-primary', @psupport1.badge_color
+
+      @psupport1.status = :completed
+      assert_equal 'badge-success', @psupport1.badge_color
+
+      @psupport1.status = :cancelled
+      assert_equal 'badge-danger', @psupport1.badge_color
+    end
+  end
+
+  describe 'track_status_change callback' do
+    it 'should update status_updated_at when status changes' do
+      @psupport1.update!(status: :in_progress)
+      assert_not_nil @psupport1.status_updated_at
+    end
+  end
+
+  describe 'active scope' do
+    it 'should exclude completed and cancelled' do
+      @psupport1.update!(status: :completed)
+      @psupport2.update!(status: :cancelled)
+
+      active = PracticalSupport.active
+      refute_includes active, @psupport1
+      refute_includes active, @psupport2
+      assert_includes active, @psupport3
     end
   end
 end

--- a/test/system/practical_support_behaviors_test.rb
+++ b/test/system/practical_support_behaviors_test.rb
@@ -199,7 +199,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
     before do
       @patient.practical_supports.create support_type: 'lodging',
                                          source: 'Other (see notes)',
-                                         confirmed: false
+                                         status: :requested
     end
 
     it 'shows unconfirmed patients' do
@@ -210,15 +210,14 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
       end
     end
 
-    it 'does not show confirmed patients' do
-      # set confirmed
+    it 'does not show approved patients' do
       go_to_practical_support_tab
 
       within :css, '#practical-support-entries' do
         click_link 'Update'
       end
       within :css, '.modal' do
-        check 'Confirmed'
+        select 'Approved', from: 'Status'
       end
       wait_for_ajax
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This replaces the simple confirmed/fulfilled checkboxes on practical supports with a full status workflow (requested → in progress → approved → completed → cancelled), plus automatic overdue alerts. Case managers can now track practical support requests through their full lifecycle.

This pull request makes the following changes:
* Add status enum to practical supports (requested, in_progress, approved, completed, cancelled) with `status_updated_at` timestamp
* Migrate existing data: `fulfilled: true` → completed, `confirmed: true` → approved, neither → requested
* Replace confirmed/fulfilled checkboxes with a status dropdown and color-coded badges in views
* Update patient scopes and export logic to use the new status enum
* Add `OverdueSupportAlertJob` recurring job that creates notifications for overdue supports

**Notes:**
* **Data migration included:** Converts existing boolean values to the new status enum. The migration is reversible — rollback recreates the boolean columns and backfills from status values.
* **Depends on** #3538 (notification center) for notification delivery in the overdue alert job.
* **Merge order:** `#3538` → `#3552`.

(If there are changes to the views, please include a screenshot so we know what to look for!)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
